### PR TITLE
Monitor: in-portfolio watchlist + per-card mode (persisted)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.routes.logs import router as logs_router
 from app.routes.agent_chat import router as agent_chat_router
 from app.routes.openspec import router as openspec_router
 from app.routes.lab import router as lab_router
+from app.routes.monitor_preferences import router as monitor_preferences_router
 
 # Configure logging to file
 log_file = Path(__file__).parent.parent / "full_execution_log.txt"
@@ -192,6 +193,7 @@ app.include_router(logs_router)
 app.include_router(agent_chat_router)
 app.include_router(openspec_router)
 app.include_router(lab_router)
+app.include_router(monitor_preferences_router)
 
 @app.get("/")
 async def root():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -180,3 +180,12 @@ class ComboTemplate(Base):
     
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class MonitorPreference(Base):
+    __tablename__ = "monitor_preferences"
+
+    symbol = Column(String, primary_key=True, index=True)
+    in_portfolio = Column(Boolean, nullable=False, default=False)
+    card_mode = Column(String, nullable=False, default="price")
+    updated_at = Column(DateTime, nullable=True, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/routes/monitor_preferences.py
+++ b/backend/app/routes/monitor_preferences.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from typing import Dict, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import MonitorPreference
+
+router = APIRouter(prefix="/api/monitor", tags=["monitor"])
+
+CardMode = Literal["price", "strategy"]
+
+
+class MonitorPreferencePayload(BaseModel):
+    in_portfolio: bool
+    card_mode: CardMode
+
+
+class MonitorPreferenceUpdate(BaseModel):
+    in_portfolio: Optional[bool] = None
+    card_mode: Optional[CardMode] = None
+
+
+def _normalize_symbol(symbol: str) -> str:
+    normalized = str(symbol or "").strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="Symbol must not be empty")
+    return normalized
+
+
+@router.get("/preferences", response_model=Dict[str, MonitorPreferencePayload])
+def list_monitor_preferences(db: Session = Depends(get_db)):
+    rows = db.query(MonitorPreference).all()
+    return {
+        row.symbol: {
+            "in_portfolio": bool(row.in_portfolio),
+            "card_mode": row.card_mode if row.card_mode in {"price", "strategy"} else "price",
+        }
+        for row in rows
+    }
+
+
+@router.put("/preferences/{symbol:path}", response_model=MonitorPreferencePayload)
+def update_monitor_preferences(
+    payload: MonitorPreferenceUpdate,
+    symbol: str = Path(..., description="Symbol (e.g. BTC/USDT or NVDA)"),
+    db: Session = Depends(get_db),
+):
+    if payload.in_portfolio is None and payload.card_mode is None:
+        raise HTTPException(status_code=400, detail="At least one field must be provided")
+
+    normalized_symbol = _normalize_symbol(symbol)
+
+    existing = (
+        db.query(MonitorPreference)
+        .filter(MonitorPreference.symbol == normalized_symbol)
+        .first()
+    )
+    if not existing:
+        existing = MonitorPreference(symbol=normalized_symbol)
+        db.add(existing)
+
+    if payload.in_portfolio is not None:
+        existing.in_portfolio = payload.in_portfolio
+    if payload.card_mode is not None:
+        existing.card_mode = payload.card_mode
+
+    existing.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(existing)
+
+    return {
+        "in_portfolio": bool(existing.in_portfolio),
+        "card_mode": existing.card_mode if existing.card_mode in {"price", "strategy"} else "price",
+    }

--- a/backend/tests/integration/test_monitor_preferences_endpoints.py
+++ b/backend/tests/integration/test_monitor_preferences_endpoints.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+import httpx
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.routes import monitor_preferences
+
+
+def _build_test_app(tmp_path: Path) -> FastAPI:
+    db_file = tmp_path / "monitor_prefs_test.db"
+    engine = create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _get_db_override():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app = FastAPI()
+    app.include_router(monitor_preferences.router)
+    app.dependency_overrides[get_db] = _get_db_override
+    return app
+
+
+async def test_monitor_preferences_defaults_to_empty_map(tmp_path: Path):
+    app = _build_test_app(tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/api/monitor/preferences")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {}
+
+
+async def test_monitor_preferences_put_and_get_roundtrip(tmp_path: Path):
+    app = _build_test_app(tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        put_response = await client.put(
+            "/api/monitor/preferences/BTC/USDT",
+            json={"in_portfolio": True, "card_mode": "strategy"},
+        )
+        get_response = await client.get("/api/monitor/preferences")
+
+    assert put_response.status_code == 200, put_response.text
+    assert put_response.json() == {"in_portfolio": True, "card_mode": "strategy"}
+
+    assert get_response.status_code == 200, get_response.text
+    assert get_response.json() == {
+        "BTC/USDT": {"in_portfolio": True, "card_mode": "strategy"},
+    }
+
+
+async def test_monitor_preferences_put_partial_update_keeps_defaults(tmp_path: Path):
+    app = _build_test_app(tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        first = await client.put(
+            "/api/monitor/preferences/NVDA",
+            json={"in_portfolio": True},
+        )
+        second = await client.put(
+            "/api/monitor/preferences/NVDA",
+            json={"card_mode": "strategy"},
+        )
+        final = await client.get("/api/monitor/preferences")
+
+    assert first.status_code == 200, first.text
+    assert first.json() == {"in_portfolio": True, "card_mode": "price"}
+
+    assert second.status_code == 200, second.text
+    assert second.json() == {"in_portfolio": True, "card_mode": "strategy"}
+
+    assert final.status_code == 200, final.text
+    assert final.json() == {
+        "NVDA": {"in_portfolio": True, "card_mode": "strategy"},
+    }
+
+
+async def test_monitor_preferences_put_requires_at_least_one_field(tmp_path: Path):
+    app = _build_test_app(tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.put("/api/monitor/preferences/NVDA", json={})
+
+    assert response.status_code == 400, response.text
+    assert "At least one field must be provided" in response.json()["detail"]

--- a/frontend/src/components/monitor/MonitorStatusTab.tsx
+++ b/frontend/src/components/monitor/MonitorStatusTab.tsx
@@ -1,41 +1,83 @@
-import React, { useEffect, useState, useMemo } from 'react';
-import type { Opportunity } from '@/components/monitor/types';
+import React, { useEffect, useMemo, useState } from 'react';
+import type { Opportunity, MonitorCardMode, MonitorPreference } from '@/components/monitor/types';
 import { OpportunityCard } from '@/components/monitor/OpportunityCard';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent, CardHeader } from '@/components/ui/Card';
 import { RefreshCw, ArrowUpDown, ChevronDown } from 'lucide-react';
 import { useToast } from "@/components/ui/use-toast";
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { API_BASE_URL } from '@/lib/apiBase';
 
 type SortOption = 'distance' | 'tier_distance' | 'symbol';
 type TierFilter = 'all' | '1_2' | '1' | '2' | '3' | 'none';
+type ListFilter = 'in_portfolio' | 'all';
+
+const DEFAULT_PREFERENCE: MonitorPreference = {
+    in_portfolio: false,
+    card_mode: 'price',
+};
 
 export const MonitorStatusTab: React.FC = () => {
     const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
     const [loading, setLoading] = useState(false);
     const [sortBy, setSortBy] = useState<SortOption>('tier_distance');
     const [tierFilter, setTierFilter] = useState<TierFilter>('all');
+    const [listFilter, setListFilter] = useState<ListFilter>('in_portfolio');
     const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+    const [preferences, setPreferences] = useState<Record<string, MonitorPreference>>({});
+    const [savingSymbols, setSavingSymbols] = useState<Record<string, boolean>>({});
     const { toast } = useToast();
+
+    const getPreference = (symbol: string): MonitorPreference => {
+        return preferences[symbol] ?? DEFAULT_PREFERENCE;
+    };
+
+    const fetchMonitorContext = async () => {
+        try {
+            const [favoritesResponse, preferencesResponse] = await Promise.all([
+                fetch(`${API_BASE_URL}/favorites/`),
+                fetch(`${API_BASE_URL}/monitor/preferences`),
+            ]);
+
+            if (!favoritesResponse.ok) {
+                throw new Error(`Failed to load favorites (${favoritesResponse.status})`);
+            }
+            if (!preferencesResponse.ok) {
+                throw new Error(`Failed to load monitor preferences (${preferencesResponse.status})`);
+            }
+
+            await favoritesResponse.json();
+            const preferencesPayload = await preferencesResponse.json();
+            setPreferences(
+                typeof preferencesPayload === 'object' && preferencesPayload
+                    ? preferencesPayload
+                    : {}
+            );
+        } catch (error) {
+            console.error(error);
+            toast({
+                title: 'Erro',
+                description: 'Não foi possível carregar preferências do monitor.',
+                variant: 'destructive',
+            });
+        }
+    };
 
     const fetchOpportunities = async (tier?: TierFilter) => {
         setLoading(true);
         try {
-            // Convert frontend tier filter to API query param
             const tierParam = tier || tierFilter;
             let apiTier: string;
             if (tierParam === 'all') {
                 apiTier = 'all';
             } else if (tierParam === '1_2') {
-                apiTier = '1,2';  // API expects comma-separated
+                apiTier = '1,2';
             } else if (tierParam === 'none') {
                 apiTier = 'none';
             } else {
-                apiTier = tierParam;  // '1', '2', '3'
+                apiTier = tierParam;
             }
-            
-            // Prefer relative "/api" so Vite proxy routes to backend even when accessing from outside the server.
-            // Only use VITE_API_URL when explicitly set.
+
             const baseUrl = import.meta.env.VITE_API_URL || "/api";
             const url = `${baseUrl}/opportunities/?tier=${encodeURIComponent(apiTier)}`;
             const response = await fetch(url);
@@ -60,34 +102,79 @@ export const MonitorStatusTab: React.FC = () => {
         }
     };
 
-    // Fetch when page loads or tier filter changes
+    const persistPreference = async (symbol: string, patch: Partial<MonitorPreference>) => {
+        const prev = getPreference(symbol);
+        const next: MonitorPreference = {
+            in_portfolio: patch.in_portfolio ?? prev.in_portfolio,
+            card_mode: patch.card_mode ?? prev.card_mode,
+        };
+
+        setPreferences((current) => ({ ...current, [symbol]: next }));
+        setSavingSymbols((current) => ({ ...current, [symbol]: true }));
+
+        try {
+            const response = await fetch(`${API_BASE_URL}/monitor/preferences/${encodeURIComponent(symbol)}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(patch),
+            });
+            const payload = await response.json();
+
+            if (!response.ok) {
+                throw new Error(String(payload?.detail || `Failed to save preference (${response.status})`));
+            }
+
+            setPreferences((current) => ({
+                ...current,
+                [symbol]: {
+                    in_portfolio: Boolean(payload?.in_portfolio),
+                    card_mode: payload?.card_mode === 'strategy' ? 'strategy' : 'price',
+                },
+            }));
+        } catch (error) {
+            setPreferences((current) => ({ ...current, [symbol]: prev }));
+            toast({
+                title: 'Erro',
+                description: error instanceof Error ? error.message : 'Falha ao salvar preferência.',
+                variant: 'destructive',
+            });
+        } finally {
+            setSavingSymbols((current) => ({ ...current, [symbol]: false }));
+        }
+    };
+
+    const handleToggleInPortfolio = (symbol: string, nextValue: boolean) => {
+        void persistPreference(symbol, { in_portfolio: nextValue });
+    };
+
+    const handleToggleCardMode = (symbol: string, nextMode: MonitorCardMode) => {
+        void persistPreference(symbol, { card_mode: nextMode });
+    };
+
     useEffect(() => {
-        fetchOpportunities(tierFilter);
+        void fetchMonitorContext();
+    }, []);
+
+    useEffect(() => {
+        void fetchOpportunities(tierFilter);
     }, [tierFilter]);
 
-    // Sort opportunities by selected criteria
     const sortedOpportunities = useMemo(() => {
         const sorted = [...opportunities].sort((a, b) => {
             if (sortBy === 'tier_distance') {
-                // Tier + Distância: Tier 1 e 2 primeiro, depois por distância
-                // HOLD sempre primeiro dentro de cada grupo de tier
                 const tierA = a.tier ?? 999;
                 const tierB = b.tier ?? 999;
-                // Agrupar Tier 1 e 2 como "prioritários" (< 3), outros depois
                 const priorityA = tierA <= 2 ? 0 : 1;
                 const priorityB = tierB <= 2 ? 0 : 1;
                 if (priorityA !== priorityB) {
                     return priorityA - priorityB;
                 }
-                // Dentro do mesmo grupo de prioridade, HOLD primeiro
                 if (a.is_holding !== b.is_holding) {
                     return a.is_holding ? -1 : 1;
                 }
-                // Depois por tier específico (1 antes de 2)
                 if (tierA !== tierB) {
                     return tierA - tierB;
                 }
-                // Depois por distância (mais próximo primeiro)
                 const distA = a.distance_to_next_status ?? 999;
                 const distB = b.distance_to_next_status ?? 999;
                 if (distA !== distB) {
@@ -95,7 +182,6 @@ export const MonitorStatusTab: React.FC = () => {
                 }
                 return a.symbol.localeCompare(b.symbol);
             } else if (sortBy === 'distance') {
-                // Distância: HOLD primeiro, depois por distância
                 if (a.is_holding !== b.is_holding) {
                     return a.is_holding ? -1 : 1;
                 }
@@ -118,14 +204,18 @@ export const MonitorStatusTab: React.FC = () => {
         return sorted;
     }, [opportunities, sortBy]);
 
-    // Separate opportunities by status, then apply tier filter
-    // Dados já vêm filtrados por tier do backend
-    const holding = sortedOpportunities.filter(o => o.is_holding);
-    const stoppedOut = sortedOpportunities.filter(o => !o.is_holding && o.status === 'STOPPED_OUT');
-    const missedEntry = sortedOpportunities.filter(o => !o.is_holding && o.status === 'MISSED_ENTRY');
-    const waiting = sortedOpportunities.filter(o => !o.is_holding && o.status !== 'STOPPED_OUT' && o.status !== 'MISSED_ENTRY');
+    const filteredOpportunities = useMemo(() => {
+        if (listFilter === 'all') {
+            return sortedOpportunities;
+        }
+        return sortedOpportunities.filter((opp) => preferences[opp.symbol]?.in_portfolio === true);
+    }, [listFilter, preferences, sortedOpportunities]);
 
-    // Lista ordenada para paginação infinita: holding → stopped → missed → waiting
+    const holding = filteredOpportunities.filter(o => o.is_holding);
+    const stoppedOut = filteredOpportunities.filter(o => !o.is_holding && o.status === 'STOPPED_OUT');
+    const missedEntry = filteredOpportunities.filter(o => !o.is_holding && o.status === 'MISSED_ENTRY');
+    const waiting = filteredOpportunities.filter(o => !o.is_holding && o.status !== 'STOPPED_OUT' && o.status !== 'MISSED_ENTRY');
+
     type SectionKey = 'holding' | 'stoppedOut' | 'missedEntry' | 'waiting';
     const orderedCards = useMemo(() => {
         const withSection = (arr: Opportunity[], s: SectionKey) =>
@@ -140,7 +230,6 @@ export const MonitorStatusTab: React.FC = () => {
 
     const { visibleItems, hasMore, sentinelRef } = useInfiniteScroll(orderedCards, 24, 24);
 
-    // Agrupa itens visíveis por seção consecutiva para manter headers + grid
     const visibleGroups = useMemo(() => {
         const g: { section: SectionKey; cards: Opportunity[] }[] = [];
         for (const { opp, section } of visibleItems) {
@@ -167,7 +256,7 @@ export const MonitorStatusTab: React.FC = () => {
             dotClass: 'bg-red-500',
             h2Class: 'text-red-600',
             badgeClass: 'bg-red-500/10 text-red-600',
-            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas a posição foi fechada no stop loss. A distância mostra o spread entre as médias. Aguardando cruzamento para baixo ou nova entrada.',
+            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas a posição foi fechada no stop loss. Aguardando cruzamento para baixo ou nova entrada.',
         },
         missedEntry: {
             title: 'Entrada Perdida',
@@ -187,14 +276,16 @@ export const MonitorStatusTab: React.FC = () => {
         },
     };
 
+    const noResultsForInPortfolio = !loading && opportunities.length > 0 && filteredOpportunities.length === 0 && listFilter === 'in_portfolio';
+
     return (
-        <div className="container mx-auto p-6 space-y-8">
+        <div className="container mx-auto p-6 space-y-8" data-testid="monitor-status-tab">
             <div className="flex flex-col gap-4">
                 <div className="flex justify-between items-center">
                     <div className="space-y-1">
                         <h1 className="text-3xl font-bold tracking-tight">Opportunity Board</h1>
                         <p className="text-muted-foreground">
-                            Monitor your favorite strategies - See which are in HOLD and how close they are to the next signal
+                            Monitor your favorite strategies.
                         </p>
                         {lastUpdated && (
                             <p className="text-xs text-muted-foreground">
@@ -203,7 +294,13 @@ export const MonitorStatusTab: React.FC = () => {
                         )}
                     </div>
                     <div className="flex gap-2">
-                        <Button variant="secondary" onClick={() => fetchOpportunities()} disabled={loading}>
+                        <Button
+                            variant="secondary"
+                            onClick={() => {
+                                void Promise.all([fetchOpportunities(), fetchMonitorContext()]);
+                            }}
+                            disabled={loading}
+                        >
                             <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
                             Refresh
                         </Button>
@@ -211,6 +308,26 @@ export const MonitorStatusTab: React.FC = () => {
                 </div>
 
                 <div className="flex items-center gap-4 flex-wrap">
+                    <div className="flex items-center gap-2" role="group" aria-label="Monitor list filter">
+                        <span className="text-sm font-medium">List:</span>
+                        <button
+                            type="button"
+                            className={`text-sm border rounded px-2 py-1.5 ${listFilter === 'in_portfolio' ? 'bg-blue-600 text-white border-blue-600' : 'bg-gray-900 text-gray-100 border-border'}`}
+                            onClick={() => setListFilter('in_portfolio')}
+                            data-testid="monitor-filter-in-portfolio"
+                        >
+                            In Portfolio
+                        </button>
+                        <button
+                            type="button"
+                            className={`text-sm border rounded px-2 py-1.5 ${listFilter === 'all' ? 'bg-blue-600 text-white border-blue-600' : 'bg-gray-900 text-gray-100 border-border'}`}
+                            onClick={() => setListFilter('all')}
+                            data-testid="monitor-filter-all"
+                        >
+                            All
+                        </button>
+                    </div>
+
                     <div className="flex items-center gap-2">
                         <span className="text-sm font-medium">Tier:</span>
                         <div className="relative">
@@ -230,6 +347,7 @@ export const MonitorStatusTab: React.FC = () => {
                             <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
                         </div>
                     </div>
+
                     <div className="flex items-center gap-2">
                         <ArrowUpDown className="w-4 h-4 text-muted-foreground" />
                         <span className="text-sm font-medium">Sort:</span>
@@ -274,6 +392,11 @@ export const MonitorStatusTab: React.FC = () => {
                         Go to Backtester
                     </Button>
                 </div>
+            ) : noResultsForInPortfolio ? (
+                <div className="text-center py-16 space-y-4" data-testid="monitor-empty-in-portfolio">
+                    <p className="text-muted-foreground">No symbols are marked as In Portfolio yet.</p>
+                    <Button variant="secondary" onClick={() => setListFilter('all')}>Show All Symbols</Button>
+                </div>
             ) : (
                 <div className="space-y-10">
                     {visibleGroups.map(({ section, cards }) => {
@@ -293,13 +416,19 @@ export const MonitorStatusTab: React.FC = () => {
                                 </p>
                                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                                     {cards.map((opp) => (
-                                        <OpportunityCard key={opp.id} opportunity={opp} />
+                                        <OpportunityCard
+                                            key={opp.id}
+                                            opportunity={opp}
+                                            preference={getPreference(opp.symbol)}
+                                            isSavingPreference={Boolean(savingSymbols[opp.symbol])}
+                                            onToggleInPortfolio={handleToggleInPortfolio}
+                                            onToggleCardMode={handleToggleCardMode}
+                                        />
                                     ))}
                                 </div>
                             </section>
                         );
                     })}
-                    {/* Sentinel: ao entrar na viewport, carrega mais itens */}
                     {hasMore && (
                         <div ref={sentinelRef} className="flex justify-center py-8" aria-hidden="true">
                             <span className="text-sm text-muted-foreground animate-pulse">Carregando mais…</span>

--- a/frontend/src/components/monitor/OpportunityCard.tsx
+++ b/frontend/src/components/monitor/OpportunityCard.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
-import { Target, Activity, Settings } from "lucide-react";
-import { API_BASE_URL } from '../../lib/apiBase';
+import { Target, Activity, Settings, Star, BarChart3 } from "lucide-react";
+import { API_BASE_URL, apiUrl } from '../../lib/apiBase';
+import { MiniCandlesChart, type MarketCandle } from './MiniCandlesChart';
 
-import type { Opportunity } from './types';
+import type { Opportunity, MonitorCardMode, MonitorPreference } from './types';
 
 interface OpportunityCardProps {
     opportunity: Opportunity;
+    preference: MonitorPreference;
+    isSavingPreference: boolean;
+    onToggleInPortfolio: (symbol: string, nextValue: boolean) => void;
+    onToggleCardMode: (symbol: string, nextMode: MonitorCardMode) => void;
 }
 
 const getDistanceColor = (distance: number | null | undefined): string => {
@@ -30,21 +35,79 @@ const getTierStyles = (tier: number | null | undefined) => {
     }
 };
 
-export const OpportunityCard: React.FC<OpportunityCardProps> = ({ opportunity }) => {
-    const { 
-        symbol, 
-        timeframe, 
-        name, 
-        is_holding, 
-        distance_to_next_status, 
+const symbolKey = (symbol: string): string => symbol.replace(/[^a-zA-Z0-9]+/g, '-').toLowerCase();
+
+export const OpportunityCard: React.FC<OpportunityCardProps> = ({
+    opportunity,
+    preference,
+    isSavingPreference,
+    onToggleInPortfolio,
+    onToggleCardMode,
+}) => {
+    const {
+        symbol,
+        timeframe,
+        name,
+        is_holding,
+        distance_to_next_status,
         next_status_label,
-        last_price 
+        last_price,
     } = opportunity;
 
-    // Local state para edição de notas diretamente do monitor
+    const isPriceMode = preference.card_mode === 'price';
+
     const [isEditingNotes, setIsEditingNotes] = React.useState(false);
     const [notesValue, setNotesValue] = React.useState(opportunity.notes || '');
     const [isSavingNotes, setIsSavingNotes] = React.useState(false);
+
+    const [candles, setCandles] = React.useState<MarketCandle[]>([]);
+    const [candlesLoading, setCandlesLoading] = React.useState(false);
+    const [candlesError, setCandlesError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        setNotesValue(opportunity.notes || '');
+    }, [opportunity.notes]);
+
+    React.useEffect(() => {
+        if (!isPriceMode) {
+            setCandlesError(null);
+            return;
+        }
+
+        const controller = new AbortController();
+        const run = async () => {
+            setCandlesLoading(true);
+            setCandlesError(null);
+            try {
+                const effectiveTf = symbol.includes('/') ? timeframe : '1d';
+                const url = apiUrl('/market/candles');
+                url.searchParams.set('symbol', symbol);
+                url.searchParams.set('timeframe', effectiveTf);
+                url.searchParams.set('limit', '120');
+
+                const response = await fetch(url.toString(), { signal: controller.signal });
+                const payload = await response.json();
+                if (!response.ok) {
+                    throw new Error(String(payload?.detail || `Failed to load candles (${response.status})`));
+                }
+
+                const rows = Array.isArray(payload?.candles) ? payload.candles : [];
+                setCandles(rows);
+            } catch (error) {
+                if (!controller.signal.aborted) {
+                    setCandles([]);
+                    setCandlesError(error instanceof Error ? error.message : 'Failed to load candles');
+                }
+            } finally {
+                if (!controller.signal.aborted) {
+                    setCandlesLoading(false);
+                }
+            }
+        };
+
+        run();
+        return () => controller.abort();
+    }, [isPriceMode, symbol, timeframe]);
 
     const formattedPrice = new Intl.NumberFormat('en-US', {
         style: 'currency',
@@ -54,31 +117,28 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({ opportunity })
     }).format(last_price);
 
     const distance = distance_to_next_status;
-    const distanceStr = distance !== null && distance !== undefined 
-        ? `${distance.toFixed(2)}%` 
+    const distanceStr = distance !== null && distance !== undefined
+        ? `${distance.toFixed(2)}%`
         : '-';
     const distanceColor = getDistanceColor(distance);
-    
-    // Show progress bar if distance is less than 1%
+
     const showProgress = distance !== null && distance !== undefined && distance < 1.0;
-    const progressPercent = showProgress 
-        ? Math.max(0, Math.min(100, (1 - distance) * 100)) 
+    const progressPercent = showProgress
+        ? Math.max(0, Math.min(100, (1 - distance) * 100))
         : 0;
 
-    // Check for special statuses from backend
     const status = opportunity.status || (is_holding ? 'HOLD' : 'WAIT');
     const isStoppedOut = status === 'STOPPED_OUT';
     const isMissedEntry = status === 'MISSED_ENTRY';
     const isWait = !is_holding && !isStoppedOut && !isMissedEntry;
     const tierStyles = getTierStyles(opportunity.tier);
-    
-    // Status badge: HOLD (green), STOPPED_OUT (red/orange), MISSED_ENTRY (yellow), or WAIT (gray)
+
     let statusBadge = 'WAIT';
     let badgeColor = "bg-slate-200 text-slate-600 border-slate-300";
     let borderColor = 'border-l-slate-300 border-l-4';
     let cardBgColor = 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700';
     let holdingIndicator = '';
-    
+
     if (is_holding) {
         statusBadge = 'HOLD';
         badgeColor = "bg-green-600 text-white border-green-600 font-bold shadow-md";
@@ -104,14 +164,13 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({ opportunity })
                       'bg-red-50/50 dark:bg-red-900/20 border-red-200 dark:border-red-800';
     }
 
-    // Message: Use backend message if available, otherwise generate from distance
     const statusMessage = opportunity.message || (
         distance !== null && distance !== undefined
             ? `${distance.toFixed(2)}% to ${next_status_label}`
             : `Waiting for ${next_status_label} signal`
     );
 
-    const cardStyle = is_holding ? { 
+    const cardStyle = is_holding ? {
         backgroundColor: 'rgb(220, 252, 231)',
         borderLeftWidth: '4px',
         borderLeftColor: 'rgb(22, 163, 74)',
@@ -133,218 +192,240 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({ opportunity })
         borderLeftColor: 'rgb(203, 213, 225)',
     };
 
+    const symbolTestKey = symbolKey(symbol);
+
     return (
-        <Card 
+        <Card
             className={`${borderColor} ${cardBgColor} ${holdingIndicator} hover:shadow-lg transition-all hover:scale-[1.02] relative`}
             style={cardStyle}
+            data-testid={`monitor-card-${symbolTestKey}`}
         >
-            {/* Visual indicator dot for special statuses */}
-            {is_holding && (
-                <div 
-                    className="absolute top-3 right-3 w-3 h-3 bg-green-500 rounded-full animate-pulse shadow-lg shadow-green-500/70 ring-2 ring-green-400"
-                    style={{ backgroundColor: 'rgb(34, 197, 94)' }}
-                ></div>
-            )}
-            {isStoppedOut && (
-                <div 
-                    className="absolute top-3 right-3 w-3 h-3 bg-red-500 rounded-full animate-pulse shadow-lg shadow-red-500/70 ring-2 ring-red-400"
-                    style={{ backgroundColor: 'rgb(239, 68, 68)' }}
-                ></div>
-            )}
-            {isMissedEntry && (
-                <div 
-                    className="absolute top-3 right-3 w-3 h-3 bg-yellow-500 rounded-full animate-pulse shadow-lg shadow-yellow-500/70 ring-2 ring-yellow-400"
-                    style={{ backgroundColor: 'rgb(234, 179, 8)' }}
-                ></div>
-            )}
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <div className="flex flex-col">
+            <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2 gap-2">
+                <div className="flex flex-col min-w-0">
                     <CardTitle className={`text-xl font-bold flex items-center gap-2 ${
-                        is_holding ? 'text-green-700 dark:text-green-300' : 
-                        isStoppedOut ? 'text-red-700 dark:text-red-300' : 
-                        isMissedEntry ? 'text-yellow-700 dark:text-yellow-300' : 
+                        is_holding ? 'text-green-700 dark:text-green-300' :
+                        isStoppedOut ? 'text-red-700 dark:text-red-300' :
+                        isMissedEntry ? 'text-yellow-700 dark:text-yellow-300' :
                         'text-gray-900 dark:text-gray-100'
                     }`}>
                         {tierStyles && (
                             <span className={`w-2 h-2 rounded-full ${tierStyles.dot} ring-1 ${tierStyles.ring} flex-shrink-0`} title={tierStyles.label} />
                         )}
-                        {symbol} <span className="text-sm font-normal text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">{timeframe}</span>
+                        <span className="truncate">{symbol}</span>
+                        <span className="text-sm font-normal text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">{timeframe}</span>
                     </CardTitle>
-                    <span className="text-sm text-gray-700 dark:text-gray-300 truncate max-w-[200px] font-medium">
+                    <span className="text-sm text-gray-700 dark:text-gray-300 truncate max-w-[220px] font-medium">
                         {name || opportunity.template_name}
                     </span>
                 </div>
-                <Badge variant="outline" className={`${badgeColor} uppercase text-sm font-bold shadow-sm px-3 py-1`}>
-                    {statusBadge}
-                </Badge>
-            </CardHeader>
-            <CardContent>
-                <div className="flex flex-col gap-4 mt-2">
-                    <div className="flex justify-between items-center">
-                        <span className="text-base font-semibold text-gray-700 dark:text-gray-300">Price:</span>
-                        <span className="font-mono font-bold text-lg text-gray-900 dark:text-gray-100">{formattedPrice}</span>
-                    </div>
 
-                    <div className="flex flex-col gap-2">
-                        <div className="flex justify-between items-center">
-                            <span className="text-base font-semibold text-gray-700 dark:text-gray-300">Distance:</span>
-                            <div className="flex items-center gap-2">
-                                <Target className="w-4 h-4 text-gray-600 dark:text-gray-400" />
-                                <span className={`font-mono font-bold text-lg ${distanceColor}`}>
-                                    {distanceStr}
-                                </span>
-                            </div>
-                        </div>
+                <div className="flex flex-col items-end gap-2">
+                    <Badge variant="outline" className={`${badgeColor} uppercase text-sm font-bold shadow-sm px-3 py-1`}>
+                        {statusBadge}
+                    </Badge>
+                    <div className="flex items-center gap-1">
+                        <button
+                            type="button"
+                            className={`rounded-md border px-2 py-1 text-xs flex items-center gap-1 ${preference.in_portfolio ? 'border-amber-500 text-amber-600 bg-amber-50' : 'border-slate-300 text-slate-600 bg-white'}`}
+                            onClick={() => onToggleInPortfolio(symbol, !preference.in_portfolio)}
+                            disabled={isSavingPreference}
+                            data-testid={`portfolio-toggle-${symbolTestKey}`}
+                            title={preference.in_portfolio ? 'Remove from In Portfolio' : 'Add to In Portfolio'}
+                        >
+                            <Star className={`w-3 h-3 ${preference.in_portfolio ? 'fill-current' : ''}`} />
+                            <span className="hidden sm:inline">Portfolio</span>
+                        </button>
 
-                        {is_holding && opportunity.distance_to_stop_pct !== null && opportunity.distance_to_stop_pct !== undefined ? (
-                            <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50/60 dark:bg-red-900/20 p-2">
-                                <div className="flex justify-between items-center">
-                                    <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">Stop risk:</span>
-                                    <span className="font-mono font-bold text-sm text-red-700 dark:text-red-300">
-                                        {opportunity.distance_to_stop_pct.toFixed(2)}%
-                                    </span>
-                                </div>
-                                <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] font-mono text-gray-700 dark:text-gray-300">
-                                    {opportunity.entry_price !== null && opportunity.entry_price !== undefined ? (
-                                        <span>entry: ${opportunity.entry_price.toFixed(8)}</span>
-                                    ) : null}
-                                    {opportunity.stop_price !== null && opportunity.stop_price !== undefined ? (
-                                        <span>stop: ${opportunity.stop_price.toFixed(8)}</span>
-                                    ) : null}
-                                </div>
-                            </div>
-                        ) : null}
-                        
-                        {/* Progress bar when close to signal (< 1%) */}
-                        {showProgress && (
-                            <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
-                                <div 
-                                    className={`h-full transition-all ${
-                                        is_holding ? 'bg-orange-500' : 'bg-yellow-500'
-                                    }`}
-                                    style={{ width: `${progressPercent}%` }}
-                                />
-                            </div>
-                        )}
-                    </div>
-
-                    <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-md text-sm border border-gray-300 dark:border-gray-600">
-                        <div className="flex items-start gap-2">
-                            <Activity className="w-4 h-4 mt-0.5 text-blue-600 dark:text-blue-400 flex-shrink-0" />
-                            <span className="font-medium text-gray-800 dark:text-gray-200 break-words">{statusMessage}</span>
-                        </div>
-                    </div>
-
-                    {opportunity.parameters && Object.keys(opportunity.parameters).length > 0 && (
-                        <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-md text-sm border border-gray-300 dark:border-gray-600">
-                            <div className="flex items-center gap-2 mb-1">
-                                <Settings className="w-4 h-4 text-violet-600 dark:text-violet-400 flex-shrink-0" />
-                                <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                    Parâmetros
-                                </span>
-                            </div>
-                            <p className="font-mono text-xs text-gray-700 dark:text-gray-300 break-words">
-                                {Object.entries(opportunity.parameters)
-                                    .map(([k, v]) => `${k}=${v}`)
-                                    .join(' ')}
-                            </p>
-                        </div>
-                    )}
-
-                    {opportunity.indicator_values && Object.keys(opportunity.indicator_values).length > 0 && (
-                        <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-md text-sm border border-blue-200 dark:border-blue-800">
-                            <div className="flex items-center gap-2 mb-1">
-                                <Target className="w-4 h-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
-                                <span className="text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400">
-                                    Valores usados (último candle fechado)
-                                </span>
-                            </div>
-                            {opportunity.indicator_values_candle_time && (
-                                <p className="text-[10px] text-blue-600/80 dark:text-blue-400/80 mb-1 font-medium">
-                                    Candle: {new Date(opportunity.indicator_values_candle_time).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short', timeZone: 'UTC' })} UTC
-                                </p>
-                            )}
-                            <p className="font-mono text-xs text-gray-700 dark:text-gray-300 break-words">
-                                {Object.entries(opportunity.indicator_values)
-                                    .map(([k, v]) => `${k}=${typeof v === 'number' ? v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : v}`)
-                                    .join(' · ')}
-                            </p>
-                        </div>
-                    )}
-
-                    <div className="p-3 bg-slate-50 dark:bg-slate-800/80 rounded-md text-sm border border-slate-200 dark:border-slate-600">
-                        <div className="flex items-center justify-between gap-2">
-                            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                Notes
-                            </span>
-                            {!isEditingNotes && (
-                                <button
-                                    type="button"
-                                    className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-                                    onClick={() => setIsEditingNotes(true)}
-                                >
-                                    Editar
-                                </button>
-                            )}
-                        </div>
-
-                        {isEditingNotes ? (
-                            <div className="mt-2 space-y-2">
-                                <textarea
-                                    className="w-full min-h-[60px] text-xs rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1 text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-                                    value={notesValue}
-                                    onChange={(e) => setNotesValue(e.target.value)}
-                                    placeholder="Adicione comentários sobre esta estratégia..."
-                                />
-                                <div className="flex justify-end gap-2">
-                                    <button
-                                        type="button"
-                                        className="px-2 py-1 text-xs rounded border border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
-                                        onClick={() => {
-                                            setNotesValue(opportunity.notes || '');
-                                            setIsEditingNotes(false);
-                                        }}
-                                        disabled={isSavingNotes}
-                                    >
-                                        Cancelar
-                                    </button>
-                                    <button
-                                        type="button"
-                                        className="px-2 py-1 text-xs rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed"
-                                        onClick={async () => {
-                                            try {
-                                                setIsSavingNotes(true);
-                                                const res = await fetch(`${API_BASE_URL}/favorites/${opportunity.id}`, {
-                                                    method: 'PATCH',
-                                                    headers: { 'Content-Type': 'application/json' },
-                                                    body: JSON.stringify({ notes: notesValue }),
-                                                });
-                                                if (!res.ok) {
-                                                    // fallback simples; o MonitorPage já tem toast para erros de load
-                                                    alert('Erro ao salvar notas da estratégia.');
-                                                    return;
-                                                }
-                                                setIsEditingNotes(false);
-                                            } catch (err) {
-                                                console.error('Erro ao salvar notas:', err);
-                                                alert('Erro ao salvar notas da estratégia.');
-                                            } finally {
-                                                setIsSavingNotes(false);
-                                            }
-                                        }}
-                                        disabled={isSavingNotes}
-                                    >
-                                        {isSavingNotes ? 'Salvando...' : 'Salvar'}
-                                    </button>
-                                </div>
-                            </div>
-                        ) : (
-                            <p className="mt-1 font-medium text-slate-700 dark:text-slate-200 break-words text-xs whitespace-pre-wrap">
-                                {notesValue || 'Sem comentários.'}
-                            </p>
-                        )}
+                        <button
+                            type="button"
+                            className="rounded-md border border-slate-300 px-2 py-1 text-xs flex items-center gap-1 bg-white text-slate-700"
+                            onClick={() => onToggleCardMode(symbol, isPriceMode ? 'strategy' : 'price')}
+                            disabled={isSavingPreference}
+                            data-testid={`mode-toggle-${symbolTestKey}`}
+                            title={isPriceMode ? 'Switch to strategy mode' : 'Switch to price mode'}
+                        >
+                            <BarChart3 className="w-3 h-3" />
+                            <span data-testid={`mode-label-${symbolTestKey}`}>{isPriceMode ? 'Price' : 'Strategy'}</span>
+                        </button>
                     </div>
                 </div>
+            </CardHeader>
+
+            <CardContent>
+                {isPriceMode ? (
+                    <div className="space-y-3">
+                        <div className="flex justify-between items-center">
+                            <span className="text-base font-semibold text-gray-700 dark:text-gray-300">Price:</span>
+                            <span className="font-mono font-bold text-lg text-gray-900 dark:text-gray-100">{formattedPrice}</span>
+                        </div>
+                        <div className="p-2 bg-gray-100 dark:bg-gray-800 rounded-md text-xs border border-gray-300 dark:border-gray-600">
+                            {candlesLoading ? 'Loading candles...' : null}
+                            {candlesError ? <span className="text-red-600 dark:text-red-300">{candlesError}</span> : null}
+                            {!candlesLoading && !candlesError && candles.length === 0 ? <span>No candle data.</span> : null}
+                            {!candlesLoading && !candlesError && candles.length > 0 ? <MiniCandlesChart candles={candles} /> : null}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-4 mt-2">
+                        <div className="flex justify-between items-center">
+                            <span className="text-base font-semibold text-gray-700 dark:text-gray-300">Price:</span>
+                            <span className="font-mono font-bold text-lg text-gray-900 dark:text-gray-100">{formattedPrice}</span>
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <div className="flex justify-between items-center">
+                                <span className="text-base font-semibold text-gray-700 dark:text-gray-300">Distance:</span>
+                                <div className="flex items-center gap-2">
+                                    <Target className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                                    <span className={`font-mono font-bold text-lg ${distanceColor}`}>
+                                        {distanceStr}
+                                    </span>
+                                </div>
+                            </div>
+
+                            {is_holding && opportunity.distance_to_stop_pct !== null && opportunity.distance_to_stop_pct !== undefined ? (
+                                <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50/60 dark:bg-red-900/20 p-2">
+                                    <div className="flex justify-between items-center">
+                                        <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">Stop risk:</span>
+                                        <span className="font-mono font-bold text-sm text-red-700 dark:text-red-300">
+                                            {opportunity.distance_to_stop_pct.toFixed(2)}%
+                                        </span>
+                                    </div>
+                                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] font-mono text-gray-700 dark:text-gray-300">
+                                        {opportunity.entry_price !== null && opportunity.entry_price !== undefined ? (
+                                            <span>entry: ${opportunity.entry_price.toFixed(8)}</span>
+                                        ) : null}
+                                        {opportunity.stop_price !== null && opportunity.stop_price !== undefined ? (
+                                            <span>stop: ${opportunity.stop_price.toFixed(8)}</span>
+                                        ) : null}
+                                    </div>
+                                </div>
+                            ) : null}
+
+                            {showProgress && (
+                                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
+                                    <div
+                                        className={`h-full transition-all ${
+                                            is_holding ? 'bg-orange-500' : 'bg-yellow-500'
+                                        }`}
+                                        style={{ width: `${progressPercent}%` }}
+                                    />
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-md text-sm border border-gray-300 dark:border-gray-600">
+                            <div className="flex items-start gap-2">
+                                <Activity className="w-4 h-4 mt-0.5 text-blue-600 dark:text-blue-400 flex-shrink-0" />
+                                <span className="font-medium text-gray-800 dark:text-gray-200 break-words">{statusMessage}</span>
+                            </div>
+                        </div>
+
+                        {opportunity.parameters && Object.keys(opportunity.parameters).length > 0 && (
+                            <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-md text-sm border border-gray-300 dark:border-gray-600">
+                                <div className="flex items-center gap-2 mb-1">
+                                    <Settings className="w-4 h-4 text-violet-600 dark:text-violet-400 flex-shrink-0" />
+                                    <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                        Parameters
+                                    </span>
+                                </div>
+                                <p className="font-mono text-xs text-gray-700 dark:text-gray-300 break-words">
+                                    {Object.entries(opportunity.parameters)
+                                        .map(([k, v]) => `${k}=${v}`)
+                                        .join(' ')}
+                                </p>
+                            </div>
+                        )}
+
+                        {opportunity.indicator_values && Object.keys(opportunity.indicator_values).length > 0 && (
+                            <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-md text-sm border border-blue-200 dark:border-blue-800">
+                                <div className="flex items-center gap-2 mb-1">
+                                    <Target className="w-4 h-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
+                                    <span className="text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400">
+                                        Indicator Values
+                                    </span>
+                                </div>
+                                <p className="font-mono text-xs text-gray-700 dark:text-gray-300 break-words">
+                                    {Object.entries(opportunity.indicator_values)
+                                        .map(([k, v]) => `${k}=${typeof v === 'number' ? v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : v}`)
+                                        .join(' · ')}
+                                </p>
+                            </div>
+                        )}
+
+                        <div className="p-3 bg-slate-50 dark:bg-slate-800/80 rounded-md text-sm border border-slate-200 dark:border-slate-600">
+                            <div className="flex items-center justify-between gap-2">
+                                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                    Notes
+                                </span>
+                                {!isEditingNotes && (
+                                    <button
+                                        type="button"
+                                        className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                                        onClick={() => setIsEditingNotes(true)}
+                                    >
+                                        Edit
+                                    </button>
+                                )}
+                            </div>
+
+                            {isEditingNotes ? (
+                                <div className="mt-2 space-y-2">
+                                    <textarea
+                                        className="w-full min-h-[60px] text-xs rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1 text-slate-800 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                                        value={notesValue}
+                                        onChange={(e) => setNotesValue(e.target.value)}
+                                        placeholder="Add notes for this strategy..."
+                                    />
+                                    <div className="flex justify-end gap-2">
+                                        <button
+                                            type="button"
+                                            className="px-2 py-1 text-xs rounded border border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                                            onClick={() => {
+                                                setNotesValue(opportunity.notes || '');
+                                                setIsEditingNotes(false);
+                                            }}
+                                            disabled={isSavingNotes}
+                                        >
+                                            Cancel
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className="px-2 py-1 text-xs rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed"
+                                            onClick={async () => {
+                                                try {
+                                                    setIsSavingNotes(true);
+                                                    const res = await fetch(`${API_BASE_URL}/favorites/${opportunity.id}`, {
+                                                        method: 'PATCH',
+                                                        headers: { 'Content-Type': 'application/json' },
+                                                        body: JSON.stringify({ notes: notesValue }),
+                                                    });
+                                                    if (!res.ok) {
+                                                        alert('Error saving notes.');
+                                                        return;
+                                                    }
+                                                    setIsEditingNotes(false);
+                                                } catch (err) {
+                                                    console.error('Error saving notes:', err);
+                                                    alert('Error saving notes.');
+                                                } finally {
+                                                    setIsSavingNotes(false);
+                                                }
+                                            }}
+                                            disabled={isSavingNotes}
+                                        >
+                                            {isSavingNotes ? 'Saving...' : 'Save'}
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <p className="mt-1 font-medium text-slate-700 dark:text-slate-200 break-words text-xs whitespace-pre-wrap">
+                                    {notesValue || 'No notes.'}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                )}
             </CardContent>
         </Card>
     );

--- a/frontend/src/components/monitor/types.ts
+++ b/frontend/src/components/monitor/types.ts
@@ -28,3 +28,10 @@ export interface Opportunity {
     stop_price?: number | null;
     distance_to_stop_pct?: number | null;
 }
+
+export type MonitorCardMode = 'price' | 'strategy';
+
+export interface MonitorPreference {
+    in_portfolio: boolean;
+    card_mode: MonitorCardMode;
+}

--- a/frontend/tests/e2e/monitor-card-mode-and-portfolio.spec.ts
+++ b/frontend/tests/e2e/monitor-card-mode-and-portfolio.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test } from '@playwright/test'
+
+const FAVORITES_PAYLOAD = [
+  {
+    id: 1,
+    name: 'BTC Trend',
+    symbol: 'BTC/USDT',
+    timeframe: '4h',
+    strategy_name: 'ema_rsi',
+    parameters: {},
+    metrics: {},
+    created_at: '2025-01-01T00:00:00Z',
+    tier: 1,
+  },
+  {
+    id: 2,
+    name: 'NVDA Trend',
+    symbol: 'NVDA',
+    timeframe: '1d',
+    strategy_name: 'ema_rsi',
+    parameters: {},
+    metrics: {},
+    created_at: '2025-01-01T00:00:00Z',
+    tier: 1,
+  },
+]
+
+const OPPORTUNITIES_PAYLOAD = [
+  {
+    id: 1,
+    symbol: 'BTC/USDT',
+    timeframe: '4h',
+    template_name: 'ema_rsi',
+    name: 'BTC Trend',
+    notes: '',
+    tier: 1,
+    parameters: { ema_short: 9, ema_long: 21 },
+    is_holding: false,
+    distance_to_next_status: 0.3,
+    next_status_label: 'entry',
+    status: 'WAIT',
+    message: 'Waiting for entry',
+    last_price: 50000,
+    timestamp: '2025-01-01T00:00:00Z',
+    details: {},
+  },
+  {
+    id: 2,
+    symbol: 'NVDA',
+    timeframe: '1d',
+    template_name: 'ema_rsi',
+    name: 'NVDA Trend',
+    notes: '',
+    tier: 1,
+    parameters: { ema_short: 9, ema_long: 21 },
+    is_holding: false,
+    distance_to_next_status: 0.5,
+    next_status_label: 'entry',
+    status: 'WAIT',
+    message: 'Waiting for entry',
+    last_price: 1000,
+    timestamp: '2025-01-01T00:00:00Z',
+    details: {},
+  },
+]
+
+function buildCandles() {
+  return [
+    { timestamp_utc: '2025-01-01T00:00:00Z', open: 100, high: 102, low: 99, close: 101, volume: 1000 },
+    { timestamp_utc: '2025-01-01T01:00:00Z', open: 101, high: 103, low: 100, close: 102, volume: 1100 },
+    { timestamp_utc: '2025-01-01T02:00:00Z', open: 102, high: 104, low: 101, close: 103, volume: 1200 },
+  ]
+}
+
+async function setupApiMocks(page: any) {
+  const preferences: Record<string, { in_portfolio: boolean; card_mode: 'price' | 'strategy' }> = {
+    'BTC/USDT': { in_portfolio: true, card_mode: 'price' },
+  }
+
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/favorites/', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(FAVORITES_PAYLOAD),
+    })
+  )
+
+  await page.route('**/api/opportunities/**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(OPPORTUNITIES_PAYLOAD),
+    })
+  )
+
+  await page.route('**/api/monitor/preferences', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(preferences),
+    })
+  )
+
+  await page.route('**/api/monitor/preferences/*', async (route: any) => {
+    const url = new URL(route.request().url())
+    const symbol = decodeURIComponent(url.pathname.split('/').pop() || '').trim()
+    const patch = route.request().postDataJSON() || {}
+    const current = preferences[symbol] || { in_portfolio: false, card_mode: 'price' }
+    const next = {
+      in_portfolio: patch.in_portfolio ?? current.in_portfolio,
+      card_mode: patch.card_mode ?? current.card_mode,
+    }
+    preferences[symbol] = next
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(next),
+    })
+  })
+
+  await page.route('**/api/market/candles**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        candles: buildCandles(),
+      }),
+    })
+  )
+}
+
+test('defaults to In Portfolio and hides symbols without preference', async ({ page }) => {
+  await setupApiMocks(page)
+  await page.goto('/monitor')
+
+  await expect(page.getByTestId('monitor-card-btc-usdt')).toBeVisible()
+  await expect(page.getByTestId('monitor-card-nvda')).toHaveCount(0)
+})
+
+test('toggle in_portfolio persists across reload', async ({ page }) => {
+  await setupApiMocks(page)
+  await page.goto('/monitor')
+
+  await page.getByTestId('monitor-filter-all').click()
+  await expect(page.getByTestId('monitor-card-nvda')).toBeVisible()
+
+  await page.getByTestId('portfolio-toggle-nvda').click()
+  await page.getByTestId('monitor-filter-in-portfolio').click()
+  await expect(page.getByTestId('monitor-card-nvda')).toBeVisible()
+
+  await page.reload()
+  await expect(page.getByTestId('monitor-card-nvda')).toBeVisible()
+})
+
+test('per-card mode toggle persists across reload', async ({ page }) => {
+  await setupApiMocks(page)
+  await page.goto('/monitor')
+
+  await expect(page.getByTestId('mode-label-btc-usdt')).toHaveText('Price')
+  await page.getByTestId('mode-toggle-btc-usdt').click()
+  await expect(page.getByTestId('mode-label-btc-usdt')).toHaveText('Strategy')
+
+  await page.reload()
+  await expect(page.getByTestId('mode-label-btc-usdt')).toHaveText('Strategy')
+})

--- a/openspec/changes/monitor-card-mode-and-portfolio/.openspec.yaml
+++ b/openspec/changes/monitor-card-mode-and-portfolio/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-25

--- a/openspec/changes/monitor-card-mode-and-portfolio/design.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The Monitor experience is now card-based and includes a price-focused dashboard (candles) plus strategy information. Users want to reduce noise by defaulting the list to a smaller subset of favorites they actively hold/monitor ("In Portfolio").
+
+Additionally, users want to toggle each symbol card between Price vs Strategy content, and for both the In Portfolio flag and per-card mode to be persisted in the backend (not local-only), so preferences survive device/browser changes.
+
+Constraints:
+- Data set is derived from Favorites.
+- Preferences are per-symbol (Monitor operates on symbol cards).
+- Must keep UX simple and mobile-friendly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist per-symbol Monitor preferences:
+  - `in_portfolio` boolean
+  - `card_mode` enum (price|strategy)
+- Default Monitor list to "In Portfolio" subset.
+- Allow user to switch list filter between In Portfolio and All.
+- Provide a per-card toggle icon to switch card mode.
+- Ensure preferences are persisted and loaded from backend.
+
+**Non-Goals:**
+- User accounts / multi-user auth model.
+- Complex watchlists beyond Favorites.
+- Full TradingView-like customization.
+
+## Decisions
+
+1) Data model: new table for monitor preferences
+- Decision: add a new SQLite table (e.g., `monitor_preferences`) keyed by symbol with columns:
+  - `symbol` (primary key)
+  - `in_portfolio` (bool)
+  - `card_mode` (text)
+  - timestamps (optional)
+- Rationale: avoids overloading the favorites schema and keeps preferences separate.
+
+2) API shape
+- Decision: expose simple REST endpoints:
+  - `GET /api/monitor/preferences` -> map keyed by symbol
+  - `PUT /api/monitor/preferences/{symbol}` -> update one symbol preference
+- Rationale: minimal to implement and easy for UI.
+
+3) UI persistence behavior
+- Decision: on Monitor load:
+  - fetch Favorites
+  - fetch preferences
+  - compute derived card list
+- Rationale: ensures stable UI and no duplication.
+
+4) Defaults
+- Decision:
+  - default filter: In Portfolio
+  - default per-card mode: Price
+  - default in_portfolio: false
+- Rationale: reduce noise and align with requested behavior.
+
+## Risks / Trade-offs
+
+- [Risk] Preferences table requires migration/initialization → Mitigation: create table on startup (like existing DB init) and keep schema minimal.
+- [Risk] Symbol normalization inconsistencies (case, whitespace) → Mitigation: normalize symbols in backend (`strip()` and keep exact casing used in favorites) and in UI.
+- [Risk] Additional API calls on load → Mitigation: keep endpoints lightweight and cache in UI state.
+
+## Migration Plan
+
+1) Add DB table + API endpoints.
+2) Add frontend integration (fetch prefs, default filter, per-card toggle).
+3) Add backend integration tests (preferences API) and Playwright E2E tests.
+4) Deploy; verify Monitor defaults and persistence.
+
+Rollback: revert frontend to local-only behavior and ignore prefs endpoints; table can remain.
+
+## Open Questions
+
+- Whether to store preferences per symbol or per favorite (strategy+symbol). Current decision is per-symbol.
+- Whether to default the active view (price/strategy) per symbol or globally. Current decision is per symbol only.

--- a/openspec/changes/monitor-card-mode-and-portfolio/proposal.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The Monitor dashboard is now card-based and mobile-friendly, but it still shows more information than needed for day-to-day checking. Alan wants to:
+
+1) Make Monitor open directly into the card-based experience.
+2) Reduce noise by defaulting to a smaller subset of favorites ("in portfolio")
+3) Allow toggling, per card, between **Price view** (candles) and **Strategy view** (current strategy metrics/status)
+4) Persist these preferences in the backend so they survive device/browser changes.
+
+## What Changes
+
+- Add an "In Portfolio" flag that can be toggled by the user for favorites symbols.
+- Default Monitor card list to show only symbols flagged as In Portfolio.
+- Add a per-card toggle icon to switch between:
+  - Price view (candles + basic price metrics)
+  - Strategy view (strategy status/metrics already present today)
+- Persist per-symbol card view mode and the In Portfolio flag in the backend.
+
+## Capabilities
+
+### New Capabilities
+- `monitor-portfolio-watchlist`: Mark favorites symbols as "In Portfolio" and default the Monitor list to that subset.
+- `monitor-card-view-mode`: Persist per-symbol card mode (price vs strategy).
+
+### Modified Capabilities
+- `frontend-ux`: Update Monitor UX to use the new defaults and toggles.
+- `backend`: Store and expose the new per-symbol preferences.
+
+## Impact
+
+- Backend: database schema update for storing monitor preferences.
+- Frontend: Monitor card UI changes + new toggle controls.
+- Tests: backend integration tests for preferences API + Playwright E2E for toggling and persistence.

--- a/openspec/changes/monitor-card-mode-and-portfolio/review-ptbr.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/review-ptbr.md
@@ -1,0 +1,32 @@
+# Revisão (PT-BR) — monitor-card-mode-and-portfolio
+
+## O que é
+Melhorar o Monitor para ficar mais útil no dia a dia no celular, reduzindo ruído e permitindo alternar o conteúdo de cada card.
+
+## Principais funcionalidades
+1) **Em carteira (In Portfolio)**
+- Marcar por **símbolo** quais ativos você realmente quer acompanhar.
+- Por padrão, o Monitor mostra só os que estão **Em carteira**.
+- Você consegue alternar para ver **Todos** quando quiser.
+
+2) **Modo do card por símbolo (Preço vs Estratégia)**
+- Cada card terá um ícone para alternar entre:
+  - **Preço**: candles + métricas básicas
+  - **Estratégia**: dados de estratégia/status (o que você já tem hoje)
+- Essa escolha é **salva no backend**, então persiste entre celular/desktop.
+
+## Persistência (backend)
+- Preferências por símbolo:
+  - `in_portfolio`: true/false
+  - `card_mode`: price/strategy
+
+## Como testar (manual rápido)
+1) Abrir `/monitor`.
+2) Ver que por padrão aparece só a lista "Em carteira".
+3) Marcar/desmarcar um ativo como Em carteira e recarregar a página → deve persistir.
+4) Em um card, alternar Preço/Estratégia e recarregar → deve persistir.
+5) Trocar o filtro "Em carteira" ↔ "Todos".
+
+## Observações
+- Sem depender de localStorage: tudo persistido no backend.
+- Mantém o dataset baseado em Favoritos.

--- a/openspec/changes/monitor-card-mode-and-portfolio/specs/backend/spec.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/specs/backend/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Backend stores Monitor preferences per symbol
+The backend MUST persist Monitor preferences per symbol.
+
+Preferences include:
+- `in_portfolio` (boolean)
+- `card_mode` (enum: price | strategy)
+
+#### Scenario: Persist preferences
+- **WHEN** the client updates preferences for a symbol
+- **THEN** the backend stores the preferences and returns them on subsequent reads
+
+#### Scenario: Default preferences
+- **WHEN** no preferences exist yet for a symbol
+- **THEN** the backend returns defaults (in_portfolio=false, card_mode=price)
+
+### Requirement: Backend exposes a preferences API
+The backend MUST expose an API for reading and updating Monitor preferences.
+
+#### Scenario: Read all preferences
+- **WHEN** the client requests preferences
+- **THEN** the backend returns the preferences keyed by symbol
+
+#### Scenario: Update preferences
+- **WHEN** the client updates preferences for a symbol
+- **THEN** the backend validates input and persists the update

--- a/openspec/changes/monitor-card-mode-and-portfolio/specs/frontend-ux/spec.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/specs/frontend-ux/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Monitor provides controls for In Portfolio and card mode
+The UI MUST provide controls on the Monitor screen to:
+- filter the list by In Portfolio vs All
+- toggle per-card mode (Price vs Strategy)
+
+#### Scenario: Filter toggle exists
+- **WHEN** the user opens Monitor
+- **THEN** the UI provides a control to switch between In Portfolio and All
+
+#### Scenario: Per-card toggle exists
+- **WHEN** the user views a symbol card
+- **THEN** the card provides a toggle control to switch between Price and Strategy modes

--- a/openspec/changes/monitor-card-mode-and-portfolio/specs/monitor-card-view-mode/spec.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/specs/monitor-card-view-mode/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Per-symbol card mode can be toggled
+The system MUST allow the user to toggle a Monitor card between Price mode and Strategy mode.
+
+#### Scenario: Toggle to Price mode
+- **WHEN** the user toggles a symbol card to Price mode
+- **THEN** the UI shows price-oriented content for that symbol (candles + basic price metrics)
+
+#### Scenario: Toggle to Strategy mode
+- **WHEN** the user toggles a symbol card to Strategy mode
+- **THEN** the UI shows strategy-oriented content for that symbol (current strategy metrics/status)
+
+### Requirement: Card mode is persisted in the backend
+The system MUST persist the per-symbol card mode preference.
+
+#### Scenario: Preference persists across reload
+- **WHEN** the user sets a symbol card mode and reloads the page
+- **THEN** the symbol card renders using the last persisted mode
+
+#### Scenario: Preference persists across devices
+- **WHEN** the user sets a symbol card mode on one device
+- **THEN** another device sees the same card mode for the symbol after fetching preferences

--- a/openspec/changes/monitor-card-mode-and-portfolio/specs/monitor-portfolio-watchlist/spec.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/specs/monitor-portfolio-watchlist/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Favorites symbols can be marked as In Portfolio
+The system MUST allow the user to mark a Favorites symbol as "In Portfolio".
+
+#### Scenario: Mark symbol as In Portfolio
+- **WHEN** the user toggles In Portfolio ON for a symbol
+- **THEN** the backend persists the preference for that symbol
+
+#### Scenario: Unmark symbol as In Portfolio
+- **WHEN** the user toggles In Portfolio OFF for a symbol
+- **THEN** the backend persists the preference for that symbol
+
+### Requirement: Monitor defaults to In Portfolio symbols
+The system MUST default the Monitor card list to symbols marked as In Portfolio.
+
+#### Scenario: Monitor loads with In Portfolio filter enabled
+- **WHEN** the user opens the Monitor screen
+- **THEN** the visible list contains only symbols marked In Portfolio
+
+#### Scenario: User can view all favorites symbols
+- **WHEN** the user switches the filter from In Portfolio to All
+- **THEN** the visible list contains all favorites symbols

--- a/openspec/changes/monitor-card-mode-and-portfolio/tasks.md
+++ b/openspec/changes/monitor-card-mode-and-portfolio/tasks.md
@@ -1,0 +1,30 @@
+## 1. Backend: Database + API
+
+- [ ] 1.1 Add a new DB table to persist monitor preferences per symbol (`monitor_preferences`)
+- [ ] 1.2 Implement `GET /api/monitor/preferences` to return preferences keyed by symbol
+- [ ] 1.3 Implement `PUT /api/monitor/preferences/{symbol}` to update `in_portfolio` and/or `card_mode`
+- [ ] 1.4 Add backend integration tests for reading/updating preferences (deterministic; no network)
+
+## 2. Frontend: Preferences Integration
+
+- [ ] 2.1 Fetch monitor preferences on Monitor load and merge with favorites-derived symbols
+- [ ] 2.2 Default Monitor list filter to show only `in_portfolio=true` symbols
+- [ ] 2.3 Add a filter control to switch between In Portfolio and All
+
+## 3. Frontend: Per-card Mode Toggle
+
+- [ ] 3.1 Add per-card toggle icon to switch between Price and Strategy views
+- [ ] 3.2 Persist card mode changes via the backend preferences API
+- [ ] 3.3 Render Price view using existing candle UI; render Strategy view using existing strategy/status content
+
+## 4. E2E Tests (Playwright)
+
+- [ ] 4.1 Add Playwright E2E test: defaults to In Portfolio list
+- [ ] 4.2 Add Playwright E2E test: toggle In Portfolio flag persists across reload
+- [ ] 4.3 Add Playwright E2E test: per-card mode toggling persists across reload
+
+## 5. Validation
+
+- [ ] 5.1 Run `openspec validate monitor-card-mode-and-portfolio --type change`
+
+> Note: Use project skills (.codex/skills) when applicable (architecture, tests, debugging, frontend).


### PR DESCRIPTION
Implements monitor preferences persisted in backend: per-symbol in_portfolio flag and card_mode (price/strategy). Monitor defaults to In Portfolio; symbols without prefs appear only in All. Includes backend integration tests and Playwright E2E coverage.