### PR TITLE
Monitor: Dashboard tab with mobile candlestick charts (favorites-only)

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1,11 +1,19 @@
 # file: backend/app/api.py
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Query
+import pandas as pd
 from typing import List
 
 from app.schemas.backtest import PresetResponse
+from app.services.market_data_providers import (
+    CCXT_SOURCE,
+    STOOQ_SOURCE,
+    YahooMarketDataProvider,
+    get_market_data_provider,
+)
 from app.services.preset_service import get_presets
 from app.services.pandas_ta_inspector import get_all_indicators_metadata
 
@@ -16,6 +24,14 @@ NASDAQ100_CONFIG_PATH = (
     / "config"
     / f"nasdaq100_symbols.v{NASDAQ100_VERSION}.json"
 )
+
+_MARKET_TIMEFRAMES = {"15m", "1h", "4h", "1d"}
+_DEFAULT_HISTORY_DAYS = {
+    "15m": 30,
+    "1h": 180,
+    "4h": 365,
+    "1d": 3650,
+}
 
 
 @router.get("/health")
@@ -177,3 +193,104 @@ async def get_arbitrage_spreads(
         "exchanges": exchange_list,
         "results": results,
     }
+
+
+def _classify_asset(symbol: str) -> str:
+    return "crypto" if "/" in symbol else "stock"
+
+
+def _validate_market_timeframe(asset: str, timeframe: str) -> str:
+    tf = str(timeframe or "").strip().lower()
+    if tf not in _MARKET_TIMEFRAMES:
+        supported = ", ".join(sorted(_MARKET_TIMEFRAMES))
+        raise ValueError(f"Unsupported timeframe '{timeframe}' for {asset}. Supported: {supported}.")
+    return tf
+
+
+def _default_since_str(timeframe: str) -> str:
+    days = _DEFAULT_HISTORY_DAYS.get(timeframe, 30)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    return since.isoformat()
+
+
+def _normalize_candles_frame(df, limit: int):
+    if df is None:
+        return []
+
+    out = df.copy()
+    if out.empty:
+        return []
+    if "timestamp_utc" not in out.columns:
+        raise ValueError("Provider returned invalid candle payload (missing timestamp_utc).")
+
+    out = out.reset_index(drop=True)
+    out["timestamp_utc"] = pd.to_datetime(out["timestamp_utc"], utc=True, errors="coerce")
+    out = out.dropna(subset=["timestamp_utc", "open", "high", "low", "close"])
+    out = out.sort_values("timestamp_utc")
+    out = out.tail(limit)
+
+    candles = []
+    for _, row in out.iterrows():
+        ts = row["timestamp_utc"]
+        candles.append(
+            {
+                "timestamp_utc": ts.isoformat(),
+                "open": float(row["open"]),
+                "high": float(row["high"]),
+                "low": float(row["low"]),
+                "close": float(row["close"]),
+                "volume": float(row.get("volume", 0.0) or 0.0),
+            }
+        )
+    return candles
+
+
+@router.get("/market/candles")
+async def get_market_candles(
+    symbol: str = Query(..., description="Ticker or pair (e.g. NVDA or BTC/USDT)"),
+    timeframe: str = Query("1h", description="One of: 15m, 1h, 4h, 1d"),
+    limit: int = Query(300, ge=1, le=2000, description="Max candles to return"),
+):
+    raw_symbol = str(symbol or "").strip()
+    if not raw_symbol:
+        raise HTTPException(status_code=400, detail="Query param 'symbol' must not be empty.")
+
+    try:
+        asset_type = _classify_asset(raw_symbol)
+        tf = _validate_market_timeframe(asset_type, timeframe)
+        since_str = _default_since_str(tf)
+
+        data_source = ""
+        if asset_type == "crypto":
+            data_source = CCXT_SOURCE
+            provider = get_market_data_provider(data_source)
+            df = provider.fetch_ohlcv(raw_symbol, tf, since_str=since_str, limit=limit)
+        elif tf == "1d":
+            # Prefer free Stooq EOD for stocks; fallback to Yahoo daily when needed.
+            data_source = STOOQ_SOURCE
+            provider = get_market_data_provider(data_source)
+            try:
+                df = provider.fetch_ohlcv(raw_symbol, tf, since_str=since_str, limit=limit)
+            except Exception:
+                data_source = "yahoo"
+                df = YahooMarketDataProvider().fetch_ohlcv(raw_symbol, tf, since_str=since_str, limit=limit)
+        else:
+            data_source = "yahoo"
+            df = YahooMarketDataProvider().fetch_ohlcv(raw_symbol, tf, since_str=since_str, limit=limit)
+
+        candles = _normalize_candles_frame(df, limit=limit)
+        return {
+            "symbol": raw_symbol,
+            "asset_type": asset_type,
+            "timeframe": tf,
+            "data_source": data_source,
+            "limit": limit,
+            "count": len(candles),
+            "candles": candles,
+        }
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed fetching candles for '{raw_symbol}': {exc}")

--- a/backend/app/services/market_data_providers.py
+++ b/backend/app/services/market_data_providers.py
@@ -368,6 +368,201 @@ class StooqEodProvider:
             raise ValueError(f"Failed fetching Stooq EOD data for '{symbol}': {exc}") from exc
 
 
+class YahooMarketDataProvider:
+    """Yahoo Finance provider used for US stocks intraday and daily candles."""
+
+    source = "yahoo"
+    DEFAULT_TIMEOUT_SECONDS = 20.0
+
+    _VALID_TIMEFRAMES = {"15m", "1h", "4h", "1d"}
+    _DEFAULT_RANGE_BY_TF = {
+        "15m": "1mo",   # ~30d
+        "1h": "6mo",    # ~180d
+        "4h": "1y",     # ~365d (aggregated from 1h)
+        "1d": "10y",    # years
+    }
+    _INTERVAL_BY_TF = {
+        "15m": "15m",
+        "1h": "60m",
+        "4h": "60m",
+        "1d": "1d",
+    }
+
+    def __init__(self, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS):
+        self.timeout_seconds = max(1.0, float(timeout_seconds))
+
+    @staticmethod
+    def _normalize_symbol(symbol: str) -> str:
+        raw = str(symbol or "").strip().upper()
+        if not raw:
+            raise ValueError("Symbol must not be empty.")
+        if "/" in raw:
+            raise ValueError("Yahoo provider expects stock tickers without '/'.")
+        return raw
+
+    @classmethod
+    def _normalize_timeframe(cls, timeframe: str) -> str:
+        tf = str(timeframe or "").strip().lower()
+        if tf not in cls._VALID_TIMEFRAMES:
+            supported = ", ".join(sorted(cls._VALID_TIMEFRAMES))
+            raise ValueError(f"Unsupported Yahoo timeframe '{timeframe}'. Supported: {supported}.")
+        return tf
+
+    @staticmethod
+    def _range_for_since(since_str: Optional[str], default_range: str) -> str:
+        since_dt = StooqEodProvider._parse_datetime_utc(since_str)
+        if since_dt is None:
+            return default_range
+
+        days = max(1, int((datetime.now(timezone.utc) - since_dt.to_pydatetime()).days))
+        if days <= 5:
+            return "5d"
+        if days <= 30:
+            return "1mo"
+        if days <= 90:
+            return "3mo"
+        if days <= 180:
+            return "6mo"
+        if days <= 365:
+            return "1y"
+        if days <= 365 * 2:
+            return "2y"
+        if days <= 365 * 5:
+            return "5y"
+        if days <= 365 * 10:
+            return "10y"
+        return "max"
+
+    @staticmethod
+    def _parse_payload(payload: dict, symbol: str) -> pd.DataFrame:
+        chart = (payload or {}).get("chart") or {}
+        if chart.get("error"):
+            message = chart["error"].get("description") or chart["error"].get("code") or "unknown yahoo error"
+            raise ValueError(f"Yahoo request failed for '{symbol}': {message}")
+
+        result = chart.get("result") or []
+        if not result:
+            raise ValueError(f"No Yahoo candles returned for '{symbol}'.")
+
+        row = result[0] or {}
+        timestamps = row.get("timestamp") or []
+        indicators = row.get("indicators") or {}
+        quotes = (indicators.get("quote") or [{}])[0] or {}
+
+        opens = quotes.get("open") or []
+        highs = quotes.get("high") or []
+        lows = quotes.get("low") or []
+        closes = quotes.get("close") or []
+        volumes = quotes.get("volume") or []
+
+        rows: list[dict] = []
+        total = min(len(timestamps), len(opens), len(highs), len(lows), len(closes))
+        for idx in range(total):
+            ts = timestamps[idx]
+            o = opens[idx]
+            h = highs[idx]
+            l = lows[idx]
+            c = closes[idx]
+            v = volumes[idx] if idx < len(volumes) else 0
+            if ts is None or o is None or h is None or l is None or c is None:
+                continue
+            t = pd.to_datetime(int(ts), unit="s", utc=True)
+            rows.append(
+                {
+                    "time": t,
+                    "timestamp_utc": t,
+                    "timestamp": int(t.value // 1_000_000),
+                    "open": float(o),
+                    "high": float(h),
+                    "low": float(l),
+                    "close": float(c),
+                    "volume": float(v or 0),
+                }
+            )
+
+        if not rows:
+            raise ValueError(f"Yahoo returned no valid OHLC rows for '{symbol}'.")
+
+        df = pd.DataFrame(rows).sort_values("timestamp_utc")
+        df = df.set_index("timestamp_utc", drop=False)
+        return df
+
+    @staticmethod
+    def _aggregate_to_4h(df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty:
+            return df
+
+        agg = (
+            df.resample("4h", on="timestamp_utc")
+            .agg(
+                {
+                    "open": "first",
+                    "high": "max",
+                    "low": "min",
+                    "close": "last",
+                    "volume": "sum",
+                }
+            )
+            .dropna(subset=["open", "high", "low", "close"])
+            .reset_index()
+        )
+
+        if agg.empty:
+            return agg
+
+        agg["time"] = pd.to_datetime(agg["timestamp_utc"], utc=True)
+        agg["timestamp"] = (agg["time"].astype("int64") // 1_000_000).astype("int64")
+        agg = agg[["timestamp", "timestamp_utc", "time", "open", "high", "low", "close", "volume"]]
+        agg = agg.set_index("timestamp_utc", drop=False).sort_index()
+        return agg
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str,
+        since_str: Optional[str] = None,
+        until_str: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> pd.DataFrame:
+        ticker = self._normalize_symbol(symbol)
+        tf = self._normalize_timeframe(timeframe)
+
+        interval = self._INTERVAL_BY_TF[tf]
+        range_param = self._range_for_since(since_str, self._DEFAULT_RANGE_BY_TF[tf])
+        url = f"https://query1.finance.yahoo.com/v8/finance/chart/{ticker}"
+
+        try:
+            response = httpx.get(
+                url,
+                params={
+                    "interval": interval,
+                    "range": range_param,
+                    "includePrePost": "false",
+                    "events": "div,splits",
+                },
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:
+            raise ValueError(f"Yahoo request failed for '{ticker}': {exc}") from exc
+
+        out = self._parse_payload(payload, symbol=ticker)
+        if tf == "4h":
+            out = self._aggregate_to_4h(out)
+
+        since_dt = StooqEodProvider._parse_datetime_utc(since_str)
+        until_dt = StooqEodProvider._parse_datetime_utc(until_str)
+        if since_dt is not None:
+            out = out[out.index >= since_dt]
+        if until_dt is not None:
+            out = out[out.index <= until_dt]
+        if isinstance(limit, int) and limit > 0:
+            out = out.tail(limit)
+
+        return out
+
+
 _PROVIDERS: dict[str, MarketDataProvider] = {}
 
 

--- a/backend/tests/integration/test_market_candles_endpoint.py
+++ b/backend/tests/integration/test_market_candles_endpoint.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import FastAPI
+import httpx
+import pandas as pd
+
+from app import api as app_api
+from utils.market_data_mocks import block_external_network
+
+
+def _build_df(rows: list[dict]) -> pd.DataFrame:
+    df = pd.DataFrame(rows)
+    df["timestamp_utc"] = pd.to_datetime(df["timestamp_utc"], utc=True)
+    df = df.sort_values("timestamp_utc")
+    df["time"] = df["timestamp_utc"]
+    df["timestamp"] = (df["timestamp_utc"].astype("int64") // 1_000_000).astype("int64")
+    return df.set_index("timestamp_utc", drop=False)
+
+
+@dataclass
+class _FakeProvider:
+    source: str
+    df: pd.DataFrame
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str,
+        since_str: str | None = None,
+        until_str: str | None = None,
+        limit: int | None = None,
+    ) -> pd.DataFrame:
+        out = self.df.copy()
+        if isinstance(limit, int) and limit > 0:
+            out = out.tail(limit)
+        return out
+
+
+def _build_app() -> FastAPI:
+    test_app = FastAPI()
+    test_app.include_router(app_api.router)
+    return test_app
+
+
+async def _get(path: str):
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        return await client.get(path)
+
+
+async def test_market_candles_crypto_returns_ordered_and_limited(monkeypatch):
+    block_external_network(monkeypatch)
+
+    crypto_df = _build_df(
+        [
+            {"timestamp_utc": "2025-01-01T02:00:00Z", "open": 101, "high": 103, "low": 100, "close": 102, "volume": 10},
+            {"timestamp_utc": "2025-01-01T00:00:00Z", "open": 99, "high": 101, "low": 98, "close": 100, "volume": 8},
+            {"timestamp_utc": "2025-01-01T01:00:00Z", "open": 100, "high": 102, "low": 99, "close": 101, "volume": 9},
+        ]
+    )
+    fake_ccxt = _FakeProvider(source="ccxt", df=crypto_df)
+
+    def _fake_get_market_data_provider(data_source: str | None):
+        assert data_source == "ccxt"
+        return fake_ccxt
+
+    monkeypatch.setattr(app_api, "get_market_data_provider", _fake_get_market_data_provider)
+
+    response = await _get("/api/market/candles?symbol=BTC/USDT&timeframe=1h&limit=2")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert payload["asset_type"] == "crypto"
+    assert payload["data_source"] == "ccxt"
+    assert payload["count"] == 2
+    assert [c["timestamp_utc"] for c in payload["candles"]] == [
+        "2025-01-01T01:00:00+00:00",
+        "2025-01-01T02:00:00+00:00",
+    ]
+
+
+async def test_market_candles_stock_intraday_uses_yahoo(monkeypatch):
+    block_external_network(monkeypatch)
+
+    stock_df = _build_df(
+        [
+            {"timestamp_utc": "2025-02-03T14:30:00Z", "open": 210, "high": 212, "low": 209, "close": 211, "volume": 1000},
+            {"timestamp_utc": "2025-02-03T14:45:00Z", "open": 211, "high": 213, "low": 210, "close": 212, "volume": 1200},
+        ]
+    )
+
+    class _FakeYahooProvider:
+        def fetch_ohlcv(
+            self,
+            symbol: str,
+            timeframe: str,
+            since_str: str | None = None,
+            until_str: str | None = None,
+            limit: int | None = None,
+        ) -> pd.DataFrame:
+            assert symbol == "NVDA"
+            assert timeframe == "15m"
+            out = stock_df.copy()
+            if isinstance(limit, int) and limit > 0:
+                out = out.tail(limit)
+            return out
+
+    monkeypatch.setattr(app_api, "YahooMarketDataProvider", _FakeYahooProvider)
+
+    def _fail_get_market_data_provider(data_source: str | None):
+        raise AssertionError(f"Unexpected provider selection: {data_source}")
+
+    monkeypatch.setattr(app_api, "get_market_data_provider", _fail_get_market_data_provider)
+
+    response = await _get("/api/market/candles?symbol=NVDA&timeframe=15m&limit=100")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert payload["asset_type"] == "stock"
+    assert payload["data_source"] == "yahoo"
+    assert payload["count"] == 2
+
+
+async def test_market_candles_stock_daily_uses_stooq_first(monkeypatch):
+    block_external_network(monkeypatch)
+
+    stock_df = _build_df(
+        [
+            {"timestamp_utc": "2025-02-01T00:00:00Z", "open": 200, "high": 205, "low": 198, "close": 203, "volume": 5000},
+        ]
+    )
+    fake_stooq = _FakeProvider(source="stooq", df=stock_df)
+
+    def _fake_get_market_data_provider(data_source: str | None):
+        assert data_source == "stooq"
+        return fake_stooq
+
+    monkeypatch.setattr(app_api, "get_market_data_provider", _fake_get_market_data_provider)
+
+    class _FailYahooProvider:
+        def fetch_ohlcv(self, *args, **kwargs):
+            raise AssertionError("Yahoo fallback should not be called when stooq succeeds")
+
+    monkeypatch.setattr(app_api, "YahooMarketDataProvider", _FailYahooProvider)
+
+    response = await _get("/api/market/candles?symbol=NVDA&timeframe=1d&limit=100")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["data_source"] == "stooq"
+    assert payload["count"] == 1
+
+
+async def test_market_candles_invalid_timeframe_returns_400(monkeypatch):
+    block_external_network(monkeypatch)
+
+    response = await _get("/api/market/candles?symbol=NVDA&timeframe=5m&limit=100")
+    assert response.status_code == 400
+    assert "Unsupported timeframe" in response.json()["detail"]

--- a/frontend/src/components/monitor/MiniCandlesChart.tsx
+++ b/frontend/src/components/monitor/MiniCandlesChart.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react'
+import { createChart, ColorType } from 'lightweight-charts'
+
+export interface MarketCandle {
+  timestamp_utc: string
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number
+}
+
+interface MiniCandlesChartProps {
+  candles: MarketCandle[]
+}
+
+export function MiniCandlesChart({ candles }: MiniCandlesChartProps) {
+  const chartContainerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!chartContainerRef.current || candles.length === 0) return
+
+    const chart = createChart(chartContainerRef.current, {
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: '#94a3b8',
+      },
+      grid: {
+        vertLines: { color: 'rgba(255, 255, 255, 0.06)' },
+        horzLines: { color: 'rgba(255, 255, 255, 0.06)' },
+      },
+      rightPriceScale: { borderColor: 'rgba(255, 255, 255, 0.12)' },
+      timeScale: {
+        borderColor: 'rgba(255, 255, 255, 0.12)',
+        timeVisible: true,
+        secondsVisible: false,
+      },
+      width: chartContainerRef.current.clientWidth,
+      height: 280,
+    })
+
+    const series = chart.addCandlestickSeries({
+      upColor: '#22c55e',
+      downColor: '#ef4444',
+      borderUpColor: '#22c55e',
+      borderDownColor: '#ef4444',
+      wickUpColor: '#22c55e',
+      wickDownColor: '#ef4444',
+    })
+
+    const chartData = candles
+      .map((c) => ({
+        time: Math.floor(new Date(c.timestamp_utc).getTime() / 1000) as any,
+        open: c.open,
+        high: c.high,
+        low: c.low,
+        close: c.close,
+      }))
+      .sort((a, b) => a.time - b.time)
+
+    series.setData(chartData)
+    chart.timeScale().fitContent()
+
+    const handleResize = () => {
+      if (chartContainerRef.current) {
+        chart.applyOptions({ width: chartContainerRef.current.clientWidth })
+      }
+    }
+    window.addEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      chart.remove()
+    }
+  }, [candles])
+
+  return <div ref={chartContainerRef} className="w-full" data-testid="market-candles-chart" />
+}

--- a/frontend/src/components/monitor/MonitorDashboardTab.tsx
+++ b/frontend/src/components/monitor/MonitorDashboardTab.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { API_BASE_URL } from '@/lib/apiBase'
+import { MiniCandlesChart, type MarketCandle } from './MiniCandlesChart'
+
+type Timeframe = '15m' | '1h' | '4h' | '1d'
+
+interface FavoriteItem {
+  id: number
+  symbol: string
+}
+
+interface SymbolCard {
+  symbol: string
+  assetType: 'crypto' | 'stock'
+  favoritesCount: number
+}
+
+const TIMEFRAMES: Timeframe[] = ['15m', '1h', '4h', '1d']
+
+function classifyAsset(symbol: string): 'crypto' | 'stock' {
+  return symbol.includes('/') ? 'crypto' : 'stock'
+}
+
+export function MonitorDashboardTab() {
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([])
+  const [favoritesLoading, setFavoritesLoading] = useState(false)
+  const [favoritesError, setFavoritesError] = useState<string | null>(null)
+  const [selectedSymbol, setSelectedSymbol] = useState<string>('')
+  const [timeframe, setTimeframe] = useState<Timeframe>('1h')
+  const [candles, setCandles] = useState<MarketCandle[]>([])
+  const [candlesLoading, setCandlesLoading] = useState(false)
+  const [candlesError, setCandlesError] = useState<string | null>(null)
+
+  const candlesCacheRef = useRef<Map<string, MarketCandle[]>>(new Map())
+
+  const symbols = useMemo<SymbolCard[]>(() => {
+    const grouped = new Map<string, SymbolCard>()
+    for (const fav of favorites) {
+      const key = String(fav.symbol || '').trim()
+      if (!key) continue
+      const row = grouped.get(key)
+      if (row) {
+        row.favoritesCount += 1
+        continue
+      }
+      grouped.set(key, {
+        symbol: key,
+        assetType: classifyAsset(key),
+        favoritesCount: 1,
+      })
+    }
+    return Array.from(grouped.values()).sort((a, b) => a.symbol.localeCompare(b.symbol))
+  }, [favorites])
+
+  useEffect(() => {
+    if (!selectedSymbol && symbols.length > 0) {
+      setSelectedSymbol(symbols[0].symbol)
+    } else if (selectedSymbol && !symbols.some((s) => s.symbol === selectedSymbol)) {
+      setSelectedSymbol(symbols[0]?.symbol || '')
+    }
+  }, [selectedSymbol, symbols])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const run = async () => {
+      setFavoritesLoading(true)
+      setFavoritesError(null)
+      try {
+        const response = await fetch(`${API_BASE_URL}/favorites/`, { signal: controller.signal })
+        if (!response.ok) {
+          throw new Error(`Failed to load favorites (${response.status})`)
+        }
+        const data = await response.json()
+        setFavorites(Array.isArray(data) ? data : [])
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setFavoritesError(error instanceof Error ? error.message : 'Failed to load favorites')
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setFavoritesLoading(false)
+        }
+      }
+    }
+    run()
+    return () => controller.abort()
+  }, [])
+
+  useEffect(() => {
+    if (!selectedSymbol) {
+      setCandles([])
+      setCandlesError(null)
+      return
+    }
+
+    const key = `${selectedSymbol}|${timeframe}`
+    const cached = candlesCacheRef.current.get(key)
+    if (cached) {
+      setCandles(cached)
+      setCandlesError(null)
+      return
+    }
+
+    const controller = new AbortController()
+    const run = async () => {
+      setCandlesLoading(true)
+      setCandlesError(null)
+      try {
+        const url = new URL(`${API_BASE_URL}/market/candles`, window.location.origin)
+        url.searchParams.set('symbol', selectedSymbol)
+        url.searchParams.set('timeframe', timeframe)
+        url.searchParams.set('limit', '300')
+        const response = await fetch(url.toString(), { signal: controller.signal })
+        const payload = await response.json()
+        if (!response.ok) {
+          throw new Error(String(payload?.detail || `Failed to load candles (${response.status})`))
+        }
+        const rows = Array.isArray(payload?.candles) ? payload.candles : []
+        candlesCacheRef.current.set(key, rows)
+        setCandles(rows)
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setCandles([])
+          setCandlesError(error instanceof Error ? error.message : 'Failed to load candles')
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setCandlesLoading(false)
+        }
+      }
+    }
+    run()
+    return () => controller.abort()
+  }, [selectedSymbol, timeframe])
+
+  const selectedMeta = symbols.find((s) => s.symbol === selectedSymbol) || null
+  const lastClose = candles.length > 0 ? candles[candles.length - 1].close : null
+  const previousClose = candles.length > 1 ? candles[candles.length - 2].close : null
+  const changePct = lastClose && previousClose ? ((lastClose - previousClose) / previousClose) * 100 : null
+
+  return (
+    <section className="space-y-4 max-w-full overflow-x-hidden" data-testid="monitor-dashboard-tab">
+      <header className="space-y-1">
+        <h2 className="text-2xl font-bold text-white">Dashboard</h2>
+        <p className="text-sm text-gray-400">Favorites only. Select a symbol to inspect candles by timeframe.</p>
+      </header>
+
+      {favoritesLoading ? <p className="text-sm text-gray-400">Loading favorites...</p> : null}
+      {favoritesError ? <p className="text-sm text-red-400">{favoritesError}</p> : null}
+
+      {!favoritesLoading && !favoritesError && symbols.length === 0 ? (
+        <p className="text-sm text-gray-400">No favorites found. Add favorites to use the dashboard.</p>
+      ) : null}
+
+      {symbols.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2" data-testid="dashboard-symbol-list">
+          {symbols.map((item) => {
+            const active = item.symbol === selectedSymbol
+            return (
+              <button
+                key={item.symbol}
+                type="button"
+                onClick={() => setSelectedSymbol(item.symbol)}
+                className={`w-full rounded-xl border text-left px-3 py-3 min-h-11 transition-colors ${
+                  active
+                    ? 'border-blue-400 bg-blue-500/15 text-white'
+                    : 'border-white/15 bg-white/5 text-gray-200 hover:bg-white/10'
+                }`}
+                aria-pressed={active}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-semibold">{item.symbol}</span>
+                  <span className="text-xs uppercase tracking-wide text-gray-300">{item.assetType}</span>
+                </div>
+                <p className="text-xs text-gray-400 mt-1">{item.favoritesCount} favorite strategy{item.favoritesCount > 1 ? 'ies' : ''}</p>
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+
+      {selectedSymbol ? (
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h3 className="text-lg font-semibold text-white">{selectedSymbol}</h3>
+              <p className="text-xs text-gray-400">
+                {selectedMeta?.assetType ?? classifyAsset(selectedSymbol)} • {timeframe} • {candles.length} candles
+              </p>
+            </div>
+            <div className="text-right">
+              <p className="text-sm text-gray-300">Last close</p>
+              <p className="font-mono text-lg text-white">{lastClose !== null ? lastClose.toFixed(4) : '-'}</p>
+              <p className={`text-xs ${changePct !== null && changePct < 0 ? 'text-red-400' : 'text-green-400'}`}>
+                {changePct !== null ? `${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%` : 'n/a'}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Timeframe">
+            {TIMEFRAMES.map((tf) => {
+              const active = tf === timeframe
+              return (
+                <button
+                  key={tf}
+                  type="button"
+                  onClick={() => setTimeframe(tf)}
+                  className={`rounded-lg border px-3 min-h-11 min-w-11 text-sm font-medium transition-colors ${
+                    active
+                      ? 'border-blue-400 bg-blue-500/20 text-white'
+                      : 'border-white/15 bg-white/5 text-gray-200 hover:bg-white/10'
+                  }`}
+                  aria-pressed={active}
+                  data-testid={`timeframe-${tf}`}
+                >
+                  {tf}
+                </button>
+              )
+            })}
+          </div>
+
+          {candlesLoading ? <p className="text-sm text-gray-400">Loading candles...</p> : null}
+          {candlesError ? <p className="text-sm text-red-400">{candlesError}</p> : null}
+          {!candlesLoading && !candlesError && candles.length === 0 ? (
+            <p className="text-sm text-gray-400">No candle data available for this symbol/timeframe.</p>
+          ) : null}
+          {!candlesLoading && !candlesError && candles.length > 0 ? <MiniCandlesChart candles={candles} /> : null}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/frontend/src/components/monitor/MonitorStatusTab.tsx
+++ b/frontend/src/components/monitor/MonitorStatusTab.tsx
@@ -1,0 +1,312 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import type { Opportunity } from '@/components/monitor/types';
+import { OpportunityCard } from '@/components/monitor/OpportunityCard';
+import { Button } from '@/components/ui/Button';
+import { Card, CardContent, CardHeader } from '@/components/ui/Card';
+import { RefreshCw, ArrowUpDown, ChevronDown } from 'lucide-react';
+import { useToast } from "@/components/ui/use-toast";
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+
+type SortOption = 'distance' | 'tier_distance' | 'symbol';
+type TierFilter = 'all' | '1_2' | '1' | '2' | '3' | 'none';
+
+export const MonitorStatusTab: React.FC = () => {
+    const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [sortBy, setSortBy] = useState<SortOption>('tier_distance');
+    const [tierFilter, setTierFilter] = useState<TierFilter>('all');
+    const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+    const { toast } = useToast();
+
+    const fetchOpportunities = async (tier?: TierFilter) => {
+        setLoading(true);
+        try {
+            // Convert frontend tier filter to API query param
+            const tierParam = tier || tierFilter;
+            let apiTier: string;
+            if (tierParam === 'all') {
+                apiTier = 'all';
+            } else if (tierParam === '1_2') {
+                apiTier = '1,2';  // API expects comma-separated
+            } else if (tierParam === 'none') {
+                apiTier = 'none';
+            } else {
+                apiTier = tierParam;  // '1', '2', '3'
+            }
+            
+            // Prefer relative "/api" so Vite proxy routes to backend even when accessing from outside the server.
+            // Only use VITE_API_URL when explicitly set.
+            const baseUrl = import.meta.env.VITE_API_URL || "/api";
+            const url = `${baseUrl}/opportunities/?tier=${encodeURIComponent(apiTier)}`;
+            const response = await fetch(url);
+            if (!response.ok) throw new Error('Failed to fetch opportunities');
+            const data = await response.json();
+            setOpportunities(data);
+            setLastUpdated(new Date());
+
+            toast({
+                title: "Atualizado",
+                description: `${data.length} estratégias analisadas`,
+            });
+        } catch (error) {
+            console.error(error);
+            toast({
+                title: "Erro",
+                description: "Não foi possível carregar. O backend está rodando?",
+                variant: "destructive"
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // Fetch when page loads or tier filter changes
+    useEffect(() => {
+        fetchOpportunities(tierFilter);
+    }, [tierFilter]);
+
+    // Sort opportunities by selected criteria
+    const sortedOpportunities = useMemo(() => {
+        const sorted = [...opportunities].sort((a, b) => {
+            if (sortBy === 'tier_distance') {
+                // Tier + Distância: Tier 1 e 2 primeiro, depois por distância
+                // HOLD sempre primeiro dentro de cada grupo de tier
+                const tierA = a.tier ?? 999;
+                const tierB = b.tier ?? 999;
+                // Agrupar Tier 1 e 2 como "prioritários" (< 3), outros depois
+                const priorityA = tierA <= 2 ? 0 : 1;
+                const priorityB = tierB <= 2 ? 0 : 1;
+                if (priorityA !== priorityB) {
+                    return priorityA - priorityB;
+                }
+                // Dentro do mesmo grupo de prioridade, HOLD primeiro
+                if (a.is_holding !== b.is_holding) {
+                    return a.is_holding ? -1 : 1;
+                }
+                // Depois por tier específico (1 antes de 2)
+                if (tierA !== tierB) {
+                    return tierA - tierB;
+                }
+                // Depois por distância (mais próximo primeiro)
+                const distA = a.distance_to_next_status ?? 999;
+                const distB = b.distance_to_next_status ?? 999;
+                if (distA !== distB) {
+                    return distA - distB;
+                }
+                return a.symbol.localeCompare(b.symbol);
+            } else if (sortBy === 'distance') {
+                // Distância: HOLD primeiro, depois por distância
+                if (a.is_holding !== b.is_holding) {
+                    return a.is_holding ? -1 : 1;
+                }
+                const distA = a.distance_to_next_status ?? 999;
+                const distB = b.distance_to_next_status ?? 999;
+                if (distA !== distB) {
+                    return distA - distB;
+                }
+                const tierA = a.tier ?? 999;
+                const tierB = b.tier ?? 999;
+                if (tierA !== tierB) {
+                    return tierA - tierB;
+                }
+                return a.symbol.localeCompare(b.symbol);
+            } else if (sortBy === 'symbol') {
+                return a.symbol.localeCompare(b.symbol);
+            }
+            return 0;
+        });
+        return sorted;
+    }, [opportunities, sortBy]);
+
+    // Separate opportunities by status, then apply tier filter
+    // Dados já vêm filtrados por tier do backend
+    const holding = sortedOpportunities.filter(o => o.is_holding);
+    const stoppedOut = sortedOpportunities.filter(o => !o.is_holding && o.status === 'STOPPED_OUT');
+    const missedEntry = sortedOpportunities.filter(o => !o.is_holding && o.status === 'MISSED_ENTRY');
+    const waiting = sortedOpportunities.filter(o => !o.is_holding && o.status !== 'STOPPED_OUT' && o.status !== 'MISSED_ENTRY');
+
+    // Lista ordenada para paginação infinita: holding → stopped → missed → waiting
+    type SectionKey = 'holding' | 'stoppedOut' | 'missedEntry' | 'waiting';
+    const orderedCards = useMemo(() => {
+        const withSection = (arr: Opportunity[], s: SectionKey) =>
+            arr.map((opp) => ({ opp, section: s }));
+        return [
+            ...withSection(holding, 'holding'),
+            ...withSection(stoppedOut, 'stoppedOut'),
+            ...withSection(missedEntry, 'missedEntry'),
+            ...withSection(waiting, 'waiting'),
+        ];
+    }, [holding, stoppedOut, missedEntry, waiting]);
+
+    const { visibleItems, hasMore, sentinelRef } = useInfiniteScroll(orderedCards, 24, 24);
+
+    // Agrupa itens visíveis por seção consecutiva para manter headers + grid
+    const visibleGroups = useMemo(() => {
+        const g: { section: SectionKey; cards: Opportunity[] }[] = [];
+        for (const { opp, section } of visibleItems) {
+            if (g.length > 0 && g[g.length - 1].section === section)
+                g[g.length - 1].cards.push(opp);
+            else
+                g.push({ section, cards: [opp] });
+        }
+        return g;
+    }, [visibleItems]);
+
+    const SECTION_CONFIG: Record<SectionKey, { title: string; subtitle: string; dotClass: string; h2Class: string; badgeClass: string; description: string }> = {
+        holding: {
+            title: 'Em Hold',
+            subtitle: 'Posições Ativas',
+            dotClass: 'bg-green-500',
+            h2Class: 'text-green-600',
+            badgeClass: 'bg-green-500/10 text-green-600',
+            description: 'Estratégias com posição aberta. A distância mostra o quanto falta para o sinal de saída.',
+        },
+        stoppedOut: {
+            title: 'Saiu no Stop',
+            subtitle: 'Stop Loss Ativado',
+            dotClass: 'bg-red-500',
+            h2Class: 'text-red-600',
+            badgeClass: 'bg-red-500/10 text-red-600',
+            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas a posição foi fechada no stop loss. A distância mostra o spread entre as médias. Aguardando cruzamento para baixo ou nova entrada.',
+        },
+        missedEntry: {
+            title: 'Entrada Perdida',
+            subtitle: 'Sem Posição',
+            dotClass: 'bg-yellow-500',
+            h2Class: 'text-yellow-600',
+            badgeClass: 'bg-yellow-500/10 text-yellow-600',
+            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas não há posição ativa. Aguardando confirmação ou nova entrada.',
+        },
+        waiting: {
+            title: 'Aguardando',
+            subtitle: 'Sem Posição',
+            dotClass: 'bg-gray-400',
+            h2Class: 'text-gray-500',
+            badgeClass: 'bg-gray-500/10 text-gray-600',
+            description: 'Estratégias aguardando sinal de entrada. A distância mostra o quanto falta para a média curta cruzar acima da longa.',
+        },
+    };
+
+    return (
+        <div className="container mx-auto p-6 space-y-8">
+            <div className="flex flex-col gap-4">
+                <div className="flex justify-between items-center">
+                    <div className="space-y-1">
+                        <h1 className="text-3xl font-bold tracking-tight">Opportunity Board</h1>
+                        <p className="text-muted-foreground">
+                            Monitor your favorite strategies - See which are in HOLD and how close they are to the next signal
+                        </p>
+                        {lastUpdated && (
+                            <p className="text-xs text-muted-foreground">
+                                Last updated: {lastUpdated.toLocaleTimeString()}
+                            </p>
+                        )}
+                    </div>
+                    <div className="flex gap-2">
+                        <Button variant="secondary" onClick={() => fetchOpportunities()} disabled={loading}>
+                            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                            Refresh
+                        </Button>
+                    </div>
+                </div>
+
+                <div className="flex items-center gap-4 flex-wrap">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">Tier:</span>
+                        <div className="relative">
+                            <select
+                                value={tierFilter}
+                                onChange={(e) => setTierFilter(e.target.value as TierFilter)}
+                                className="text-sm border border-border rounded pl-2 pr-8 py-1.5 bg-gray-900 text-gray-100 appearance-none cursor-pointer focus:ring-1 focus:ring-primary focus:border-primary"
+                                title="Filtrar por tier"
+                            >
+                                <option value="all" className="bg-gray-900">Tier: All</option>
+                                <option value="1" className="bg-gray-900">Tier 1 – Core</option>
+                                <option value="2" className="bg-gray-900">Tier 2 – Complementares</option>
+                                <option value="3" className="bg-gray-900">Tier 3</option>
+                                <option value="1_2" className="bg-gray-900">Tier 1 + Tier 2</option>
+                                <option value="none" className="bg-gray-900">Sem tier</option>
+                            </select>
+                            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <ArrowUpDown className="w-4 h-4 text-muted-foreground" />
+                        <span className="text-sm font-medium">Sort:</span>
+                        <div className="relative">
+                            <select
+                                value={sortBy}
+                                onChange={(e) => setSortBy(e.target.value as SortOption)}
+                                className="text-sm border border-border rounded pl-2 pr-8 py-1.5 bg-gray-900 text-gray-100 appearance-none cursor-pointer focus:ring-1 focus:ring-primary focus:border-primary"
+                            >
+                                <option value="tier_distance" className="bg-gray-900">Tier + Distância</option>
+                                <option value="distance" className="bg-gray-900">Distância (mais próximo)</option>
+                                <option value="symbol" className="bg-gray-900">Símbolo</option>
+                            </select>
+                            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {loading && opportunities.length === 0 ? (
+                <div className="space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                        {[1, 2, 3, 4].map(i => (
+                            <Card key={i} className="border-l-4 border-l-gray-300 animate-pulse">
+                                <CardHeader className="space-y-2">
+                                    <div className="h-5 bg-gray-200 rounded w-3/4"></div>
+                                    <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+                                </CardHeader>
+                                <CardContent className="space-y-3">
+                                    <div className="h-4 bg-gray-200 rounded"></div>
+                                    <div className="h-4 bg-gray-200 rounded"></div>
+                                    <div className="h-12 bg-gray-200 rounded"></div>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+                </div>
+            ) : opportunities.length === 0 && !loading ? (
+                <div className="text-center py-20 space-y-4">
+                    <p className="text-muted-foreground">No favorites found. Star some strategies in the Backtester to see them here!</p>
+                    <Button variant="secondary" onClick={() => window.location.href = '/'}>
+                        Go to Backtester
+                    </Button>
+                </div>
+            ) : (
+                <div className="space-y-10">
+                    {visibleGroups.map(({ section, cards }) => {
+                        const cfg = SECTION_CONFIG[section];
+                        const total = { holding: holding.length, stoppedOut: stoppedOut.length, missedEntry: missedEntry.length, waiting: waiting.length }[section];
+                        return (
+                            <section key={section} className="space-y-4">
+                                <h2 className={`text-xl font-semibold flex items-center gap-2 ${cfg.h2Class}`}>
+                                    <span className={`w-3 h-3 ${cfg.dotClass} rounded-full`}></span>
+                                    {cfg.title} ({total})
+                                    <span className={`${cfg.badgeClass} text-xs px-2 py-0.5 rounded-full ml-2`}>
+                                        {cfg.subtitle}
+                                    </span>
+                                </h2>
+                                <p className="text-sm text-muted-foreground ml-5">
+                                    {cfg.description}
+                                </p>
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                                    {cards.map((opp) => (
+                                        <OpportunityCard key={opp.id} opportunity={opp} />
+                                    ))}
+                                </div>
+                            </section>
+                        );
+                    })}
+                    {/* Sentinel: ao entrar na viewport, carrega mais itens */}
+                    {hasMore && (
+                        <div ref={sentinelRef} className="flex justify-center py-8" aria-hidden="true">
+                            <span className="text-sm text-muted-foreground animate-pulse">Carregando mais…</span>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/frontend/src/pages/MonitorPage.tsx
+++ b/frontend/src/pages/MonitorPage.tsx
@@ -1,312 +1,46 @@
-import React, { useEffect, useState, useMemo } from 'react';
-import type { Opportunity } from '@/components/monitor/types';
-import { OpportunityCard } from '@/components/monitor/OpportunityCard';
-import { Button } from '@/components/ui/Button';
-import { Card, CardContent, CardHeader } from '@/components/ui/Card';
-import { RefreshCw, ArrowUpDown, ChevronDown } from 'lucide-react';
-import { useToast } from "@/components/ui/use-toast";
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useState } from 'react'
+import { MonitorDashboardTab } from '@/components/monitor/MonitorDashboardTab'
+import { MonitorStatusTab } from '@/components/monitor/MonitorStatusTab'
 
-type SortOption = 'distance' | 'tier_distance' | 'symbol';
-type TierFilter = 'all' | '1_2' | '1' | '2' | '3' | 'none';
+type MonitorTab = 'status' | 'dashboard'
 
-export const MonitorPage: React.FC = () => {
-    const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [sortBy, setSortBy] = useState<SortOption>('tier_distance');
-    const [tierFilter, setTierFilter] = useState<TierFilter>('all');
-    const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-    const { toast } = useToast();
+export function MonitorPage() {
+  const [activeTab, setActiveTab] = useState<MonitorTab>('status')
 
-    const fetchOpportunities = async (tier?: TierFilter) => {
-        setLoading(true);
-        try {
-            // Convert frontend tier filter to API query param
-            const tierParam = tier || tierFilter;
-            let apiTier: string;
-            if (tierParam === 'all') {
-                apiTier = 'all';
-            } else if (tierParam === '1_2') {
-                apiTier = '1,2';  // API expects comma-separated
-            } else if (tierParam === 'none') {
-                apiTier = 'none';
-            } else {
-                apiTier = tierParam;  // '1', '2', '3'
-            }
-            
-            // Prefer relative "/api" so Vite proxy routes to backend even when accessing from outside the server.
-            // Only use VITE_API_URL when explicitly set.
-            const baseUrl = import.meta.env.VITE_API_URL || "/api";
-            const url = `${baseUrl}/opportunities/?tier=${encodeURIComponent(apiTier)}`;
-            const response = await fetch(url);
-            if (!response.ok) throw new Error('Failed to fetch opportunities');
-            const data = await response.json();
-            setOpportunities(data);
-            setLastUpdated(new Date());
+  return (
+    <div className="container mx-auto p-4 md:p-6 space-y-6 max-w-full overflow-x-hidden">
+      <div className="flex items-center gap-2 p-1 rounded-xl bg-white/5 border border-white/10 w-full sm:w-fit" role="tablist" aria-label="Monitor tabs">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'status'}
+          onClick={() => setActiveTab('status')}
+          className={`rounded-lg px-4 py-2 min-h-11 text-sm font-semibold transition-colors ${
+            activeTab === 'status'
+              ? 'bg-blue-500/20 text-white border border-blue-400/60'
+              : 'text-gray-300 border border-transparent hover:bg-white/10'
+          }`}
+        >
+          Status
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'dashboard'}
+          onClick={() => setActiveTab('dashboard')}
+          className={`rounded-lg px-4 py-2 min-h-11 text-sm font-semibold transition-colors ${
+            activeTab === 'dashboard'
+              ? 'bg-blue-500/20 text-white border border-blue-400/60'
+              : 'text-gray-300 border border-transparent hover:bg-white/10'
+          }`}
+        >
+          Dashboard
+        </button>
+      </div>
 
-            toast({
-                title: "Atualizado",
-                description: `${data.length} estratégias analisadas`,
-            });
-        } catch (error) {
-            console.error(error);
-            toast({
-                title: "Erro",
-                description: "Não foi possível carregar. O backend está rodando?",
-                variant: "destructive"
-            });
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // Fetch when page loads or tier filter changes
-    useEffect(() => {
-        fetchOpportunities(tierFilter);
-    }, [tierFilter]);
-
-    // Sort opportunities by selected criteria
-    const sortedOpportunities = useMemo(() => {
-        const sorted = [...opportunities].sort((a, b) => {
-            if (sortBy === 'tier_distance') {
-                // Tier + Distância: Tier 1 e 2 primeiro, depois por distância
-                // HOLD sempre primeiro dentro de cada grupo de tier
-                const tierA = a.tier ?? 999;
-                const tierB = b.tier ?? 999;
-                // Agrupar Tier 1 e 2 como "prioritários" (< 3), outros depois
-                const priorityA = tierA <= 2 ? 0 : 1;
-                const priorityB = tierB <= 2 ? 0 : 1;
-                if (priorityA !== priorityB) {
-                    return priorityA - priorityB;
-                }
-                // Dentro do mesmo grupo de prioridade, HOLD primeiro
-                if (a.is_holding !== b.is_holding) {
-                    return a.is_holding ? -1 : 1;
-                }
-                // Depois por tier específico (1 antes de 2)
-                if (tierA !== tierB) {
-                    return tierA - tierB;
-                }
-                // Depois por distância (mais próximo primeiro)
-                const distA = a.distance_to_next_status ?? 999;
-                const distB = b.distance_to_next_status ?? 999;
-                if (distA !== distB) {
-                    return distA - distB;
-                }
-                return a.symbol.localeCompare(b.symbol);
-            } else if (sortBy === 'distance') {
-                // Distância: HOLD primeiro, depois por distância
-                if (a.is_holding !== b.is_holding) {
-                    return a.is_holding ? -1 : 1;
-                }
-                const distA = a.distance_to_next_status ?? 999;
-                const distB = b.distance_to_next_status ?? 999;
-                if (distA !== distB) {
-                    return distA - distB;
-                }
-                const tierA = a.tier ?? 999;
-                const tierB = b.tier ?? 999;
-                if (tierA !== tierB) {
-                    return tierA - tierB;
-                }
-                return a.symbol.localeCompare(b.symbol);
-            } else if (sortBy === 'symbol') {
-                return a.symbol.localeCompare(b.symbol);
-            }
-            return 0;
-        });
-        return sorted;
-    }, [opportunities, sortBy]);
-
-    // Separate opportunities by status, then apply tier filter
-    // Dados já vêm filtrados por tier do backend
-    const holding = sortedOpportunities.filter(o => o.is_holding);
-    const stoppedOut = sortedOpportunities.filter(o => !o.is_holding && o.status === 'STOPPED_OUT');
-    const missedEntry = sortedOpportunities.filter(o => !o.is_holding && o.status === 'MISSED_ENTRY');
-    const waiting = sortedOpportunities.filter(o => !o.is_holding && o.status !== 'STOPPED_OUT' && o.status !== 'MISSED_ENTRY');
-
-    // Lista ordenada para paginação infinita: holding → stopped → missed → waiting
-    type SectionKey = 'holding' | 'stoppedOut' | 'missedEntry' | 'waiting';
-    const orderedCards = useMemo(() => {
-        const withSection = (arr: Opportunity[], s: SectionKey) =>
-            arr.map((opp) => ({ opp, section: s }));
-        return [
-            ...withSection(holding, 'holding'),
-            ...withSection(stoppedOut, 'stoppedOut'),
-            ...withSection(missedEntry, 'missedEntry'),
-            ...withSection(waiting, 'waiting'),
-        ];
-    }, [holding, stoppedOut, missedEntry, waiting]);
-
-    const { visibleItems, hasMore, sentinelRef } = useInfiniteScroll(orderedCards, 24, 24);
-
-    // Agrupa itens visíveis por seção consecutiva para manter headers + grid
-    const visibleGroups = useMemo(() => {
-        const g: { section: SectionKey; cards: Opportunity[] }[] = [];
-        for (const { opp, section } of visibleItems) {
-            if (g.length > 0 && g[g.length - 1].section === section)
-                g[g.length - 1].cards.push(opp);
-            else
-                g.push({ section, cards: [opp] });
-        }
-        return g;
-    }, [visibleItems]);
-
-    const SECTION_CONFIG: Record<SectionKey, { title: string; subtitle: string; dotClass: string; h2Class: string; badgeClass: string; description: string }> = {
-        holding: {
-            title: 'Em Hold',
-            subtitle: 'Posições Ativas',
-            dotClass: 'bg-green-500',
-            h2Class: 'text-green-600',
-            badgeClass: 'bg-green-500/10 text-green-600',
-            description: 'Estratégias com posição aberta. A distância mostra o quanto falta para o sinal de saída.',
-        },
-        stoppedOut: {
-            title: 'Saiu no Stop',
-            subtitle: 'Stop Loss Ativado',
-            dotClass: 'bg-red-500',
-            h2Class: 'text-red-600',
-            badgeClass: 'bg-red-500/10 text-red-600',
-            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas a posição foi fechada no stop loss. A distância mostra o spread entre as médias. Aguardando cruzamento para baixo ou nova entrada.',
-        },
-        missedEntry: {
-            title: 'Entrada Perdida',
-            subtitle: 'Sem Posição',
-            dotClass: 'bg-yellow-500',
-            h2Class: 'text-yellow-600',
-            badgeClass: 'bg-yellow-500/10 text-yellow-600',
-            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas não há posição ativa. Aguardando confirmação ou nova entrada.',
-        },
-        waiting: {
-            title: 'Aguardando',
-            subtitle: 'Sem Posição',
-            dotClass: 'bg-gray-400',
-            h2Class: 'text-gray-500',
-            badgeClass: 'bg-gray-500/10 text-gray-600',
-            description: 'Estratégias aguardando sinal de entrada. A distância mostra o quanto falta para a média curta cruzar acima da longa.',
-        },
-    };
-
-    return (
-        <div className="container mx-auto p-6 space-y-8">
-            <div className="flex flex-col gap-4">
-                <div className="flex justify-between items-center">
-                    <div className="space-y-1">
-                        <h1 className="text-3xl font-bold tracking-tight">Opportunity Board</h1>
-                        <p className="text-muted-foreground">
-                            Monitor your favorite strategies - See which are in HOLD and how close they are to the next signal
-                        </p>
-                        {lastUpdated && (
-                            <p className="text-xs text-muted-foreground">
-                                Last updated: {lastUpdated.toLocaleTimeString()}
-                            </p>
-                        )}
-                    </div>
-                    <div className="flex gap-2">
-                        <Button variant="secondary" onClick={() => fetchOpportunities()} disabled={loading}>
-                            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-                            Refresh
-                        </Button>
-                    </div>
-                </div>
-
-                <div className="flex items-center gap-4 flex-wrap">
-                    <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium">Tier:</span>
-                        <div className="relative">
-                            <select
-                                value={tierFilter}
-                                onChange={(e) => setTierFilter(e.target.value as TierFilter)}
-                                className="text-sm border border-border rounded pl-2 pr-8 py-1.5 bg-gray-900 text-gray-100 appearance-none cursor-pointer focus:ring-1 focus:ring-primary focus:border-primary"
-                                title="Filtrar por tier"
-                            >
-                                <option value="all" className="bg-gray-900">Tier: All</option>
-                                <option value="1" className="bg-gray-900">Tier 1 – Core</option>
-                                <option value="2" className="bg-gray-900">Tier 2 – Complementares</option>
-                                <option value="3" className="bg-gray-900">Tier 3</option>
-                                <option value="1_2" className="bg-gray-900">Tier 1 + Tier 2</option>
-                                <option value="none" className="bg-gray-900">Sem tier</option>
-                            </select>
-                            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
-                        </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                        <ArrowUpDown className="w-4 h-4 text-muted-foreground" />
-                        <span className="text-sm font-medium">Sort:</span>
-                        <div className="relative">
-                            <select
-                                value={sortBy}
-                                onChange={(e) => setSortBy(e.target.value as SortOption)}
-                                className="text-sm border border-border rounded pl-2 pr-8 py-1.5 bg-gray-900 text-gray-100 appearance-none cursor-pointer focus:ring-1 focus:ring-primary focus:border-primary"
-                            >
-                                <option value="tier_distance" className="bg-gray-900">Tier + Distância</option>
-                                <option value="distance" className="bg-gray-900">Distância (mais próximo)</option>
-                                <option value="symbol" className="bg-gray-900">Símbolo</option>
-                            </select>
-                            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            {loading && opportunities.length === 0 ? (
-                <div className="space-y-4">
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                        {[1, 2, 3, 4].map(i => (
-                            <Card key={i} className="border-l-4 border-l-gray-300 animate-pulse">
-                                <CardHeader className="space-y-2">
-                                    <div className="h-5 bg-gray-200 rounded w-3/4"></div>
-                                    <div className="h-4 bg-gray-200 rounded w-1/2"></div>
-                                </CardHeader>
-                                <CardContent className="space-y-3">
-                                    <div className="h-4 bg-gray-200 rounded"></div>
-                                    <div className="h-4 bg-gray-200 rounded"></div>
-                                    <div className="h-12 bg-gray-200 rounded"></div>
-                                </CardContent>
-                            </Card>
-                        ))}
-                    </div>
-                </div>
-            ) : opportunities.length === 0 && !loading ? (
-                <div className="text-center py-20 space-y-4">
-                    <p className="text-muted-foreground">No favorites found. Star some strategies in the Backtester to see them here!</p>
-                    <Button variant="secondary" onClick={() => window.location.href = '/'}>
-                        Go to Backtester
-                    </Button>
-                </div>
-            ) : (
-                <div className="space-y-10">
-                    {visibleGroups.map(({ section, cards }) => {
-                        const cfg = SECTION_CONFIG[section];
-                        const total = { holding: holding.length, stoppedOut: stoppedOut.length, missedEntry: missedEntry.length, waiting: waiting.length }[section];
-                        return (
-                            <section key={section} className="space-y-4">
-                                <h2 className={`text-xl font-semibold flex items-center gap-2 ${cfg.h2Class}`}>
-                                    <span className={`w-3 h-3 ${cfg.dotClass} rounded-full`}></span>
-                                    {cfg.title} ({total})
-                                    <span className={`${cfg.badgeClass} text-xs px-2 py-0.5 rounded-full ml-2`}>
-                                        {cfg.subtitle}
-                                    </span>
-                                </h2>
-                                <p className="text-sm text-muted-foreground ml-5">
-                                    {cfg.description}
-                                </p>
-                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                                    {cards.map((opp) => (
-                                        <OpportunityCard key={opp.id} opportunity={opp} />
-                                    ))}
-                                </div>
-                            </section>
-                        );
-                    })}
-                    {/* Sentinel: ao entrar na viewport, carrega mais itens */}
-                    {hasMore && (
-                        <div ref={sentinelRef} className="flex justify-center py-8" aria-hidden="true">
-                            <span className="text-sm text-muted-foreground animate-pulse">Carregando mais…</span>
-                        </div>
-                    )}
-                </div>
-            )}
-        </div>
-    );
-};
+      <div role="tabpanel">
+        {activeTab === 'status' ? <MonitorStatusTab /> : <MonitorDashboardTab />}
+      </div>
+    </div>
+  )
+}

--- a/frontend/tests/e2e/monitor-dashboard-mobile-candles.spec.ts
+++ b/frontend/tests/e2e/monitor-dashboard-mobile-candles.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test'
+
+const FAVORITES_PAYLOAD = [
+  {
+    id: 1,
+    name: 'NVDA Trend',
+    symbol: 'NVDA',
+    timeframe: '1d',
+    strategy_name: 'ema_rsi',
+    parameters: {},
+    metrics: {},
+    created_at: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'BTC Momentum',
+    symbol: 'BTC/USDT',
+    timeframe: '4h',
+    strategy_name: 'ema_rsi',
+    parameters: {},
+    metrics: {},
+    created_at: '2025-01-01T00:00:00Z',
+  },
+]
+
+function buildCandles() {
+  return [
+    { timestamp_utc: '2025-01-01T00:00:00Z', open: 100, high: 102, low: 99, close: 101, volume: 1000 },
+    { timestamp_utc: '2025-01-01T01:00:00Z', open: 101, high: 103, low: 100, close: 102, volume: 1100 },
+    { timestamp_utc: '2025-01-01T02:00:00Z', open: 102, high: 104, low: 101, close: 103, volume: 1200 },
+  ]
+}
+
+async function setupApiMocks(page: any) {
+  const requestedTimeframes: string[] = []
+
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/opportunities/**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  )
+
+  await page.route('**/api/favorites/', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(FAVORITES_PAYLOAD),
+    })
+  )
+
+  await page.route('**/api/market/candles**', (route: any) => {
+    const url = new URL(route.request().url())
+    requestedTimeframes.push(url.searchParams.get('timeframe') || '')
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        symbol: url.searchParams.get('symbol'),
+        timeframe: url.searchParams.get('timeframe'),
+        asset_type: 'crypto',
+        data_source: 'ccxt',
+        candles: buildCandles(),
+        count: 3,
+        limit: 300,
+      }),
+    })
+  })
+
+  return {
+    requestedTimeframes,
+  }
+}
+
+test.use({ viewport: { width: 390, height: 844 } })
+
+test('monitor shows status and dashboard tabs and loads favorites in dashboard', async ({ page }) => {
+  await setupApiMocks(page)
+  await page.goto('/monitor')
+
+  await expect(page.getByRole('tab', { name: 'Status' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Dashboard' })).toBeVisible()
+
+  await page.getByRole('tab', { name: 'Dashboard' }).click()
+  await expect(page.getByTestId('monitor-dashboard-tab')).toBeVisible()
+  await expect(page.getByTestId('dashboard-symbol-list')).toContainText('NVDA')
+  await expect(page.getByTestId('dashboard-symbol-list')).toContainText('BTC/USDT')
+})
+
+test('monitor dashboard selects symbol and renders chart container', async ({ page }) => {
+  await setupApiMocks(page)
+  await page.goto('/monitor')
+  await page.getByRole('tab', { name: 'Dashboard' }).click()
+
+  await page.getByRole('button', { name: /BTC\/USDT/i }).click()
+  await expect(page.getByTestId('market-candles-chart')).toBeVisible()
+})
+
+test('monitor dashboard timeframe switching updates request and state', async ({ page }) => {
+  const mocks = await setupApiMocks(page)
+  await page.goto('/monitor')
+  await page.getByRole('tab', { name: 'Dashboard' }).click()
+
+  await expect(page.getByTestId('timeframe-1h')).toHaveAttribute('aria-pressed', 'true')
+  await page.getByTestId('timeframe-4h').click()
+  await expect(page.getByTestId('timeframe-4h')).toHaveAttribute('aria-pressed', 'true')
+
+  await expect.poll(() => mocks.requestedTimeframes.includes('4h')).toBe(true)
+})

--- a/openspec/changes/monitor-dashboard-mobile-candles/.openspec.yaml
+++ b/openspec/changes/monitor-dashboard-mobile-candles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-25

--- a/openspec/changes/monitor-dashboard-mobile-candles/design.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/design.md
@@ -1,0 +1,72 @@
+## Context
+
+We want a **mobile-first** monitoring dashboard that feels like a lightweight TradingView, but is limited to the user’s **Favorites** symbols. The dashboard must render **candlestick charts** and allow timeframe switching.
+
+Constraints:
+- Reuse existing market data origins where possible:
+  - Stocks: Stooq (typically 1d)
+  - Crypto: CCXT (supports intraday timeframes like 1h/4h)
+- Keep the initial version small and stable; focus on UX and correctness.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a new dashboard route optimized for mobile.
+- Display Favorites symbols and allow selecting a symbol.
+- Render candlestick chart for the selected symbol.
+- Support timeframe switching (1h/4h/1d) with validation.
+- Avoid external UI complexity; keep controls touch-friendly.
+
+**Non-Goals:**
+- Full TradingView feature parity (drawing tools, many indicators, multi-pane layouts).
+- Storing custom layouts per user.
+- Adding new data providers beyond existing Stooq/CCXT.
+
+## Decisions
+
+1) Tabs inside existing Monitor
+- Decision: enhance the existing Monitor screen by adding tabs:
+  - Status (existing behavior)
+  - Dashboard (new mobile-first)
+- Rationale: preserves existing workflows while enabling iterative improvements in the same entry point.
+
+2) Candlestick chart library
+- Decision: use a lightweight React candlestick chart solution (e.g., `lightweight-charts` wrapper) rather than building custom SVG.
+- Rationale: candlestick rendering and time axes are non-trivial; library reduces bugs.
+
+3) Backend candle endpoint
+- Decision: add a small backend endpoint that returns OHLC candles for a symbol/timeframe using existing providers.
+- Rationale: keeps frontend simple and consistent; provides one contract for both stocks and crypto.
+
+4) Timeframe constraints and provider selection
+- Decision: enforce provider-specific timeframe validation:
+  - Stocks:
+    - `15m`, `1h`, `4h` via Yahoo (intraday with limited history windows)
+    - `1d` via Stooq or Yahoo
+  - Crypto (ccxt): allow `15m`, `1h`, `4h`, `1d` initially
+- Rationale: enables intraday monitoring for stocks while keeping behavior predictable.
+
+5) Favorites as the only dataset
+- Decision: dashboard pulls symbols from existing Favorites endpoint/data.
+- Rationale: matches user intent and reduces scope.
+
+## Risks / Trade-offs
+
+- [Risk] E2E test flakiness due to charts rendering in headless mode → Mitigation: E2E asserts presence of chart container + basic UI state, not pixel-perfect candles.
+- [Risk] Stooq limitations for intraday → Mitigation: show disabled timeframes for stocks and clear validation messages.
+- [Risk] Increased frontend bundle size due to chart library → Mitigation: choose small library; lazy-load chart component.
+
+## Migration Plan
+
+1) Add backend candle endpoint and unit/integration tests.
+2) Add frontend dashboard route and UI.
+3) Add Playwright E2E tests for navigation + timeframe switching.
+4) Deploy and verify on mobile.
+
+Rollback: revert the change or hide the dashboard route behind a feature flag.
+
+## Open Questions
+
+- Final route naming: `/dashboard` vs `/monitor2`.
+- How many candles to fetch by default (limit) per timeframe.
+- Whether to show mini sparklines in the list or only in the selected detail view.

--- a/openspec/changes/monitor-dashboard-mobile-candles/proposal.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The current Monitor experience is useful for strategy status, but it is not optimized for **mobile trading-style monitoring** (quick price sense-making, visual trend scanning, and timeframe switching).
+
+Alan wants a mobile-first dashboard that feels closer to a lightweight TradingView, but restricted to the symbols already in **Favorites**, using the same existing data sources.
+
+## What Changes
+
+- Enhance the existing **Monitor** screen by adding tabs:
+  - **Status** (existing Monitor behavior)
+  - **Dashboard** (new, mobile-first)
+- Dashboard tab shows a compact list of favorites with quick metrics (price + change) and a **candlestick chart**.
+- Allow the user to switch timeframes (e.g., 1h / 4h / 1d) per symbol.
+- Reuse existing backend data sources where possible:
+  - Crypto: CCXT
+  - Stocks: Yahoo for intraday candles (15m/1h/4h) and Stooq/Yahoo for 1d
+- For stocks intraday, apply sensible default history windows (e.g., 15m ~30d, 1h ~180d, 4h ~365d).
+
+## Capabilities
+
+### New Capabilities
+- `monitor-dashboard-mobile`: Mobile-first trading-style dashboard for Favorites, with candlestick charts and timeframe switching.
+
+### Modified Capabilities
+- `frontend-ux`: Add responsive dashboard route and ensure mobile usability.
+- `backend`: If needed, expose an API for OHLC candles for favorites (prefer reusing existing endpoints/services).
+
+## Impact
+
+- Frontend: new dashboard page/components, chart library integration, mobile UX.
+- Backend: may require a small endpoint to provide OHLC data for a symbol/timeframe using existing providers.
+- Tests: Playwright E2E for core flows (open dashboard, change timeframe, verify candles render).

--- a/openspec/changes/monitor-dashboard-mobile-candles/review-ptbr.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/review-ptbr.md
@@ -1,0 +1,35 @@
+# Revisão (PT-BR) — monitor-dashboard-mobile-candles
+
+## O que é
+Criar uma tela **Dashboard (mobile-first)** para acompanhar o mercado “estilo TradingView”, porém **somente para os símbolos que estão em Favoritos**.
+
+## Principais pontos
+- Reaproveitar a tela **Monitor**, adicionando abas:
+  - **Status** (o que já existe hoje)
+  - **Dashboard** (novo, mobile-first)
+- Na aba Dashboard:
+  - Lista de cards com os símbolos favoritos.
+  - Ao selecionar um símbolo, mostra um **gráfico candlestick**.
+  - Troca de timeframe: **15m / 1h / 4h / 1d**.
+  - Para **ações**, usar **Yahoo** para intraday e manter `1d` via Stooq/Yahoo:
+    - 15m: ~30 dias
+    - 1h: ~180 dias
+    - 4h: ~365 dias
+    - 1d: anos
+  - Para **cripto**, usar **CCXT** (15m/1h/4h/1d)
+- Usar as **mesmas origens** já existentes quando possível (CCXT para cripto; Stooq/Yahoo para ações).
+
+## Por que
+O `/monitor` atual é bom pra status, mas no celular você quer uma visão rápida de preço/tendência por timeframe.
+
+## Como testar (manual rápido)
+1) Abrir a nova tela Dashboard no celular.
+2) Ver se lista só o que está em Favoritos.
+3) Tocar num símbolo e confirmar que o gráfico candlestick aparece.
+4) Trocar timeframe:
+   - Em cripto, 1h/4h/1d devem funcionar.
+   - Em ações, apenas 1d deve ficar habilitado (outros desabilitados/erro claro).
+
+## Observações
+- Pode exigir um endpoint backend simples para devolver candles (OHLC) com limite.
+- E2E (Playwright) vai validar navegação + troca de timeframe sem depender de rede externa.

--- a/openspec/changes/monitor-dashboard-mobile-candles/specs/backend/spec.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/specs/backend/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Backend provides OHLC candles for Favorites symbols
+The backend MUST provide OHLC candlestick data for a given symbol and timeframe using existing market data providers.
+
+#### Scenario: Request candles for a crypto pair
+- **WHEN** the client requests candles for a symbol containing `/` and a supported timeframe
+- **THEN** the backend returns OHLC candles sourced via the existing CCXT provider (or equivalent)
+
+#### Scenario: Request daily candles for a stock ticker
+- **WHEN** the client requests candles for a stock symbol without `/` and timeframe 1d
+- **THEN** the backend returns OHLC candles sourced via Stooq or Yahoo (or equivalent)
+
+#### Scenario: Request intraday candles for a stock ticker
+- **WHEN** the client requests candles for a stock symbol without `/` and timeframe in {15m, 1h, 4h}
+- **THEN** the backend returns OHLC candles sourced via Yahoo (or equivalent)
+
+### Requirement: Timeframe validation
+The backend MUST validate requested timeframes per data source.
+
+#### Scenario: Unsupported timeframe for stocks
+- **WHEN** the client requests a stock timeframe outside {15m, 1h, 4h, 1d}
+- **THEN** the backend returns a clear validation error
+
+#### Scenario: Supported timeframe for crypto
+- **WHEN** the client requests a supported crypto timeframe (e.g., 1h, 4h, 1d)
+- **THEN** the backend returns candle data successfully
+
+### Requirement: Candles response is ordered and bounded
+The backend MUST return candle data in chronological order and limit the number of returned candles.
+
+#### Scenario: Candles ordered
+- **WHEN** the backend returns candles
+- **THEN** the candles are ordered by timestamp ascending
+
+#### Scenario: Candles limited
+- **WHEN** the client does not specify a limit
+- **THEN** the backend uses a safe default limit

--- a/openspec/changes/monitor-dashboard-mobile-candles/specs/frontend-ux/spec.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/specs/frontend-ux/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Monitor includes tabs for Status and Dashboard
+The UI MUST provide tabs on the Monitor screen for switching between Status and Dashboard.
+
+#### Scenario: Tabs are visible
+- **WHEN** the user opens the Monitor screen
+- **THEN** the UI shows tabs labeled Status and Dashboard
+
+#### Scenario: Switching tabs updates the view
+- **WHEN** the user switches from Status to Dashboard (or vice versa)
+- **THEN** the visible content changes to the selected tab
+
+### Requirement: Favorites-only dataset is used
+The UI MUST use only the Favorites dataset for the dashboard.
+
+#### Scenario: No non-favorite symbols appear
+- **WHEN** the dashboard renders
+- **THEN** only favorites appear in the dashboard list
+
+### Requirement: Candlestick chart uses a consistent visual language
+The UI MUST render a candlestick chart with clear up/down candle colors and readable axes.
+
+#### Scenario: Candle colors represent direction
+- **WHEN** candles are rendered
+- **THEN** bullish candles use one color and bearish candles use another color
+
+#### Scenario: Chart remains usable on small screens
+- **WHEN** the chart is rendered on a small viewport
+- **THEN** labels do not overlap excessively and the user can still interpret the trend

--- a/openspec/changes/monitor-dashboard-mobile-candles/specs/monitor-dashboard-mobile/spec.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/specs/monitor-dashboard-mobile/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Monitor includes a Dashboard tab (mobile-first)
+The system MUST provide a mobile-first **Dashboard** tab inside the existing Monitor screen.
+
+#### Scenario: User opens Monitor
+- **WHEN** the user navigates to the Monitor screen
+- **THEN** the UI renders tabs including Status and Dashboard
+
+#### Scenario: User opens Dashboard tab
+- **WHEN** the user selects the Dashboard tab
+- **THEN** the UI renders a dashboard view optimized for mobile screens
+
+#### Scenario: Dashboard list is derived from Favorites
+- **WHEN** the dashboard loads
+- **THEN** it shows only symbols that exist in the Favorites dataset
+
+### Requirement: Asset type and data source follow existing rules
+The system MUST reuse existing asset classification and data source rules where possible.
+
+#### Scenario: Crypto symbols are classified by slash
+- **WHEN** a favorite symbol contains `/` (e.g., `BTC/USDT`)
+- **THEN** the system treats the symbol as Crypto
+
+#### Scenario: Stock symbols are classified by no slash
+- **WHEN** a favorite symbol does not contain `/` (e.g., `NVDA`)
+- **THEN** the system treats the symbol as Stocks
+
+### Requirement: Candlestick chart renders for a selected symbol
+The system MUST render a candlestick chart for the selected favorite symbol.
+
+#### Scenario: User selects a symbol
+- **WHEN** the user taps a symbol card (or selects it)
+- **THEN** the UI displays a candlestick chart for that symbol
+
+### Requirement: Timeframe switching for charts
+The system MUST allow switching the candlestick chart timeframe for a symbol.
+
+#### Scenario: Switch to 15m
+- **WHEN** the user selects timeframe = 15m
+- **THEN** the candlestick chart updates to show 15m candles
+
+#### Scenario: Switch to 1h
+- **WHEN** the user selects timeframe = 1h
+- **THEN** the candlestick chart updates to show 1h candles
+
+#### Scenario: Switch to 4h
+- **WHEN** the user selects timeframe = 4h
+- **THEN** the candlestick chart updates to show 4h candles
+
+#### Scenario: Switch to 1d
+- **WHEN** the user selects timeframe = 1d
+- **THEN** the candlestick chart updates to show 1d candles
+
+### Requirement: Dashboard works on mobile without horizontal scrolling
+The dashboard MUST avoid horizontal scrolling and provide touch-friendly controls.
+
+#### Scenario: No horizontal scroll on mobile
+- **WHEN** the dashboard is rendered on a small viewport
+- **THEN** the main content fits the viewport width without requiring horizontal scrolling
+
+#### Scenario: Touch targets are large enough
+- **WHEN** controls (symbol selection, timeframe buttons) are rendered on mobile
+- **THEN** they provide touch targets of at least 44x44px (or equivalent)

--- a/openspec/changes/monitor-dashboard-mobile-candles/tasks.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Backend: Candle API
 
-- [ ] 1.1 Identify existing market data provider utilities/services that can return OHLC
-- [ ] 1.2 Add a backend endpoint (e.g., `GET /api/market/candles?symbol=...&timeframe=...&limit=...`) returning OHLC candles
-- [ ] 1.3 Implement timeframe validation:
+- [x] 1.1 Identify existing market data provider utilities/services that can return OHLC
+- [x] 1.2 Add a backend endpoint (e.g., `GET /api/market/candles?symbol=...&timeframe=...&limit=...`) returning OHLC candles
+- [x] 1.3 Implement timeframe validation:
   - stocks: 15m/1h/4h/1d (intraday via Yahoo with default history windows)
   - crypto: 15m/1h/4h/1d
-- [ ] 1.4 Add integration tests for the candle endpoint using deterministic fixtures/mocks (no external network)
+- [x] 1.4 Add integration tests for the candle endpoint using deterministic fixtures/mocks (no external network)
 
 ## 2. Frontend: Monitor Tabs + Dashboard
 
-- [ ] 2.1 Add tabs to the existing Monitor screen: Status (existing) and Dashboard (new)
-- [ ] 2.2 Ensure existing Monitor Status view remains unchanged
-- [ ] 2.3 Load Favorites list and render mobile-first symbol cards (favorites-only) in the Dashboard tab
-- [ ] 2.4 Add symbol selection state and a detail view for the selected symbol
+- [x] 2.1 Add tabs to the existing Monitor screen: Status (existing) and Dashboard (new)
+- [x] 2.2 Ensure existing Monitor Status view remains unchanged
+- [x] 2.3 Load Favorites list and render mobile-first symbol cards (favorites-only) in the Dashboard tab
+- [x] 2.4 Add symbol selection state and a detail view for the selected symbol
 
 ## 3. Candlestick Chart UI
 
-- [ ] 3.1 Add a lightweight candlestick chart library and wrapper component
-- [ ] 3.2 Fetch candles from the backend endpoint and render candlesticks
-- [ ] 3.3 Add timeframe switching controls (15m/1h/4h/1d) and update chart accordingly
-- [ ] 3.4 Apply default history windows for stocks intraday:
+- [x] 3.1 Add a lightweight candlestick chart library and wrapper component
+- [x] 3.2 Fetch candles from the backend endpoint and render candlesticks
+- [x] 3.3 Add timeframe switching controls (15m/1h/4h/1d) and update chart accordingly
+- [x] 3.4 Apply default history windows for stocks intraday:
   - 15m ~30d
   - 1h ~180d
   - 4h ~365d
@@ -28,18 +28,18 @@
 
 ## 4. UX / Performance
 
-- [ ] 4.1 Ensure no horizontal scrolling on mobile
-- [ ] 4.2 Ensure touch targets are >= 44x44px for primary controls
-- [ ] 4.3 Add sensible candle fetch limits and avoid excessive refetching
+- [x] 4.1 Ensure no horizontal scrolling on mobile
+- [x] 4.2 Ensure touch targets are >= 44x44px for primary controls
+- [x] 4.3 Add sensible candle fetch limits and avoid excessive refetching
 
 ## 5. Tests (E2E)
 
-- [ ] 5.1 Add Playwright E2E test: open dashboard and see favorites list
-- [ ] 5.2 Add Playwright E2E test: select a symbol and see chart container
-- [ ] 5.3 Add Playwright E2E test: switch timeframe and verify request/visual state changes
+- [x] 5.1 Add Playwright E2E test: open dashboard and see favorites list
+- [x] 5.2 Add Playwright E2E test: select a symbol and see chart container
+- [x] 5.3 Add Playwright E2E test: switch timeframe and verify request/visual state changes
 
 ## 6. Validation
 
-- [ ] 6.1 Run `openspec validate monitor-dashboard-mobile-candles --type change`
+- [x] 6.1 Run `openspec validate monitor-dashboard-mobile-candles --type change`
 
 > Note: Use project skills (.codex/skills) when applicable (architecture, tests, debugging, frontend).

--- a/openspec/changes/monitor-dashboard-mobile-candles/tasks.md
+++ b/openspec/changes/monitor-dashboard-mobile-candles/tasks.md
@@ -1,0 +1,45 @@
+## 1. Backend: Candle API
+
+- [ ] 1.1 Identify existing market data provider utilities/services that can return OHLC
+- [ ] 1.2 Add a backend endpoint (e.g., `GET /api/market/candles?symbol=...&timeframe=...&limit=...`) returning OHLC candles
+- [ ] 1.3 Implement timeframe validation:
+  - stocks: 15m/1h/4h/1d (intraday via Yahoo with default history windows)
+  - crypto: 15m/1h/4h/1d
+- [ ] 1.4 Add integration tests for the candle endpoint using deterministic fixtures/mocks (no external network)
+
+## 2. Frontend: Monitor Tabs + Dashboard
+
+- [ ] 2.1 Add tabs to the existing Monitor screen: Status (existing) and Dashboard (new)
+- [ ] 2.2 Ensure existing Monitor Status view remains unchanged
+- [ ] 2.3 Load Favorites list and render mobile-first symbol cards (favorites-only) in the Dashboard tab
+- [ ] 2.4 Add symbol selection state and a detail view for the selected symbol
+
+## 3. Candlestick Chart UI
+
+- [ ] 3.1 Add a lightweight candlestick chart library and wrapper component
+- [ ] 3.2 Fetch candles from the backend endpoint and render candlesticks
+- [ ] 3.3 Add timeframe switching controls (15m/1h/4h/1d) and update chart accordingly
+- [ ] 3.4 Apply default history windows for stocks intraday:
+  - 15m ~30d
+  - 1h ~180d
+  - 4h ~365d
+  - 1d ~years
+  and guard unsupported combinations with clear UI feedback
+
+## 4. UX / Performance
+
+- [ ] 4.1 Ensure no horizontal scrolling on mobile
+- [ ] 4.2 Ensure touch targets are >= 44x44px for primary controls
+- [ ] 4.3 Add sensible candle fetch limits and avoid excessive refetching
+
+## 5. Tests (E2E)
+
+- [ ] 5.1 Add Playwright E2E test: open dashboard and see favorites list
+- [ ] 5.2 Add Playwright E2E test: select a symbol and see chart container
+- [ ] 5.3 Add Playwright E2E test: switch timeframe and verify request/visual state changes
+
+## 6. Validation
+
+- [ ] 6.1 Run `openspec validate monitor-dashboard-mobile-candles --type change`
+
+> Note: Use project skills (.codex/skills) when applicable (architecture, tests, debugging, frontend).


### PR DESCRIPTION
Adds Monitor tabs (Status/Dashboard) and a new Favorites-only mobile-first dashboard with candlestick charts and timeframe switching (15m/1h/4h/1d). Adds backend candle endpoint and tests.