### PR TITLE
Fix monitor chart layout and stock candle freshness fallback

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -36,6 +36,7 @@ _DEFAULT_HISTORY_DAYS = {
     "1d": 400,
 }
 _CANDLES_CACHE_TTL_SECONDS = 120.0
+_STOCK_1D_STALENESS_DAYS = 12
 _CANDLES_CACHE_LOCK = threading.Lock()
 _CANDLES_CACHE: Dict[Tuple[str, str, int], Dict[str, Any]] = {}
 
@@ -207,6 +208,24 @@ def _ui_default_since_str(timeframe: str, limit: int) -> str:
     return since.isoformat()
 
 
+def _is_stock_1d_data_stale(df: pd.DataFrame, timeframe: str) -> bool:
+    if timeframe != "1d" or df is None:
+        return False
+    if df.empty:
+        return True
+
+    index_values = pd.to_datetime(df.index, utc=True, errors="coerce")
+    if index_values.empty:
+        return True
+
+    latest = index_values.max()
+    if pd.isna(latest):
+        return True
+
+    threshold = datetime.now(timezone.utc) - timedelta(days=_STOCK_1D_STALENESS_DAYS)
+    return latest < pd.Timestamp(threshold)
+
+
 def _normalize_candles_frame(df, limit: int):
     if df is None:
         return []
@@ -310,8 +329,19 @@ async def get_market_candles(
                 df = YahooMarketDataProvider().fetch_ohlcv(
                     raw_symbol, tf, since_str=since_str, limit=limit
                 )
-        else:
-            raise ValueError("Stocks currently support only timeframe='1d'.")
+            else:
+                if _is_stock_1d_data_stale(df, tf):
+                    yahoo_provider = YahooMarketDataProvider()
+                    try:
+                        yahoo_df = yahoo_provider.fetch_ohlcv(
+                            raw_symbol, tf, since_str=since_str, limit=limit
+                        )
+                    except Exception:
+                        pass
+                    else:
+                        df = yahoo_df
+                        data_source = "yahoo"
+                        provider = yahoo_provider
 
         candles = _normalize_candles_frame(df, limit=limit)
         payload = {

--- a/backend/app/services/market_data_providers.py
+++ b/backend/app/services/market_data_providers.py
@@ -151,6 +151,18 @@ class StooqEodProvider:
             return ts.tz_localize("UTC")
         return ts.tz_convert("UTC")
 
+    @staticmethod
+    def _is_protected_stooq_payload(body: str) -> bool:
+        if not isinstance(body, str):
+            return False
+        lower = body.lower()
+        return (
+            "get your apikey" in lower
+            or "captcha" in lower
+            or "api key required" in lower
+            or "protected response" in lower
+        )
+
     def _normalize_timeframe(self, timeframe: str) -> str:
         tf = str(timeframe or "").strip().lower()
         if tf != "1d":
@@ -284,6 +296,10 @@ class StooqEodProvider:
                 body = response.text.strip()
                 if not body:
                     raise ValueError("empty response body")
+                if self._is_protected_stooq_payload(body):
+                    raise ValueError(
+                        f"Stooq returned protected response for '{provider_symbol}' (API key required)."
+                    )
                 if "no data" in body.lower():
                     raise ValueError(
                         f"No EOD data returned by Stooq for symbol '{provider_symbol}'."
@@ -366,7 +382,15 @@ class StooqEodProvider:
                 fresh_df, since_str=since_str, until_str=until_str, limit=limit
             )
         except Exception as exc:
+            protected_source = self._is_protected_stooq_payload(str(exc))
             if cached_df is not None:
+                if protected_source:
+                    logger.warning(
+                        "Stooq refresh blocked for %s; forcing caller-level fallback for '%s'.",
+                        provider_symbol,
+                        symbol,
+                    )
+                    raise
                 logger.warning(
                     "Stooq refresh failed for %s; serving stale cache (%d rows): %s",
                     provider_symbol,
@@ -386,6 +410,18 @@ class YahooMarketDataProvider:
 
     source = "yahoo"
     DEFAULT_TIMEOUT_SECONDS = 20.0
+    DEFAULT_MAX_RETRIES = 3
+    DEFAULT_RETRY_BACKOFF_SECONDS = 1.0
+    _REQUEST_HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/124.0.0.0 Safari/537.36"
+        ),
+        "Accept": "application/json",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Connection": "keep-alive",
+    }
 
     _VALID_TIMEFRAMES = {"15m", "1h", "4h", "1d"}
     _DEFAULT_RANGE_BY_TF = {
@@ -401,8 +437,15 @@ class YahooMarketDataProvider:
         "1d": "1d",
     }
 
-    def __init__(self, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS):
+    def __init__(
+        self,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
+    ):
         self.timeout_seconds = max(1.0, float(timeout_seconds))
+        self.max_retries = max(1, int(max_retries))
+        self.retry_backoff_seconds = max(0.2, float(retry_backoff_seconds))
 
     @staticmethod
     def _normalize_symbol(symbol: str) -> str:
@@ -548,21 +591,35 @@ class YahooMarketDataProvider:
         range_param = self._range_for_since(since_str, self._DEFAULT_RANGE_BY_TF[tf])
         url = f"https://query1.finance.yahoo.com/v8/finance/chart/{ticker}"
 
-        try:
-            response = httpx.get(
-                url,
-                params={
-                    "interval": interval,
-                    "range": range_param,
-                    "includePrePost": "false",
-                    "events": "div,splits",
-                },
-                timeout=self.timeout_seconds,
-            )
-            response.raise_for_status()
-            payload = response.json()
-        except Exception as exc:
-            raise ValueError(f"Yahoo request failed for '{ticker}': {exc}") from exc
+        payload: dict = {}
+        last_error: Exception | None = None
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = httpx.get(
+                    url,
+                    params={
+                        "interval": interval,
+                        "range": range_param,
+                        "includePrePost": "false",
+                        "events": "div,splits",
+                    },
+                    headers=self._REQUEST_HEADERS,
+                    timeout=self.timeout_seconds,
+                )
+                if response.status_code == 429:
+                    raise ValueError(f"HTTP 429 Too Many Requests from Yahoo for '{ticker}'.")
+                response.raise_for_status()
+                payload = response.json()
+                break
+            except Exception as exc:
+                last_error = exc
+                if attempt < self.max_retries and isinstance(exc, ValueError) and "429" in str(exc):
+                    time.sleep(self.retry_backoff_seconds * (2 ** (attempt - 1)))
+                    continue
+                if attempt >= self.max_retries:
+                    raise ValueError(f"Yahoo request failed for '{ticker}': {exc}") from exc
+                time.sleep(self.retry_backoff_seconds)
+                continue
 
         out = self._parse_payload(payload, symbol=ticker)
         if tf == "4h":

--- a/backend/app/services/opportunity_service.py
+++ b/backend/app/services/opportunity_service.py
@@ -13,6 +13,8 @@ from app.services.combo_service import ComboService
 from app.services.asset_classification import classify_asset_type
 from app.services.market_data_providers import (
     CCXT_SOURCE,
+    STOOQ_SOURCE,
+    YahooMarketDataProvider,
     get_market_data_provider,
     resolve_data_source_for_symbol,
 )
@@ -54,6 +56,21 @@ def _history_limit_for_timeframe(timeframe: str) -> int:
     if tf == "4h":
         return 320
     return 320
+
+
+def _normalize_market_timeframe(symbol: str, requested_timeframe: str, data_source: str) -> str:
+    tf = str(requested_timeframe or "1d").strip().lower()
+    if data_source == STOOQ_SOURCE and tf != "1d":
+        # US stocks/ETFs use only daily EOD candles in the current pipeline.
+        # Keep backward compatibility by coercing legacy intraday favorites to 1d,
+        # so monitor does not silently skip these strategies.
+        logger.warning(
+            "Coercing timeframe '%s' to '1d' for stooq symbol '%s' in monitor jobs",
+            tf,
+            symbol,
+        )
+        return "1d"
+    return tf
 
 
 def _read_ohlcv_cache(cache_key: str) -> Optional[pd.DataFrame]:
@@ -434,13 +451,14 @@ class OpportunityService:
             data_source = resolve_data_source_for_symbol(symbol, params.get("data_source"))
             if data_source == CCXT_SOURCE and _is_unsupported_symbol(symbol):
                 continue
-            cache_key = f"{data_source}:{symbol}_{tf}"
+            normalized_tf = _normalize_market_timeframe(symbol, tf, data_source)
+            cache_key = f"{data_source}:{symbol}_{normalized_tf}"
             if cache_key in unique_market_jobs:
                 continue
             unique_market_jobs[cache_key] = {
                 "data_source": data_source,
                 "symbol": symbol,
-                "timeframe": tf,
+                "timeframe": normalized_tf,
             }
 
         def _fetch_market_job(job: dict[str, Any]) -> tuple[str, pd.DataFrame]:
@@ -452,13 +470,31 @@ class OpportunityService:
             history_days = _history_days_for_timeframe(job["timeframe"])
             history_limit = _history_limit_for_timeframe(job["timeframe"])
             start_date = (datetime.now() - timedelta(days=history_days)).strftime("%Y-%m-%d")
+
             provider = get_market_data_provider(job["data_source"])
-            df = provider.fetch_ohlcv(
-                symbol=job["symbol"],
-                timeframe=job["timeframe"],
-                since_str=start_date,
-                limit=history_limit,
-            )
+            try:
+                df = provider.fetch_ohlcv(
+                    symbol=job["symbol"],
+                    timeframe=job["timeframe"],
+                    since_str=start_date,
+                    limit=history_limit,
+                )
+            except Exception as exc:
+                if job["data_source"] == STOOQ_SOURCE and job["timeframe"] == "1d":
+                    logger.warning(
+                        "Falling back to Yahoo for stock symbol '%s' after stooq error: %s",
+                        job["symbol"],
+                        exc,
+                    )
+                    df = YahooMarketDataProvider().fetch_ohlcv(
+                        symbol=job["symbol"],
+                        timeframe=job["timeframe"],
+                        since_str=start_date,
+                        limit=history_limit,
+                    )
+                else:
+                    raise
+
             _write_ohlcv_cache(cache_key, df)
             return cache_key, df
 
@@ -483,9 +519,10 @@ class OpportunityService:
                 template_name = fav["strategy_name"]
                 params = fav.get("parameters") or {}
                 data_source = resolve_data_source_for_symbol(symbol, params.get("data_source"))
+                normalized_tf = _normalize_market_timeframe(symbol, tf, data_source)
 
                 logger.debug(
-                    f"Processing strategy {fav['id']}: {symbol} {tf} - {template_name} (source={data_source})"
+                    f"Processing strategy {fav['id']}: {symbol} {normalized_tf} - {template_name} (source={data_source})"
                 )
 
                 # 0. Skip known unsupported symbols (delisted / no data) before fetching
@@ -494,14 +531,14 @@ class OpportunityService:
                         {
                             "id": fav["id"],
                             "symbol": symbol,
-                            "timeframe": tf,
+                            "timeframe": normalized_tf,
                             "reason": "Symbol delisted or not available on exchange (e.g. Binance leveraged tokens)",
                         }
                     )
                     continue
 
                 # 1. Fetch Data (1D usually)
-                cache_key = f"{data_source}:{symbol}_{tf}"
+                cache_key = f"{data_source}:{symbol}_{normalized_tf}"
                 if cache_key not in data_cache:
                     fetch_exc = fetch_errors.get(cache_key)
                     if fetch_exc:
@@ -509,7 +546,7 @@ class OpportunityService:
                             {
                                 "id": fav["id"],
                                 "symbol": symbol,
-                                "timeframe": tf,
+                                "timeframe": normalized_tf,
                                 "reason": f"Error fetching data ({data_source}): {fetch_exc}",
                             }
                         )
@@ -518,7 +555,7 @@ class OpportunityService:
                         {
                             "id": fav["id"],
                             "symbol": symbol,
-                            "timeframe": tf,
+                            "timeframe": normalized_tf,
                             "reason": f"No cached market data available for {cache_key}",
                         }
                     )
@@ -531,7 +568,7 @@ class OpportunityService:
                         {
                             "id": fav["id"],
                             "symbol": symbol,
-                            "timeframe": tf,
+                            "timeframe": normalized_tf,
                             "reason": "No data (symbol may be delisted, or cache/API issue)",
                         }
                     )
@@ -540,20 +577,20 @@ class OpportunityService:
                 # Heuristic: fix corrupted tail candles (open[t] != close[t-1]) so MAs match TradingView/Binance.
                 # This is especially important for the last closed candle used in distance calculations.
                 if data_source == CCXT_SOURCE:
-                    df = _apply_crypto_continuity_fix(df, tf)
+                    df = _apply_crypto_continuity_fix(df, normalized_tf)
 
                 # 2. Get Template Metadata from Database (entry_logic and exit_logic)
                 # This dynamically loads the buy/sell rules from combo_templates table
                 meta = self.combo_service.get_template_metadata(template_name)
                 if not meta:
                     logger.warning(
-                        f"Strategy {fav['id']} ({symbol} {tf}): Template '{template_name}' not found"
+                        f"Strategy {fav['id']} ({symbol} {normalized_tf}): Template '{template_name}' not found"
                     )
                     skipped_strategies.append(
                         {
                             "id": fav["id"],
                             "symbol": symbol,
-                            "timeframe": tf,
+                            "timeframe": normalized_tf,
                             "template_name": template_name,
                             "reason": f"Template '{template_name}' not found",
                         }
@@ -1241,7 +1278,7 @@ class OpportunityService:
                         "id": fav["id"],
                         "symbol": symbol,
                         "asset_type": classify_asset_type(symbol),
-                        "timeframe": tf,
+                        "timeframe": normalized_tf,
                         "template_name": template_name,
                         "name": fav["name"],  # User custom name
                         "notes": fav.get("notes"),

--- a/frontend/src/components/monitor/ChartModal.tsx
+++ b/frontend/src/components/monitor/ChartModal.tsx
@@ -13,7 +13,11 @@ import {
 } from 'lightweight-charts';
 
 import type { MarketCandle } from './MiniCandlesChart';
-import type { Opportunity, OpportunitySignalHistoryItem } from './types';
+import {
+    getOpportunityAssetType,
+    type Opportunity,
+    type OpportunitySignalHistoryItem,
+} from './types';
 import { CHART_TIMEFRAMES, fetchMarketCandles, type ChartTimeframe } from './chartData';
 import { resolveOpportunitySignal } from './signalResolution';
 
@@ -25,13 +29,12 @@ interface ChartModalProps {
     onClose: () => void;
 }
 
-type IndicatorKey = 'emaShort' | 'smaMedium' | 'smaLong' | 'rsi';
+type IndicatorKey = 'emaShort' | 'smaMedium' | 'smaLong';
 
 interface IndicatorState {
     emaShort: boolean;
     smaMedium: boolean;
     smaLong: boolean;
-    rsi: boolean;
 }
 
 interface TooltipSnapshot {
@@ -39,14 +42,12 @@ interface TooltipSnapshot {
     emaShort?: number;
     smaMedium?: number;
     smaLong?: number;
-    rsi?: number;
 }
 
 const DEFAULT_INDICATORS: IndicatorState = {
     emaShort: true,
     smaMedium: true,
     smaLong: true,
-    rsi: true,
 };
 const LOGICAL_RANGE_PADDING = 8;
 const MIN_VISIBLE_BARS = 12;
@@ -258,47 +259,6 @@ function calculateEma(candles: MarketCandle[], period: number): LineData<Time>[]
     return result;
 }
 
-function calculateRsi(candles: MarketCandle[], period: number): LineData<Time>[] {
-    if (candles.length <= period) {
-        return [];
-    }
-
-    let gains = 0;
-    let losses = 0;
-
-    for (let index = 1; index <= period; index += 1) {
-        const delta = candles[index].close - candles[index - 1].close;
-        gains += Math.max(delta, 0);
-        losses += Math.max(-delta, 0);
-    }
-
-    let avgGain = gains / period;
-    let avgLoss = losses / period;
-    const result: LineData<Time>[] = [];
-
-    const firstRs = avgLoss === 0 ? 100 : avgGain / avgLoss;
-    result.push({
-        time: toUtcTimestamp(candles[period].timestamp_utc),
-        value: 100 - 100 / (1 + firstRs),
-    });
-
-    for (let index = period + 1; index < candles.length; index += 1) {
-        const delta = candles[index].close - candles[index - 1].close;
-        const gain = Math.max(delta, 0);
-        const loss = Math.max(-delta, 0);
-        avgGain = ((avgGain * (period - 1)) + gain) / period;
-        avgLoss = ((avgLoss * (period - 1)) + loss) / period;
-        const rs = avgLoss === 0 ? 100 : avgGain / avgLoss;
-
-        result.push({
-            time: toUtcTimestamp(candles[index].timestamp_utc),
-            value: 100 - 100 / (1 + rs),
-        });
-    }
-
-    return result;
-}
-
 export const ChartModal: React.FC<ChartModalProps> = ({
     symbol,
     opportunity,
@@ -306,21 +266,27 @@ export const ChartModal: React.FC<ChartModalProps> = ({
     initialTimeframe,
     onClose,
 }) => {
-    const [timeframe, setTimeframe] = React.useState<ChartTimeframe>(initialTimeframe);
+    const isStock = getOpportunityAssetType(opportunity) === 'stock';
+    const enforcedTimeframe: ChartTimeframe = isStock ? '1d' : initialTimeframe;
+    const chartTimeframes = React.useMemo<ChartTimeframe[]>(
+        () => (isStock ? ['1d'] : CHART_TIMEFRAMES),
+        [isStock],
+    );
+
+    const [timeframe, setTimeframe] = React.useState<ChartTimeframe>(enforcedTimeframe);
     const [candles, setCandles] = React.useState<MarketCandle[]>(initialCandles);
     const [loading, setLoading] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
     const [visibleIndicators, setVisibleIndicators] = React.useState<IndicatorState>(DEFAULT_INDICATORS);
     const [tooltip, setTooltip] = React.useState<TooltipSnapshot | null>(null);
     const [visibleBarCount, setVisibleBarCount] = React.useState<number | null>(null);
+    const [chartMode, setChartMode] = React.useState<'compact' | 'algorithmic'>('algorithmic');
 
     const cacheRef = React.useRef<Map<string, MarketCandle[]>>(new Map([
-        [`${symbol}|${initialTimeframe}`, initialCandles],
+        [`${symbol}|${enforcedTimeframe}`, initialCandles],
     ]));
     const mainChartRef = React.useRef<HTMLDivElement>(null);
-    const rsiChartRef = React.useRef<HTMLDivElement>(null);
     const mainChartApiRef = React.useRef<IChartApi | null>(null);
-    const rsiChartApiRef = React.useRef<IChartApi | null>(null);
 
     const sortedCandles = React.useMemo(
         () => [...candles].sort((left, right) => Date.parse(left.timestamp_utc) - Date.parse(right.timestamp_utc)),
@@ -330,7 +296,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         emaShort: getNumericParameter(opportunity.parameters, ['ema_short', 'emaShort', 'sma_short', 'smaShort'], 9),
         smaMedium: getNumericParameter(opportunity.parameters, ['sma_medium', 'smaMedium', 'ema_medium', 'emaMedium'], 21),
         smaLong: getNumericParameter(opportunity.parameters, ['sma_long', 'smaLong', 'ema_long', 'emaLong'], 50),
-        rsi: getNumericParameter(opportunity.parameters, ['rsi_length', 'rsiLength', 'rsi_period', 'rsiPeriod'], 14),
     }), [opportunity.parameters]);
     const maColors = React.useMemo(() => getMAColorsByPeriod({
         emaShort: indicatorPeriods.emaShort,
@@ -341,7 +306,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         emaShort: `EMA ${indicatorPeriods.emaShort}`,
         smaMedium: `SMA ${indicatorPeriods.smaMedium}`,
         smaLong: `SMA ${indicatorPeriods.smaLong}`,
-        rsi: `RSI ${indicatorPeriods.rsi}`,
     }), [indicatorPeriods]);
 
     const candlestickData = React.useMemo(() => (
@@ -374,16 +338,10 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         () => calculateSma(sortedCandles, indicatorPeriods.smaLong),
         [indicatorPeriods.smaLong, sortedCandles],
     );
-    const rsiData = React.useMemo(
-        () => calculateRsi(sortedCandles, indicatorPeriods.rsi),
-        [indicatorPeriods.rsi, sortedCandles],
-    );
-
     const tooltipData = React.useMemo(() => {
         const emaShortMap = new Map<number, number>();
         const smaMediumMap = new Map<number, number>();
         const smaLongMap = new Map<number, number>();
-        const rsiMap = new Map<number, number>();
 
         emaShortData.forEach((point) => {
             if (typeof point.time === 'number') {
@@ -400,12 +358,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                 smaLongMap.set(point.time, point.value);
             }
         });
-        rsiData.forEach((point) => {
-            if (typeof point.time === 'number') {
-                rsiMap.set(point.time, point.value);
-            }
-        });
-
         return new Map<number, TooltipSnapshot>(
             sortedCandles.map((candle) => {
                 const time = toUtcTimestamp(candle.timestamp_utc);
@@ -416,18 +368,18 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                         emaShort: emaShortMap.get(time),
                         smaMedium: smaMediumMap.get(time),
                         smaLong: smaLongMap.get(time),
-                        rsi: rsiMap.get(time),
                     },
                 ];
             }),
         );
-    }, [emaShortData, rsiData, smaLongData, smaMediumData, sortedCandles]);
+    }, [emaShortData, smaLongData, smaMediumData, sortedCandles]);
 
     const latestCandle = sortedCandles[sortedCandles.length - 1] ?? null;
     const latestSnapshot = React.useMemo(
         () => (latestCandle ? tooltipData.get(toUtcTimestamp(latestCandle.timestamp_utc)) ?? null : null),
         [latestCandle, tooltipData],
     );
+    const isAlgorithmicChartMode = chartMode === 'algorithmic';
 
     const displaySnapshot = tooltip ?? latestSnapshot;
     const resolvedSignal = React.useMemo(
@@ -502,12 +454,10 @@ export const ChartModal: React.FC<ChartModalProps> = ({
 
     const resetZoom = () => {
         const mainChart = mainChartApiRef.current;
-        const rsiChart = rsiChartApiRef.current;
-        if (!mainChart || !rsiChart) {
+        if (!mainChart) {
             return;
         }
         mainChart.timeScale().fitContent();
-        rsiChart.timeScale().fitContent();
         syncVisibleBars(mainChart.timeScale().getVisibleLogicalRange());
     };
 
@@ -537,6 +487,16 @@ export const ChartModal: React.FC<ChartModalProps> = ({
     }, [onClose]);
 
     React.useEffect(() => {
+        if (isStock && timeframe !== '1d') {
+            setTimeframe('1d');
+            return;
+        }
+
+        if (!isStock && !CHART_TIMEFRAMES.includes(timeframe)) {
+            setTimeframe(enforcedTimeframe);
+            return;
+        }
+
         const cacheKey = `${symbol}|${timeframe}`;
         const cached = cacheRef.current.get(cacheKey);
         if (cached) {
@@ -571,10 +531,10 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         void run();
 
         return () => controller.abort();
-    }, [symbol, timeframe]);
+    }, [symbol, timeframe, isStock, enforcedTimeframe]);
 
     React.useEffect(() => {
-        if (!mainChartRef.current || !rsiChartRef.current || candlestickData.length === 0) {
+        if (!mainChartRef.current || candlestickData.length === 0) {
             return undefined;
         }
 
@@ -617,45 +577,7 @@ export const ChartModal: React.FC<ChartModalProps> = ({
             },
         });
 
-        const rsiChart = createChart(rsiChartRef.current, {
-            autoSize: true,
-            layout: {
-                background: { type: ColorType.Solid, color: '#0d1117' },
-                textColor: '#8b949e',
-            },
-            grid: {
-                vertLines: { color: 'rgba(48, 54, 61, 0.35)' },
-                horzLines: { color: 'rgba(48, 54, 61, 0.35)' },
-            },
-            rightPriceScale: {
-                borderColor: 'rgba(48, 54, 61, 0.85)',
-                scaleMargins: { top: 0.15, bottom: 0.15 },
-            },
-            timeScale: {
-                borderColor: 'rgba(48, 54, 61, 0.85)',
-                timeVisible: true,
-                secondsVisible: false,
-            },
-            crosshair: {
-                mode: CrosshairMode.Normal,
-                vertLine: { color: 'rgba(210, 153, 34, 0.35)', width: 1, labelBackgroundColor: '#161b22' },
-                horzLine: { color: 'rgba(210, 153, 34, 0.35)', width: 1, labelBackgroundColor: '#161b22' },
-            },
-            handleScroll: {
-                mouseWheel: true,
-                pressedMouseMove: true,
-                horzTouchDrag: true,
-                vertTouchDrag: true,
-            },
-            handleScale: {
-                mouseWheel: true,
-                pinch: true,
-                axisPressedMouseMove: true,
-                axisDoubleClickReset: true,
-            },
-        });
         mainChartApiRef.current = mainChart;
-        rsiChartApiRef.current = rsiChart;
 
         const candleSeries = mainChart.addCandlestickSeries({
             upColor: '#22c55e',
@@ -699,28 +621,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
             lastValueVisible: false,
         });
 
-        const rsiSeries = rsiChart.addLineSeries({
-            color: '#a371f7',
-            lineWidth: 2,
-            visible: visibleIndicators.rsi,
-            priceLineVisible: false,
-        });
-
-        const rsiUpper = rsiChart.addLineSeries({
-            color: 'rgba(248, 81, 73, 0.4)',
-            lineWidth: 1,
-            lineStyle: LineStyle.Dashed,
-            priceLineVisible: false,
-            lastValueVisible: false,
-        });
-        const rsiLower = rsiChart.addLineSeries({
-            color: 'rgba(34, 197, 94, 0.4)',
-            lineWidth: 1,
-            lineStyle: LineStyle.Dashed,
-            priceLineVisible: false,
-            lastValueVisible: false,
-        });
-
         candleSeries.setData(candlestickData);
         candleSeries.setMarkers(
             historicalSignalMarkers.length > 0
@@ -739,20 +639,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         emaShortSeries.setData(emaShortData);
         smaMediumSeries.setData(smaMediumData);
         smaLongSeries.setData(smaLongData);
-        rsiSeries.setData(rsiData);
-
-        if (rsiData.length > 0) {
-            const firstRsiTime = rsiData[0].time;
-            const lastRsiTime = rsiData[rsiData.length - 1].time;
-            rsiUpper.setData([
-                { time: firstRsiTime, value: 70 },
-                { time: lastRsiTime, value: 70 },
-            ]);
-            rsiLower.setData([
-                { time: firstRsiTime, value: 30 },
-                { time: lastRsiTime, value: 30 },
-            ]);
-        }
 
         if (opportunity.entry_price !== null && opportunity.entry_price !== undefined) {
             candleSeries.createPriceLine({
@@ -776,24 +662,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         }
 
         mainChart.timeScale().fitContent();
-        rsiChart.timeScale().fitContent();
-
-        let syncing = false;
-        const syncRange = (source: IChartApi, target: IChartApi) => {
-            const handler = (range: LogicalRange | null) => {
-                if (!range || syncing) {
-                    return;
-                }
-                syncing = true;
-                target.timeScale().setVisibleLogicalRange(range);
-                syncing = false;
-            };
-            source.timeScale().subscribeVisibleLogicalRangeChange(handler);
-            return handler;
-        };
-
-        const mainRangeHandler = syncRange(mainChart, rsiChart);
-        const rsiRangeHandler = syncRange(rsiChart, mainChart);
         const onVisibleRangeChange = (range: LogicalRange | null) => {
             syncVisibleBars(range);
         };
@@ -811,24 +679,17 @@ export const ChartModal: React.FC<ChartModalProps> = ({
 
         const onResize = () => {
             mainChart.applyOptions({ width: mainChartRef.current?.clientWidth ?? 0 });
-            rsiChart.applyOptions({ width: rsiChartRef.current?.clientWidth ?? 0 });
         };
         window.addEventListener('resize', onResize);
 
         return () => {
             window.removeEventListener('resize', onResize);
             mainChart.unsubscribeCrosshairMove(onCrosshairMove);
-            mainChart.timeScale().unsubscribeVisibleLogicalRangeChange(mainRangeHandler);
             mainChart.timeScale().unsubscribeVisibleLogicalRangeChange(onVisibleRangeChange);
-            rsiChart.timeScale().unsubscribeVisibleLogicalRangeChange(rsiRangeHandler);
             if (mainChartApiRef.current === mainChart) {
                 mainChartApiRef.current = null;
             }
-            if (rsiChartApiRef.current === rsiChart) {
-                rsiChartApiRef.current = null;
-            }
             mainChart.remove();
-            rsiChart.remove();
         };
     }, [
         candlestickData,
@@ -845,13 +706,11 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         resolvedSignal.visual.markerColor,
         resolvedSignal.visual.markerPosition,
         resolvedSignal.visual.markerShape,
-        rsiData,
         signalLabel,
         smaLongData,
         smaMediumData,
         tooltipData,
         visibleIndicators.emaShort,
-        visibleIndicators.rsi,
         visibleIndicators.smaLong,
         visibleIndicators.smaMedium,
         volumeData,
@@ -885,22 +744,12 @@ export const ChartModal: React.FC<ChartModalProps> = ({
             ),
             color: maColors.smaLong,
         },
-        {
-            label: indicatorLabels.rsi,
-            value: getIndicatorValue(
-                opportunity.indicator_values,
-                [`rsi_${indicatorPeriods.rsi}`, `rsi${indicatorPeriods.rsi}`, 'rsi_14', 'rsi14'],
-                latestSnapshot?.rsi,
-            ),
-            color: '#a371f7',
-        },
     ];
 
     const indicatorToggleStyles: Record<IndicatorKey, string> = React.useMemo(() => ({
         emaShort: maColors.emaShort,
         smaMedium: maColors.smaMedium,
         smaLong: maColors.smaLong,
-        rsi: '#c297ff',
     }), [maColors.emaShort, maColors.smaMedium, maColors.smaLong]);
 
     return (
@@ -914,7 +763,7 @@ export const ChartModal: React.FC<ChartModalProps> = ({
             data-testid="chart-modal-backdrop"
         >
             <div
-                className="mx-auto flex h-full max-h-[860px] w-full max-w-[1440px] flex-col overflow-hidden rounded-2xl border border-[#30363d] bg-[#0d1117] shadow-[0_20px_60px_rgba(0,0,0,0.55)]"
+                className="mx-auto flex h-full max-h-[98vh] w-full max-w-[min(98vw,1680px)] flex-col overflow-hidden rounded-2xl border border-[#30363d] bg-[#0d1117] shadow-[0_20px_60px_rgba(0,0,0,0.55)]"
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="chart-modal-title"
@@ -957,7 +806,7 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                     <div className="flex min-h-0 flex-1 flex-col border-b border-[#30363d] lg:border-b-0 lg:border-r">
                         <div className="flex flex-wrap items-center gap-2 border-b border-[#30363d] px-5 py-3">
                             <div className="flex items-center gap-2" role="group" aria-label="Chart timeframe selector">
-                                {CHART_TIMEFRAMES.map((item) => {
+                                {chartTimeframes.map((item) => {
                                     const active = item === timeframe;
                                     return (
                                         <button
@@ -1029,12 +878,38 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                                     Mouse wheel: zoom
                                 </span>
                             </div>
+                            <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[#1f6feb]/45 bg-[linear-gradient(135deg,rgba(31,111,235,0.18),rgba(9,105,218,0.06))] px-3 py-2">
+                                <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#79c0ff]">
+                                    Layout
+                                </span>
+                                <button
+                                    type="button"
+                                    className={`inline-flex h-10 items-center gap-2 rounded-lg border px-3 text-sm font-semibold transition ${
+                                        chartMode === 'compact'
+                                            ? 'border-[#4c8dff] bg-[#0f2747] text-[#dbeafe]'
+                                            : 'border-[#30363d] bg-[#0f2747]/55 text-[#8b949e]'
+                                    }`}
+                                    onClick={() => setChartMode('compact')}
+                                >
+                                    Compacto
+                                </button>
+                                <button
+                                    type="button"
+                                    className={`inline-flex h-10 items-center gap-2 rounded-lg border px-3 text-sm font-semibold transition ${
+                                        chartMode === 'algorithmic'
+                                            ? 'border-[#4c8dff] bg-[#0f2747] text-[#dbeafe]'
+                                            : 'border-[#30363d] bg-[#0f2747]/55 text-[#8b949e]'
+                                    }`}
+                                    onClick={() => setChartMode('algorithmic')}
+                                >
+                                    Algorítmica
+                                </button>
+                            </div>
                             <div className="ml-auto flex flex-wrap items-center gap-2" role="group" aria-label="Chart indicators">
                                 {[
                                     { key: 'emaShort', label: indicatorLabels.emaShort },
                                     { key: 'smaMedium', label: indicatorLabels.smaMedium },
                                     { key: 'smaLong', label: indicatorLabels.smaLong },
-                                    { key: 'rsi', label: indicatorLabels.rsi },
                                 ].map((indicator) => {
                                     const active = visibleIndicators[indicator.key as IndicatorKey];
                                     return (
@@ -1061,21 +936,30 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                             </div>
                         </div>
 
-                        <div className="relative flex min-h-0 flex-1 flex-col gap-3 p-4">
+                        <div className={`relative flex min-h-0 flex-1 flex-col gap-3 p-4 ${isAlgorithmicChartMode ? 'pb-5' : ''}`}>
                             {error ? (
                                 <div className="rounded-xl border border-[#f85149]/40 bg-[#f85149]/10 px-4 py-3 text-sm text-[#ffb1ac]">
                                     {error}
                                 </div>
                             ) : null}
 
-                            <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_280px]">
+                            <div className={`grid gap-3 ${isAlgorithmicChartMode ? 'grid-cols-1' : 'xl:grid-cols-[minmax(0,1fr)_280px]'}`}>
                                 <div className="min-w-0 space-y-3">
                                     <div
-                                        className="relative rounded-2xl border border-[#30363d] bg-[#0b1118] p-2"
+                                        className={`relative rounded-2xl border border-[#30363d] bg-[#0b1118] p-2 ${isAlgorithmicChartMode ? 'min-h-0 flex-1' : ''}`}
                                         onWheel={handleChartWheel}
                                         data-testid="chart-modal-main-chart-shell"
                                     >
-                                        <div ref={mainChartRef} className="h-[420px] w-full" data-testid="chart-modal-main-chart" />
+                                        <div
+                                            ref={mainChartRef}
+                                            className="w-full h-full"
+                                            style={
+                                                isAlgorithmicChartMode
+                                                    ? { minHeight: '520px', height: 'min(82vh, calc(100vh - 250px))' }
+                                                    : undefined
+                                            }
+                                            data-testid="chart-modal-main-chart"
+                                        />
                                         <div className="pointer-events-none absolute left-4 top-4 rounded-full border border-[#79c0ff]/25 bg-[#0d1117]/86 px-3 py-1 text-[11px] font-medium text-[#c9e6ff]">
                                             Scroll to zoom
                                         </div>
@@ -1085,189 +969,184 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                                             </div>
                                         ) : null}
                                     </div>
-                                    <div
-                                        className="rounded-2xl border border-[#30363d] bg-[#0b1118] p-2"
-                                        onWheel={handleChartWheel}
-                                        data-testid="chart-modal-rsi-chart-shell"
-                                    >
-                                        <div ref={rsiChartRef} className="h-[140px] w-full" data-testid="chart-modal-rsi-chart" />
-                                    </div>
                                 </div>
 
-                                <div className="rounded-2xl border border-[#30363d] bg-[#11161d] p-4 text-sm text-[#c9d1d9]">
-                                    <div className="space-y-5">
-                                        <section>
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Signal Context</p>
-                                            <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Resolved state</span>
-                                                    <span className="font-mono text-[#e6edf3]">{resolvedSignal.visual.badgeText}</span>
+                                {isAlgorithmicChartMode ? null : (
+                                    <div className="rounded-2xl border border-[#30363d] bg-[#11161d] p-4 text-sm text-[#c9d1d9]">
+                                        <div className="space-y-5">
+                                            <section>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Signal Context</p>
+                                                <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Resolved state</span>
+                                                        <span className="font-mono text-[#e6edf3]">{resolvedSignal.visual.badgeText}</span>
+                                                    </div>
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Strategy timeframe</span>
+                                                        <span className="font-mono text-[#e6edf3]">{resolvedSignal.strategyTimeframe ?? '-'}</span>
+                                                    </div>
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Displayed timeframe</span>
+                                                        <span className="font-mono text-[#e6edf3]">{resolvedSignal.displayTimeframe ?? '-'}</span>
+                                                    </div>
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Reference candle</span>
+                                                        <span className="font-mono text-[#e6edf3]">{formatTimestamp(resolvedSignal.referenceCandleTime)}</span>
+                                                    </div>
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Latest displayed candle</span>
+                                                        <span className="font-mono text-[#e6edf3]">{formatTimestamp(resolvedSignal.latestCandleTime)}</span>
+                                                    </div>
+                                                    <div className="rounded-lg border border-[#30363d] bg-[#11161d] px-3 py-2 text-xs text-[#c9d1d9]">
+                                                        {resolvedSignal.statusMessage}
+                                                        {resolvedSignal.freshnessReason ? ` ${resolvedSignal.freshnessReason}` : ''}
+                                                    </div>
                                                 </div>
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Strategy timeframe</span>
-                                                    <span className="font-mono text-[#e6edf3]">{resolvedSignal.strategyTimeframe ?? '-'}</span>
-                                                </div>
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Displayed timeframe</span>
-                                                    <span className="font-mono text-[#e6edf3]">{resolvedSignal.displayTimeframe ?? '-'}</span>
-                                                </div>
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Reference candle</span>
-                                                    <span className="font-mono text-[#e6edf3]">{formatTimestamp(resolvedSignal.referenceCandleTime)}</span>
-                                                </div>
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Latest displayed candle</span>
-                                                    <span className="font-mono text-[#e6edf3]">{formatTimestamp(resolvedSignal.latestCandleTime)}</span>
-                                                </div>
-                                                <div className="rounded-lg border border-[#30363d] bg-[#11161d] px-3 py-2 text-xs text-[#c9d1d9]">
-                                                    {resolvedSignal.statusMessage}
-                                                    {resolvedSignal.freshnessReason ? ` ${resolvedSignal.freshnessReason}` : ''}
-                                                </div>
-                                            </div>
-                                        </section>
+                                            </section>
 
-                                        <section>
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Crosshair</p>
-                                            <div className="mt-2 grid grid-cols-2 gap-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                <div>
-                                                    <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Time</p>
-                                                    <p className="font-mono text-sm text-[#e6edf3]">{formatTimestamp(displaySnapshot?.candle.timestamp_utc)}</p>
+                                            <section>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Crosshair</p>
+                                                <div className="mt-2 grid grid-cols-2 gap-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    <div>
+                                                        <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Time</p>
+                                                        <p className="font-mono text-sm text-[#e6edf3]">{formatTimestamp(displaySnapshot?.candle.timestamp_utc)}</p>
+                                                    </div>
+                                                    <div>
+                                                        <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Volume</p>
+                                                        <p className="font-mono text-sm text-[#e6edf3]">
+                                                            {displaySnapshot?.candle.volume?.toLocaleString('en-US') ?? '-'}
+                                                        </p>
+                                                    </div>
+                                                    <div>
+                                                        <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Open</p>
+                                                        <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.open)}</p>
+                                                    </div>
+                                                    <div>
+                                                        <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">High</p>
+                                                        <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.high)}</p>
+                                                    </div>
+                                                    <div>
+                                                        <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Low</p>
+                                                        <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.low)}</p>
+                                                    </div>
+                                                    <div>
+                                                        <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Close</p>
+                                                        <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.close)}</p>
+                                                    </div>
                                                 </div>
-                                                <div>
-                                                    <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Volume</p>
-                                                    <p className="font-mono text-sm text-[#e6edf3]">
-                                                        {displaySnapshot?.candle.volume?.toLocaleString('en-US') ?? '-'}
+                                            </section>
+
+                                            <section>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Distance</p>
+                                                <div className="mt-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">To {resolvedSignal.visual.markerLabel.toLowerCase()}</p>
+                                                    <p className={`font-mono text-lg font-semibold ${
+                                                        (opportunity.distance_to_next_status ?? 999) < 0.5 ? 'text-[#3fb950]' : 'text-[#e6edf3]'
+                                                    }`}>
+                                                        {formatPercent(opportunity.distance_to_next_status)}
                                                     </p>
                                                 </div>
-                                                <div>
-                                                    <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Open</p>
-                                                    <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.open)}</p>
-                                                </div>
-                                                <div>
-                                                    <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">High</p>
-                                                    <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.high)}</p>
-                                                </div>
-                                                <div>
-                                                    <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Low</p>
-                                                    <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.low)}</p>
-                                                </div>
-                                                <div>
-                                                    <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">Close</p>
-                                                    <p className="font-mono text-sm text-[#e6edf3]">{formatPrice(displaySnapshot?.candle.close)}</p>
-                                                </div>
-                                            </div>
-                                        </section>
+                                            </section>
 
-                                        <section>
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Distance</p>
-                                            <div className="mt-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                <p className="text-[11px] uppercase tracking-wide text-[#8b949e]">To {resolvedSignal.visual.markerLabel.toLowerCase()}</p>
-                                                <p className={`font-mono text-lg font-semibold ${
-                                                    (opportunity.distance_to_next_status ?? 999) < 0.5 ? 'text-[#3fb950]' : 'text-[#e6edf3]'
-                                                }`}>
-                                                    {formatPercent(opportunity.distance_to_next_status)}
-                                                </p>
-                                            </div>
-                                        </section>
+                                            <section>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Risk / Stop</p>
+                                                <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Entry</span>
+                                                        <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.entry_price)}</span>
+                                                    </div>
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Stop</span>
+                                                        <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.stop_price)}</span>
+                                                    </div>
+                                                    <div className="flex justify-between gap-3">
+                                                        <span className="text-[#8b949e]">Risk</span>
+                                                        <span className="font-mono text-[#f85149]">{formatPercent(opportunity.distance_to_stop_pct)}</span>
+                                                    </div>
+                                                </div>
+                                            </section>
 
-                                        <section>
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Risk / Stop</p>
-                                            <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Entry</span>
-                                                    <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.entry_price)}</span>
+                                            <section>
+                                                <div className="flex items-center justify-between gap-3">
+                                                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Signal History</p>
+                                                    <span className="text-[11px] text-[#8b949e]">
+                                                        {canRenderSignalHistoryMarkers
+                                                            ? 'Markers aligned with chart timeframe.'
+                                                            : 'Markers hidden: chart timeframe differs from strategy timeframe.'}
+                                                    </span>
                                                 </div>
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Stop</span>
-                                                    <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.stop_price)}</span>
-                                                </div>
-                                                <div className="flex justify-between gap-3">
-                                                    <span className="text-[#8b949e]">Risk</span>
-                                                    <span className="font-mono text-[#f85149]">{formatPercent(opportunity.distance_to_stop_pct)}</span>
-                                                </div>
-                                            </div>
-                                        </section>
-
-                                        <section>
-                                            <div className="flex items-center justify-between gap-3">
-                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Signal History</p>
-                                                <span className="text-[11px] text-[#8b949e]">
-                                                    {canRenderSignalHistoryMarkers
-                                                        ? 'Markers aligned with chart timeframe.'
-                                                        : 'Markers hidden: chart timeframe differs from strategy timeframe.'}
-                                                </span>
-                                            </div>
-                                            <div className="mt-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                {signalHistory.length > 0 ? (
-                                                    <div className="space-y-2" data-testid="chart-modal-signal-history">
-                                                        {signalHistory.map((item, index) => {
-                                                            const marker = getSignalHistoryMarker(item);
-                                                            return (
-                                                                <div
-                                                                    key={`${item.timestamp}-${item.type}-${index}`}
-                                                                    className="flex items-start justify-between gap-3 rounded-lg border border-[#30363d] bg-[#11161d] px-3 py-2"
-                                                                    data-testid={`chart-modal-signal-history-item-${index}`}
-                                                                >
-                                                                    <div className="space-y-1">
-                                                                        <div className="flex items-center gap-2">
-                                                                            <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: marker.color }} />
-                                                                            <span className="font-mono text-sm text-[#e6edf3]">{getSignalHistoryLabel(item)}</span>
-                                                                            <span className="text-xs text-[#8b949e]">{formatSignalReason(item.reason)}</span>
+                                                <div className="mt-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    {signalHistory.length > 0 ? (
+                                                        <div className="space-y-2" data-testid="chart-modal-signal-history">
+                                                            {signalHistory.map((item, index) => {
+                                                                const marker = getSignalHistoryMarker(item);
+                                                                return (
+                                                                    <div
+                                                                        key={`${item.timestamp}-${item.type}-${index}`}
+                                                                        className="flex items-start justify-between gap-3 rounded-lg border border-[#30363d] bg-[#11161d] px-3 py-2"
+                                                                        data-testid={`chart-modal-signal-history-item-${index}`}
+                                                                    >
+                                                                        <div className="space-y-1">
+                                                                            <div className="flex items-center gap-2">
+                                                                                <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: marker.color }} />
+                                                                                <span className="font-mono text-sm text-[#e6edf3]">{getSignalHistoryLabel(item)}</span>
+                                                                                <span className="text-xs text-[#8b949e]">{formatSignalReason(item.reason)}</span>
+                                                                            </div>
+                                                                            <p className="text-xs text-[#8b949e]">{formatTimestamp(item.timestamp)}</p>
                                                                         </div>
-                                                                        <p className="text-xs text-[#8b949e]">{formatTimestamp(item.timestamp)}</p>
+                                                                        <span className="font-mono text-sm text-[#e6edf3]">{formatPrice(item.price)}</span>
                                                                     </div>
-                                                                    <span className="font-mono text-sm text-[#e6edf3]">{formatPrice(item.price)}</span>
-                                                                </div>
-                                                            );
-                                                        })}
-                                                    </div>
-                                                ) : (
-                                                    <p className="text-[#8b949e]">No confirmed entry/exit history available for this strategy.</p>
-                                                )}
-                                            </div>
-                                        </section>
-
-                                        <section>
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Parameters</p>
-                                            <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                {opportunity.parameters && Object.keys(opportunity.parameters).length > 0 ? (
-                                                    Object.entries(opportunity.parameters).map(([key, value]) => (
-                                                        <div key={key} className="flex justify-between gap-3">
-                                                            <span className="text-[#8b949e]">{key}</span>
-                                                            <span className="font-mono text-[#e6edf3]">{String(value)}</span>
+                                                                );
+                                                            })}
                                                         </div>
-                                                    ))
-                                                ) : (
-                                                    <p className="text-[#8b949e]">No parameters available.</p>
-                                                )}
-                                            </div>
-                                        </section>
+                                                    ) : (
+                                                        <p className="text-[#8b949e]">No confirmed entry/exit history available for this strategy.</p>
+                                                    )}
+                                                </div>
+                                            </section>
 
-                                        <section>
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Indicators</p>
-                                            <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                {sidebarIndicators.map((item) => (
-                                                    <div key={item.label} className="flex items-center justify-between gap-3">
-                                                        <div className="flex items-center gap-2">
-                                                            <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: item.color }} />
-                                                            <span className="text-[#8b949e]">{item.label}</span>
+                                            <section>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Parameters</p>
+                                                <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    {opportunity.parameters && Object.keys(opportunity.parameters).length > 0 ? (
+                                                        Object.entries(opportunity.parameters).map(([key, value]) => (
+                                                            <div key={key} className="flex justify-between gap-3">
+                                                                <span className="text-[#8b949e]">{key}</span>
+                                                                <span className="font-mono text-[#e6edf3]">{String(value)}</span>
+                                                            </div>
+                                                        ))
+                                                    ) : (
+                                                        <p className="text-[#8b949e]">No parameters available.</p>
+                                                    )}
+                                                </div>
+                                            </section>
+
+                                            <section>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Indicators</p>
+                                                <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    {sidebarIndicators.map((item) => (
+                                                        <div key={item.label} className="flex items-center justify-between gap-3">
+                                                            <div className="flex items-center gap-2">
+                                                                <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: item.color }} />
+                                                                <span className="text-[#8b949e]">{item.label}</span>
+                                                            </div>
+                                                            <span className="font-mono text-[#e6edf3]">{formatIndicator(item.value)}</span>
                                                         </div>
-                                                        <span className="font-mono text-[#e6edf3]">{formatIndicator(item.value)}</span>
-                                                    </div>
-                                                ))}
-                                            </div>
-                                        </section>
+                                                    ))}
+                                                </div>
+                                            </section>
 
-                                        <section>
-                                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Notes</p>
-                                            <div className="mt-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                <p className="whitespace-pre-wrap text-sm text-[#c9d1d9]">
-                                                    {opportunity.notes?.trim() ? opportunity.notes : 'No notes for this strategy.'}
-                                                </p>
-                                            </div>
-                                        </section>
+                                            <section>
+                                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Notes</p>
+                                                <div className="mt-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                    <p className="whitespace-pre-wrap text-sm text-[#c9d1d9]">
+                                                        {opportunity.notes?.trim() ? opportunity.notes : 'No notes for this strategy.'}
+                                                    </p>
+                                                </div>
+                                            </section>
+                                        </div>
                                     </div>
-                                </div>
+                                )}
                             </div>
                         </div>
 
@@ -1278,7 +1157,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                                 <span className="inline-flex items-center gap-2"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: maColors.emaShort }} /> {indicatorLabels.emaShort}</span>
                                 <span className="inline-flex items-center gap-2"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: maColors.smaMedium }} /> {indicatorLabels.smaMedium}</span>
                                 <span className="inline-flex items-center gap-2"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: maColors.smaLong }} /> {indicatorLabels.smaLong}</span>
-                                <span className="inline-flex items-center gap-2"><span className="h-2 w-2 rounded-full bg-[#a371f7]" /> {indicatorLabels.rsi}</span>
                                 <span className="inline-flex items-center gap-2"><span className="h-2 w-2 rounded-full bg-[#3fb950]" /> Buy</span>
                                 <span className="inline-flex items-center gap-2"><span className="h-2 w-2 rounded-full bg-[#f85149]" /> Sell</span>
                             </div>

--- a/frontend/src/components/monitor/MonitorDashboardTab.tsx
+++ b/frontend/src/components/monitor/MonitorDashboardTab.tsx
@@ -66,6 +66,13 @@ export function MonitorDashboardTab() {
   }, [selectedSymbol, symbols])
 
   useEffect(() => {
+    const selectedMeta = symbols.find((item) => item.symbol === selectedSymbol);
+    if (selectedMeta?.assetType === 'stock' && timeframe !== '1d') {
+      setTimeframe('1d')
+    }
+  }, [selectedSymbol, symbols, timeframe])
+
+  useEffect(() => {
     const controller = new AbortController()
     const run = async () => {
       setFavoritesLoading(true)

--- a/frontend/src/components/monitor/MonitorStatusTab.tsx
+++ b/frontend/src/components/monitor/MonitorStatusTab.tsx
@@ -277,9 +277,11 @@ export const MonitorStatusTab: React.FC = () => {
     };
 
     const handleOpenChart = async (opportunity: Opportunity) => {
-        const initialTimeframe = toChartTimeframe(
+        const isStock = getOpportunityAssetType(opportunity) === 'stock';
+        const requestedTimeframe = toChartTimeframe(
             getPreference(opportunity.symbol).price_timeframe || opportunity.timeframe,
         );
+        const initialTimeframe: ChartTimeframe = isStock ? '1d' : requestedTimeframe;
 
         setOpeningChartSymbol(opportunity.symbol);
 


### PR DESCRIPTION
## O que foi alterado

- Expandir o modal do monitor para aproveitar mais área da tela.
- Ajustar o modal para manter mais espaço no modo Algorítmico e ocultar o painel lateral nesse modo.
- Corrigir estrutura de JSX que quebrava o build no ChartModal.
- Remover/evitar o RSI do fluxo de gráfico maximizado.
- Melhorar atualização de candles de ações (1D): detectar dados desatualizados e fazer fallback para Yahoo quando necessário.

## Arquivos alterados

- backend/app/api.py
- backend/app/services/market_data_providers.py
- backend/app/services/opportunity_service.py
- frontend/src/components/monitor/ChartModal.tsx
- frontend/src/components/monitor/MonitorDashboardTab.tsx
- frontend/src/components/monitor/MonitorStatusTab.tsx

## Contexto

- Branch: fix/monitor-layout-algorithmic
- Commit: 657b2d4