### PR TITLE
chore: sync AGENTS workflow flow to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,24 @@
-# AGENTS.md — Guia rápido para operação local neste repo
+# AGENTS.md — Guia rápido para agentes (e humanos) neste repo
 
-Este arquivo organiza o fluxo de trabalho para evitar retrabalho e manter padrão operacional no repo.
+Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
 
 ## TL;DR
 
 - **Branch padrão:** trabalhe em `develop` para trabalho diário de implementação e validações.
 - **Fluxo de produção:** implemente em `develop`, valide e abra PR `develop -> main` para promoção.
-- **Política de branching:** sem branchs de feature; trabalhe em `develop` e promova para `main` apenas via PR.
 - **Referência operacional:** `docs/workflow-criar-funcionalidade.md`.
-- `docs/workflow-criar-funcionalidade.md` define onde registrar decisão e evidência por change (via PR e resumo no chat).
 - OpenSpec é a camada de especificação técnico (artifacts).
 - Workflow DB e `docs/coordination/*.md` são fontes de operação e evidência.
 
 ## Regras de operação
 
 - Fluxo único (sem divisão por agentes): você conduz descoberta, planejamento, implementação, validação e fechamento.
-- Trabalhe sempre em `develop` para mudanças de implementação e use PR `develop -> main` para homologação.
 - Registre em `docs/workflow-criar-funcionalidade.md` e no PR:
   - status atual
   - decisões de escopo
   - evidências de teste/PR
 - Para promover produção, trabalhe em `develop` e abra PR de `develop -> main`.
+
 ## Como rodar (VPS / dev)
 
 ### Backend (FastAPI)
@@ -62,22 +60,82 @@ npm --prefix frontend run build
 - Frontend: `frontend/README.md`
 - Workflow OpenSpec/Codex: `docs/os_codex_workflow.md`
 
-## Convenções de UI/UX
+## Convenções de UI/UX (Lab)
 
-- **Upstream** deve ser uma conversa fluida (Humano ↔ Trader) para clarificar inputs, limites e risco.
+- **Upstream** deve ser uma conversa fluida (Humano ↔ Trader) para clarificar inputs/constraints/risco.
 - O label "validator" na UI/copy deve aparecer como **Trader**.
 
-## Regras de operação
+## Agentes e responsabilidades
 
-- Fluxo único (sem divisão por agentes): você conduz descoberta, planejamento, implementação, validação e fechamento.
-- Registre em `docs/workflow-criar-funcionalidade.md` e no PR:
-  - status atual
-  - decisões de escopo
-  - evidências de teste/PR
-- Para promover produção, trabalhe em `main` e abra PR de revisão se quiser validação externa.
+O time é composto por 5 agentes, cada um com papel definido:
 
-## Ferramentas
+### main — Project Manager / Team Leader
+**Template base:** Orion (productivity)
 
-- **QA UI/browser:** preferir Microsoft Playwright CLI (`playwright-cli`) em vez de MCP.
-- Para interfaces com evidência visual, usar `/usr/local/bin/playwright-cli-headed` no fluxo de captura.
-- Use `skills/playwright-cli-official/` e `skills/interface-design-codex/` como referência.
+Orquestra o time, coordena workflow, delegation, status reports, prazos.
+- Mantém conversa com Alan curta/gerencial
+- Consulta workflow DB e `docs/coordination/*.md` como fonte principal
+- Move status de mudança no workflow, celebra marcos, identifica riscos proativamente
+- Fornece próximo passo após completar tarefa
+- Pede clarifying questions quando necessário
+- Dá estimates de tempo quando possível
+
+### PO — Product Manager
+Define especificações, gerencia backlog, Requirements, escopo do produto.
+- Define taxonomia de work items (`change`, `story`, `bug`) e dependências
+- É dono dos artefatos OpenSpec da change: `proposal.md`, `specs/**`, `design.md`, `tasks.md` e `review-ptbr.md`
+- Só libera DEV depois de approval
+- **Quando não há change ativa (todas arquivadas), o PO deve puxar a change de maior prioridade no status `Pending` para iniciar planejamento no próximo turno.**
+
+### DESIGN — UX/UI Researcher
+**Template base:** UX Researcher (creative)
+
+Foca em UX/prototipação e pesquisa de usuário.
+- Publica protótipos e decisões visuais na seção de handoff da change
+- Complementa a planning package com protótipo visual e decisões de UX para DEV/QA
+- Desenha pesquisas de usuário e scripts de entrevista
+- Analisa feedback de usuários (tickets, reviews, pesquisas)
+- Identifica problemas de usabilidade
+- Gera relatórios com recomendações baseadas em evidências
+
+### DEV — Software Engineer + Code Reviewer
+**Template base:** Lens (development)
+
+Implementa código +レビュー automática.
+- Implementa com base no workflow DB + notas de handoff como runtime
+- Respeita taxonomia `change`/`story`/`bug`, ownership, locks e dependências
+- Faz code review: bugs, security issues, logic errors
+- Scaneia vulnerabilidades (SQL injection, XSS, hardcoded secrets)
+- Avalia qualidade (A-F), sugere melhorias
+
+### QA — Tester + Bug Hunter
+**Template base:** Trace (development)
+
+Valida + análise profunda de bugs.
+- Valida regressões, consistência do workflow DB e critérios de aceite
+- Bugs reais viram `bug` rastreável; bugs filhos bloqueiam story
+- Análise de erro: parse stack traces, identifica root cause vs symptoms
+- Fornece steps de debug em ordem de probabilidade
+- Cria bug reports com steps de reprodução e severidade
+
+### Regras operacionais dos agentes
+- O **workflow DB** é a fonte operacional de verdade.
+- **OpenSpec** define artefatos e a trilha técnica.
+- **`docs/coordination/*.md`** é o registro operacional vivo de handoff, evidências e status textual.
+- `docs/coordination/<change>.md` é o canal padrão entre agentes, com menções `@PO`, `@DESIGN`, `@DEV`, `@QA`, `@Alan`.
+- Nenhum agente (PO/DESIGN/DEV/QA) pode considerar sua etapa concluída só com artefatos; é obrigatório atualizar o runtime e registrar handoff no mesmo turno.
+- Toda etapa só fecha de verdade com **runtime + handoff registrado**; se um dos dois faltar, o próximo turno deve reconciliar antes de seguir.
+- O contrato operacional curto (papéis, handoff, DoD por status, bloqueios) fica consolidado em `docs/multiagent-operating-playbook.md`.
+- Quando Alan homologar uma change em chat, o orquestrador deve fechar e arquivar no mesmo turno (runtime + OpenSpec + handoff), sem pendência operacional.
+- `change` é o container raiz da entrega; `story` é a fatia padrão de execução quando houver ownership/dependência própria; `bug` representa defeito real. Não criar cards separados para micro-passos sem necessidade operacional.
+- Múltiplas stories/agentes podem trabalhar em paralelo, desde que respeitem **locks**, **dependências** e **WIP**.
+- Regra prática de WIP: por padrão, no máximo **2 stories ativas por change** e **1 story ativa por agent run**.
+- **Regra de auto-trigger:** Quando o status da change avança no runtime, o agente responsável pela nova etapa deve ser acionado. Ex: status vira PO → acionar PO; vira DEV → acionar DEV; vira QA → acionar QA.
+- **Regra de validação QA:** Antes de enviar para homologação Alan, QA deve rodar o checklist de validação UI (`docs/qa-ui-checklist.md`) e testes E2E (`frontend/tests/*.spec.ts`).
+- Lock padrão fica no nível da **story**; bug filho herda esse lock salvo reassignment explícito.
+- Uma **story** só pode ser fechada quando todos os **bugs filhos** estiverem concluídos.
+- Antes de promover para `QA`, `Homologation` ou `Archived`, reconciliar runtime + `docs/coordination/<change>.md` + `tasks.md` + handoff; para archive, preferir `scripts/archive_change_safe.sh`.
+
+## Engenharia de prompt
+
+Se for necessário mudar o tom de um agente (ex: deixar o design mais exploratório ou o DEV mais cauteloso), primeiro atualiza este arquivo com o novo prompt/personalidade e registra no `docs/coordination/<change>.md` do fluxo ativo. Nunca altere agentes apenas via jobs sem documentar aqui.


### PR DESCRIPTION
Sincroniza AGENTS.md com o fluxo acordado e finaliza ajuste pendente: trabalho em main/desenvolvimento sem branches extras, com PR para promoção. Sem mudanças funcionais.