### PR TITLE
Preserve monitor design artifacts

### DIFF
--- a/openspec/changes/o-gr-fico-da-funcionalidade-monitor-esta-dando-sinal-de-sa-da-incorreto/design.md
+++ b/openspec/changes/o-gr-fico-da-funcionalidade-monitor-esta-dando-sinal-de-sa-da-incorreto/design.md
@@ -1,0 +1,62 @@
+# Design
+
+## Contexto
+O bug do Monitor nao pede redesign amplo, mas exige um tratamento visual que elimine qualquer falso positivo de `EXIT` quando timeframe, candle ou frescor nao estiverem alinhados.
+
+## Direcao
+Introduzir um estado visual `INCONCLUSIVO` sincronizado entre badge, marcador de grafico e bloco de contexto.
+
+O objetivo e simples:
+- `EXIT` so existe quando tudo fecha 100%
+- qualquer divergencia cai para um estado neutro e explicado
+- o fallback nao pode parecer uma quase-venda
+
+## Regras visuais
+
+### EXIT confirmado
+Usar o azul atual somente quando todos os itens abaixo forem verdadeiros:
+- estado resolvido = `EXIT`
+- timeframe exibido = timeframe do sinal
+- candle exibido = candle de referencia do sinal
+- payload fresco
+- badge, marcador e contexto apontam para o mesmo estado
+
+### INCONCLUSIVO
+Usar estado neutro em qualquer um destes casos:
+- timeframe divergente
+- candle divergente
+- payload stale
+- campos ausentes
+- conflito entre badge, grafico e metadado
+- loading sem confirmacao final
+
+## Linguagem visual
+- `EXIT confirmado`: azul ja existente, reservado exclusivamente para saida valida
+- `Holding`: verde ja existente
+- `INCONCLUSIVO`: fundo ardósia/zinco, texto claro, borda discreta, sem cor de acao
+- `Motivo do bloqueio`: chips neutros com baixo contraste cromatico e alta legibilidade textual
+
+## Comportamento esperado
+- badge principal em caixa alta curta: `INCONCLUSIVO`
+- mensagem principal objetiva: `EXIT bloqueado ate alinhar contexto`
+- marcador neutro no grafico, sem seta de saida
+- bloco de contexto com `timeframe`, `candle` e `freshness`
+- linha de motivo explicando por que o estado foi bloqueado
+
+## Rejeicoes explicitas
+- nao usar `EXIT` com tooltip de aviso
+- nao esconder o problema removendo contexto
+- nao usar a mesma aparencia para loading e saida confirmada
+- nao reaproveitar azul de confirmacao em cenarios ambiguos
+
+## Notas para DEV
+- o marcador neutro deve substituir a seta de saida quando `isUncertain = true`
+- o contexto minimo visivel para QA deve expor timeframe, candle e frescor
+- o azul de `EXIT` nao pode aparecer em nenhum fallback
+
+## Notas para QA
+Validar que:
+- nenhum caso inconclusivo usa rotulo `EXIT`
+- nenhum caso inconclusivo desenha seta acima do candle
+- o motivo do bloqueio aparece no card
+- a combinacao badge + grafico + contexto e deterministica com o mesmo payload

--- a/openspec/changes/o-gr-fico-da-funcionalidade-monitor-esta-dando-sinal-de-sa-da-incorreto/prototype.html
+++ b/openspec/changes/o-gr-fico-da-funcionalidade-monitor-esta-dando-sinal-de-sa-da-incorreto/prototype.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Monitor · Estado Inconclusivo</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111a;
+      --panel: #0f1b27;
+      --panel-2: #132231;
+      --border: rgba(148, 163, 184, 0.18);
+      --text: #e5eef8;
+      --muted: #8fa3b8;
+      --green: #22c55e;
+      --blue: #0ea5e9;
+      --slate: #94a3b8;
+      --slate-2: #1f2c3b;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, sans-serif;
+      background: radial-gradient(circle at top, #102235 0%, var(--bg) 58%);
+      color: var(--text);
+      padding: 24px;
+    }
+
+    main {
+      max-width: 1240px;
+      margin: 0 auto;
+      display: grid;
+      gap: 20px;
+    }
+
+    .hero,
+    .card {
+      background: linear-gradient(180deg, rgba(19, 34, 49, 0.96), rgba(10, 18, 28, 0.98));
+      border: 1px solid var(--border);
+      border-radius: 24px;
+      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+    }
+
+    .hero {
+      padding: 28px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .eyebrow {
+      color: #77d3f7;
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.05;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 900px;
+      color: var(--muted);
+      line-height: 1.6;
+    }
+
+    .tokens,
+    .grid,
+    .context {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .token,
+    .context-item,
+    .reason {
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.03);
+      border-radius: 16px;
+    }
+
+    .token {
+      padding: 8px 12px;
+      font-size: 13px;
+    }
+
+    .grid {
+      align-items: stretch;
+    }
+
+    .card {
+      width: min(100%, 390px);
+      overflow: hidden;
+      border-left: 4px solid transparent;
+    }
+
+    .card.exit { border-left-color: var(--blue); }
+    .card.neutral { border-left-color: var(--slate); }
+    .card.loading { border-left-color: #64748b; }
+
+    .card-head,
+    .summary {
+      padding: 18px;
+    }
+
+    .card-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      padding-bottom: 8px;
+    }
+
+    .symbol {
+      font-size: 18px;
+      font-weight: 700;
+    }
+
+    .meta,
+    .summary p {
+      color: var(--muted);
+      line-height: 1.5;
+      margin: 0;
+    }
+
+    .price {
+      text-align: right;
+      font-size: 22px;
+      font-weight: 700;
+    }
+
+    .price small {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 12px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .badge.exit {
+      background: rgba(14, 165, 233, 0.18);
+      color: #8de2ff;
+      border-color: rgba(14, 165, 233, 0.35);
+    }
+
+    .badge.neutral,
+    .badge.loading {
+      background: rgba(148, 163, 184, 0.15);
+      color: #d7dee8;
+      border-color: rgba(148, 163, 184, 0.32);
+    }
+
+    .chart {
+      height: 150px;
+      margin: 0 18px;
+      border-radius: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.14);
+      background:
+        linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(180deg, rgba(10, 18, 28, 0.6), rgba(19, 34, 49, 0.9));
+      background-size: 100% 30px, 28px 100%, auto;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .line {
+      position: absolute;
+      inset: auto 18px 26px 18px;
+      height: 68px;
+      border-radius: 999px;
+      border: 2px solid rgba(34, 197, 94, 0.55);
+      border-color: transparent transparent rgba(34, 197, 94, 0.55) transparent;
+      transform: skewX(-18deg);
+    }
+
+    .marker {
+      position: absolute;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .marker.exit { top: 10px; right: 56px; color: var(--blue); }
+    .marker.neutral { bottom: 12px; right: 56px; color: var(--slate); }
+    .marker.loading { bottom: 12px; left: 50%; transform: translateX(-50%); color: var(--slate); }
+
+    .pill {
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid currentColor;
+      background: rgba(8, 15, 24, 0.86);
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .arrow {
+      width: 2px;
+      height: 34px;
+      background: currentColor;
+      position: relative;
+    }
+
+    .arrow::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      border-left: 7px solid transparent;
+      border-right: 7px solid transparent;
+    }
+
+    .arrow.down::after {
+      top: 100%;
+      border-top: 10px solid currentColor;
+    }
+
+    .arrow.up::after {
+      bottom: 100%;
+      border-bottom: 10px solid currentColor;
+    }
+
+    .summary {
+      display: grid;
+      gap: 14px;
+    }
+
+    .summary h2 {
+      margin: 0;
+      font-size: 17px;
+    }
+
+    .context-item {
+      padding: 12px;
+      flex: 1 1 100px;
+    }
+
+    .context-item span {
+      display: block;
+      color: var(--muted);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 6px;
+    }
+
+    .reason {
+      padding: 12px 14px;
+      font-size: 13px;
+      line-height: 1.45;
+      color: #d8e2ee;
+    }
+
+    .reason.exit {
+      background: rgba(14, 165, 233, 0.1);
+      border-color: rgba(14, 165, 233, 0.22);
+      color: #bceeff;
+    }
+
+    @media (max-width: 820px) {
+      body { padding: 18px; }
+      .card { width: 100%; }
+      .price { text-align: left; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="hero">
+      <div class="eyebrow">Card #96 · Monitor · Estado neutro obrigatorio</div>
+      <h1>EXIT so existe quando o contexto fecha 100%</h1>
+      <p>Este prototipo separa visualmente saida confirmada de qualquer cenario ambiguo. Se timeframe, candle ou frescor falharem, o Monitor troca a leitura de acao por um estado inconclusivo explicado, sem seta de saida e sem azul de confirmacao.</p>
+      <div class="tokens">
+        <div class="token">Dominio: trading sensivel a falso positivo</div>
+        <div class="token">Assinatura: acao confirmada vs bloqueio neutro</div>
+        <div class="token">Padrao rejeitado: EXIT com aviso textual</div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card exit">
+        <div class="card-head">
+          <div>
+            <div class="badge exit">Exit confirmado</div>
+            <div class="symbol">BTC/USDT</div>
+            <div class="meta">Monitor · 1h · candle atual</div>
+          </div>
+          <div class="price">
+            68,420
+            <small>payload fresco · sincronizado</small>
+          </div>
+        </div>
+        <div class="chart">
+          <div class="line"></div>
+          <div class="marker exit">
+            <div class="pill">EXIT</div>
+            <div class="arrow down"></div>
+          </div>
+        </div>
+        <div class="summary">
+          <h2>Saida confirmada para o contexto atual</h2>
+          <p>Badge, marcador e metadados leem o mesmo estado resolvido. O azul fica reservado apenas para esse caso.</p>
+          <div class="context">
+            <div class="context-item"><span>Timeframe</span><strong>1h</strong></div>
+            <div class="context-item"><span>Candle ref</span><strong>2026-04-18 03:00</strong></div>
+            <div class="context-item"><span>Freshness</span><strong>OK</strong></div>
+          </div>
+          <div class="reason exit">Sinal confirmado na mesma janela exibida. Nenhum fallback aplicado.</div>
+        </div>
+      </article>
+
+      <article class="card neutral">
+        <div class="card-head">
+          <div>
+            <div class="badge neutral">Inconclusivo</div>
+            <div class="symbol">BTC/USDT</div>
+            <div class="meta">Monitor · 1h visivel · payload 4h</div>
+          </div>
+          <div class="price">
+            68,420
+            <small>contexto divergente</small>
+          </div>
+        </div>
+        <div class="chart">
+          <div class="line"></div>
+          <div class="marker neutral">
+            <div class="pill">Bloqueado</div>
+            <div class="arrow up"></div>
+          </div>
+        </div>
+        <div class="summary">
+          <h2>EXIT bloqueado ate alinhar contexto</h2>
+          <p>O estado nao sugere venda. A interface explica o motivo do bloqueio e expone o contexto usado para QA e debug.</p>
+          <div class="context">
+            <div class="context-item"><span>Timeframe</span><strong>UI 1h / payload 4h</strong></div>
+            <div class="context-item"><span>Candle ref</span><strong>nao confere</strong></div>
+            <div class="context-item"><span>Freshness</span><strong>OK</strong></div>
+          </div>
+          <div class="reason">O marker de saida e removido. O fallback usa linguagem neutra e nao reaproveita o azul de confirmacao.</div>
+        </div>
+      </article>
+
+      <article class="card loading">
+        <div class="card-head">
+          <div>
+            <div class="badge loading">Inconclusivo</div>
+            <div class="symbol">BTC/USDT</div>
+            <div class="meta">Monitor · aguardando confirmacao final</div>
+          </div>
+          <div class="price">
+            --
+            <small>payload stale</small>
+          </div>
+        </div>
+        <div class="chart">
+          <div class="line"></div>
+          <div class="marker loading">
+            <div class="pill">Checando</div>
+          </div>
+        </div>
+        <div class="summary">
+          <h2>Loading e stale permanecem neutros</h2>
+          <p>Sem confirmacao final, a UI continua explicativa e bloqueada. Isso evita alternancia erratica entre `EXIT` e outro estado.</p>
+          <div class="context">
+            <div class="context-item"><span>Timeframe</span><strong>1h</strong></div>
+            <div class="context-item"><span>Candle ref</span><strong>pendente</strong></div>
+            <div class="context-item"><span>Freshness</span><strong>stale</strong></div>
+          </div>
+          <div class="reason">Mesmo sem conflito visual, um payload stale nao pode promover o card para `EXIT confirmado`.</div>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- preserve the monitor false-positive EXIT design notes in the canonical OpenSpec change
- add the prototype HTML that was previously stranded in the old card-93 branch
- keep repository setup and lint/format work isolated in PR #16

## Scope
- OpenSpec artifacts only
- no runtime code changes

## Validation
- extracted from the stale card-93 branch into the canonical change path
- branch split performed without force-pushing the original setup PR