### PR TITLE
feat: add admin backfill job monitoring and scheduler

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.routes.user_credentials import router as user_credentials_router
 from app.routes.system_preferences import router as system_preferences_router
 from app.routes.retrospectives import router as retrospectives_router
 from app.routes.admin_users import router as admin_users_router
+from app.routes.admin_backfill import router as admin_backfill_router
 from app.services.signal_monitor import signal_monitor
 from app.services.binance_service import (
     start_signal_feed_snapshot_worker,
@@ -49,6 +50,7 @@ from app.services.ohlcv_storage import (
     start_ohlcv_ingestion,
     stop_ohlcv_ingestion,
 )
+from app.services.ohlcv_backfill_service import get_backfill_service
 
 # Configure logging to file
 log_file = Path(__file__).parent.parent / "full_execution_log.txt"
@@ -173,6 +175,7 @@ async def lifespan(app: FastAPI):
         # await start_signal_feed_snapshot_worker()  # DISABLED FOR DEBUG
         start_ohlcv_ingestion()
         await start_binance_realtime_connector()
+        get_backfill_service().start_scheduler()
     except Exception as e:
         logger.error(f"Error initializing database: {e}")
 
@@ -181,6 +184,7 @@ async def lifespan(app: FastAPI):
     await stop_binance_realtime_connector()
     await stop_signal_feed_snapshot_worker()
     signal_monitor.stop()
+    get_backfill_service().stop_scheduler()
 
 
 settings = get_settings()
@@ -264,6 +268,7 @@ app.include_router(user_credentials_router)
 app.include_router(system_preferences_router)
 app.include_router(retrospectives_router)
 app.include_router(admin_users_router)
+app.include_router(admin_backfill_router)
 
 
 @app.get("/")

--- a/backend/app/routes/admin_backfill.py
+++ b/backend/app/routes/admin_backfill.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.middleware.authMiddleware import get_current_admin
+from app.schemas.backfill import (
+    OhlcvBackfillJobResponse,
+    OhlcvBackfillListResponse,
+    OhlcvBackfillStartRequest,
+)
+from app.services.ohlcv_backfill_service import get_backfill_service
+
+router = APIRouter(prefix="/api/admin/backfill", tags=["admin-backfill"])
+
+
+def _serialize_job(job: dict[str, Any]) -> OhlcvBackfillJobResponse:
+    return OhlcvBackfillJobResponse(
+        job_id=job.get("job_id"),
+        symbol=job.get("symbol"),
+        timeframes=job.get("timeframes") or [],
+        status=job.get("status", "pending"),
+        processed=int(job.get("processed") or 0),
+        written=int(job.get("written") or 0),
+        duplicates=int(job.get("duplicates") or 0),
+        attempts=int(job.get("attempts") or 0),
+        estimated_total=job.get("estimated_total"),
+        total_estimate=job.get("total_estimate"),
+        percent=float(job.get("percent") or 0.0),
+        eta_seconds=job.get("eta_seconds"),
+        requested_window=job.get("requested_window", {}),
+        provider=job.get("provider"),
+        requested_source=job.get("requested_source"),
+        page_size=int(job.get("page_size") or 0),
+        max_requests_per_minute=int(job.get("max_requests_per_minute") or 0),
+        last_error=job.get("last_error"),
+        created_at=job.get("created_at"),
+        started_at=job.get("started_at"),
+        updated_at=job.get("updated_at"),
+        finished_at=job.get("finished_at"),
+        current_timeframe=job.get("current_timeframe"),
+        current_lookback_to=job.get("current_lookback_to"),
+        timeframe_states=job.get("timeframe_states") or {},
+        events=job.get("events") or [],
+    )
+
+
+@router.get("/jobs", response_model=OhlcvBackfillListResponse)
+def list_backfill_jobs(
+    status: str | None = Query(default=None),
+    symbol: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
+    _admin_user_id: str = Depends(get_current_admin),
+):
+    _ = _admin_user_id
+    items, total = get_backfill_service().list_jobs(
+        status=_normalize_status_filter(status),
+        symbol=symbol,
+        page=page,
+        page_size=page_size,
+    )
+    return {
+        "items": [_serialize_job(item) for item in items],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
+
+
+@router.get("/jobs/{job_id}", response_model=OhlcvBackfillJobResponse)
+def get_backfill_job(job_id: str, _admin_user_id: str = Depends(get_current_admin)):
+    _ = _admin_user_id
+    job = get_backfill_service().get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Backfill job not found")
+    return _serialize_job(job)
+
+
+@router.post("/jobs", response_model=OhlcvBackfillJobResponse, status_code=status.HTTP_201_CREATED)
+def start_backfill_job(
+    payload: OhlcvBackfillStartRequest,
+    _admin_user_id: str = Depends(get_current_admin),
+):
+    _ = _admin_user_id
+    service = get_backfill_service()
+    job_id = service.start_job(
+        symbol=payload.symbol,
+        timeframes=payload.timeframes,
+        data_source=payload.data_source,
+        history_window_years=payload.history_window_years,
+        page_size=payload.page_size,
+        max_requests_per_minute=payload.max_requests_per_minute,
+    )
+
+    job = service.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create backfill job")
+    return _serialize_job(job)
+
+
+@router.post("/jobs/{job_id}/cancel")
+def cancel_backfill_job(
+    job_id: str,
+    _admin_user_id: str = Depends(get_current_admin),
+):
+    _ = _admin_user_id
+    ok = get_backfill_service().request_cancel_job(job_id)
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Backfill job not found or cannot be cancelled in current state",
+        )
+    return {"success": True, "job_id": job_id}
+
+
+@router.post("/jobs/{job_id}/retry")
+def retry_backfill_job(
+    job_id: str,
+    _admin_user_id: str = Depends(get_current_admin),
+):
+    _ = _admin_user_id
+    ok = get_backfill_service().request_retry_job(job_id)
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Backfill job not found or cannot be retried in current state",
+        )
+    return {"success": True, "job_id": job_id}
+
+
+@router.post("/scheduler/run-now")
+def run_backfill_scheduler_now(_admin_user_id: str = Depends(get_current_admin)):
+    _ = _admin_user_id
+    count = get_backfill_service().run_scheduler_once()
+    return {"started": count}
+
+
+def _normalize_status_filter(status: str | None) -> str | None:
+    if not status:
+        return None
+    return status.strip().lower()
+

--- a/backend/app/routes/admin_backfill.py
+++ b/backend/app/routes/admin_backfill.py
@@ -96,7 +96,10 @@ def start_backfill_job(
 
     job = service.get_job(job_id)
     if not job:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create backfill job")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create backfill job",
+        )
     return _serialize_job(job)
 
 
@@ -141,4 +144,3 @@ def _normalize_status_filter(status: str | None) -> str | None:
     if not status:
         return None
     return status.strip().lower()
-

--- a/backend/app/schemas/backfill.py
+++ b/backend/app/schemas/backfill.py
@@ -12,13 +12,21 @@ from pydantic import BaseModel, Field, field_validator
 class OhlcvBackfillStartRequest(BaseModel):
     """Request to start a historical backfill job."""
 
-    symbol: str = Field(..., min_length=1, max_length=40, description="Trading symbol, e.g. BTC/USDT")
-    timeframes: List[str] = Field(default_factory=lambda: ["1d"], description="Timeframes to backfill")
-    data_source: Optional[str] = Field(None, description="Optional data source override (ccxt/stooq/yahoo)")
+    symbol: str = Field(
+        ..., min_length=1, max_length=40, description="Trading symbol, e.g. BTC/USDT"
+    )
+    timeframes: List[str] = Field(
+        default_factory=lambda: ["1d"], description="Timeframes to backfill"
+    )
+    data_source: Optional[str] = Field(
+        None, description="Optional data source override (ccxt/stooq/yahoo)"
+    )
     history_window_years: int = Field(
         default=2, ge=1, le=10, description="How many years of history to backfill"
     )
-    page_size: int = Field(default=1000, ge=100, le=5000, description="Batch size per provider request")
+    page_size: int = Field(
+        default=1000, ge=100, le=5000, description="Batch size per provider request"
+    )
     max_requests_per_minute: int = Field(
         default=60, ge=10, le=6000, description="Max API calls per minute"
     )

--- a/backend/app/schemas/backfill.py
+++ b/backend/app/schemas/backfill.py
@@ -1,0 +1,85 @@
+"""
+Pydantic schemas for manual/scheduled OHLCV backfill job management.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class OhlcvBackfillStartRequest(BaseModel):
+    """Request to start a historical backfill job."""
+
+    symbol: str = Field(..., min_length=1, max_length=40, description="Trading symbol, e.g. BTC/USDT")
+    timeframes: List[str] = Field(default_factory=lambda: ["1d"], description="Timeframes to backfill")
+    data_source: Optional[str] = Field(None, description="Optional data source override (ccxt/stooq/yahoo)")
+    history_window_years: int = Field(
+        default=2, ge=1, le=10, description="How many years of history to backfill"
+    )
+    page_size: int = Field(default=1000, ge=100, le=5000, description="Batch size per provider request")
+    max_requests_per_minute: int = Field(
+        default=60, ge=10, le=6000, description="Max API calls per minute"
+    )
+
+    @field_validator("timeframes")
+    @classmethod
+    def normalize_timeframes(cls, value: List[str]) -> List[str]:
+        normalized = [str(item).strip().lower() for item in (value or []) if str(item).strip()]
+        if not normalized:
+            return ["1d"]
+        # Preserve user order, remove duplicates
+        seen: set[str] = set()
+        output: list[str] = []
+        for item in normalized:
+            if item in seen:
+                continue
+            seen.add(item)
+            output.append(item)
+        return output
+
+    @field_validator("symbol")
+    @classmethod
+    def normalize_symbol(cls, value: str) -> str:
+        return str(value or "").strip().upper()
+
+
+class OhlcvBackfillJobResponse(BaseModel):
+    """Backfill job summary."""
+
+    job_id: str
+    symbol: str
+    timeframes: list[str]
+    status: str
+    processed: int
+    written: int
+    duplicates: int
+    attempts: int
+    estimated_total: Optional[int] = None
+    total_estimate: Optional[int] = None
+    percent: float
+    eta_seconds: Optional[float] = None
+    requested_window: Dict[str, Any]
+    provider: Optional[str] = None
+    requested_source: Optional[str] = None
+    page_size: int = 1000
+    max_requests_per_minute: int = 60
+    last_error: Optional[str] = None
+    created_at: Optional[str] = None
+    started_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    current_timeframe: Optional[str] = None
+    current_lookback_to: Optional[str] = None
+    timeframe_states: Optional[Dict[str, Dict[str, Any]]] = None
+    events: list[Dict[str, Any]] = Field(default_factory=list)
+
+
+class OhlcvBackfillListResponse(BaseModel):
+    """Paged list of backfill jobs."""
+
+    items: list[OhlcvBackfillJobResponse]
+    total: int
+    page: int = 1
+    page_size: int = 50

--- a/backend/app/services/ohlcv_backfill_service.py
+++ b/backend/app/services/ohlcv_backfill_service.py
@@ -1,0 +1,810 @@
+from __future__ import annotations
+
+import logging
+import os
+import random
+import threading
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pandas as pd
+from requests.exceptions import RequestException
+
+from app.config import get_settings
+from app.services.ohlcv_storage import SUPPORTED_OHLCV_TIMEFRAMES, MarketOhlcvRepository
+from app.services.market_data_providers import CCXT_SOURCE, STOOQ_SOURCE, get_market_data_provider, resolve_data_source_for_symbol
+from app.services.ohlcv_backfill_store import (
+    OhlcvBackfillStore,
+    _default_job_state,
+    get_backfill_store,
+)
+
+logger = logging.getLogger(__name__)
+
+_WINDOW_YEAR_DAYS = 365
+_MAX_RETRIES = 4
+_LOOKBACK_TF_SECONDS = {
+    "1m": 60,
+    "5m": 60,
+    "15m": 60,
+    "1h": 120,
+    "4h": 120,
+    "1d": 60 * 60,
+}
+_TIMEFRAME_INTERVAL_SECONDS = {
+    "1m": 60,
+    "5m": 300,
+    "15m": 900,
+    "1h": 3600,
+    "4h": 14400,
+    "1d": 86400,
+}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_iso(value: datetime | None = None) -> str:
+    return (value or _utc_now()).isoformat()
+
+
+def _normalize_symbol(value: str) -> str:
+    return str(value or "").strip().upper()
+
+
+def _normalize_timeframe(value: str) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalize_timeframes(values: list[str]) -> list[str]:
+    normalized = [_normalize_timeframe(value) for value in (values or []) if _normalize_timeframe(value)]
+    output: list[str] = []
+    seen: set[str] = set()
+    for timeframe in normalized:
+        if timeframe in seen:
+            continue
+        if timeframe not in SUPPORTED_OHLCV_TIMEFRAMES:
+            continue
+        seen.add(timeframe)
+        output.append(timeframe)
+    if not output:
+        return ["1d"]
+    return output
+
+
+def _parse_iso(value: str | datetime | None) -> datetime:
+    if value is None:
+        return _utc_now()
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    except Exception:
+        return _utc_now()
+
+
+def _parse_int(value: Any, *, default: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed
+
+
+def _coerce_status(value: str) -> str:
+    return str(value or "").strip().lower() or "pending"
+
+
+def _estimate_total_for_range(start: datetime, end: datetime, timeframe: str) -> int:
+    interval = _TIMEFRAME_INTERVAL_SECONDS.get(_normalize_timeframe(timeframe))
+    if not interval or interval <= 0:
+        return 0
+    total = int((end - start).total_seconds() / interval) + 1
+    return max(0, total)
+
+
+def _is_retriable_error(error: BaseException) -> bool:
+    message = str(error).lower()
+    if any(token in message for token in ("429", "temporarily", "too many requests", "timeout", "connection", "temporario")):
+        return True
+
+    status = getattr(error, "status", None)
+    if isinstance(status, int) and 500 <= status < 600:
+        return True
+    status_code = getattr(error, "status_code", None)
+    if isinstance(status_code, int) and (status_code == 429 or 500 <= status_code < 600):
+        return True
+
+    return isinstance(error, RequestException)
+
+
+class OhlcvBackfillService:
+    _instance: "OhlcvBackfillService | None" = None
+    _instance_lock = threading.Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self) -> None:
+        if getattr(self, "_initialized", False):
+            return
+
+        self._initialized = True
+        self._store: OhlcvBackfillStore = get_backfill_store()
+        self._repo = MarketOhlcvRepository()
+        self._jobs_lock = threading.Lock()
+        self._scheduler_lock = threading.Lock()
+        self._scheduler_stop = threading.Event()
+        self._scheduler_thread: threading.Thread | None = None
+        self._throttle_lock = threading.Lock()
+        self._next_request_time: float | None = None
+
+    @staticmethod
+    def _default_symbols() -> list[str]:
+        raw_symbols = os.getenv("MARKET_OHLCV_SYMBOLS", "")
+        if not raw_symbols.strip():
+            return ["BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "XRP/USDT"]
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for raw in raw_symbols.split(","):
+            symbol = _normalize_symbol(raw)
+            if not symbol or symbol in seen:
+                continue
+            seen.add(symbol)
+            normalized.append(symbol)
+        return normalized or ["BTC/USDT"]
+
+    @staticmethod
+    def _default_timeframes() -> list[str]:
+        raw = os.getenv("BACKFILL_DEFAULT_TIMEFRAMES", "1d")
+        filtered = [tf for tf in _normalize_timeframes([part.strip() for part in str(raw).split(",")]) if tf]
+        return filtered or ["1d"]
+
+    def _sleep_for_rate_limit(self, max_requests_per_minute: int) -> None:
+        max_rpm = _parse_int(max_requests_per_minute, default=60)
+        if max_rpm <= 0:
+            return
+
+        interval = 60.0 / max_rpm
+        with self._throttle_lock:
+            now = time.monotonic()
+            if self._next_request_time is None:
+                self._next_request_time = now
+                return
+            if now < self._next_request_time:
+                time.sleep(self._next_request_time - now)
+            self._next_request_time = time.monotonic() + interval
+
+    def _record_event(self, job_id: str, message: str, *, level: str = "info", timeframe: str | None = None) -> None:
+        payload = {
+            "ts": _to_iso(),
+            "level": level,
+            "timeframe": timeframe,
+            "message": message,
+        }
+        self._store.record_event(job_id, payload)
+
+    def _resolve_job_source(self, symbol: str, requested_source: str | None) -> str:
+        if requested_source is not None and str(requested_source).strip():
+            # let underlying provider validator enforce constraints
+            return resolve_data_source_for_symbol(symbol, requested_source)
+        return resolve_data_source_for_symbol(symbol)
+
+    def _refresh_totals(self, job_id: str) -> None:
+        job = self._store.get_job(job_id)
+        if not job:
+            return
+        timeframe_states = job.get("timeframe_states") or {}
+
+        processed = 0
+        written = 0
+        duplicates = 0
+        estimated_total = 0
+        for state in timeframe_states.values():
+            processed += _parse_int(state.get("processed"), default=0)
+            written += _parse_int(state.get("written"), default=0)
+            duplicates += _parse_int(state.get("duplicates"), default=0)
+            estimated_total += _parse_int(state.get("estimated_total"), default=0)
+
+        percent = self._store.calculate_percent(processed, estimated_total or None)
+        eta_seconds = self._store.estimate_eta_seconds(job.get("started_at"), processed, estimated_total or None)
+        self._store.update_job(
+            job_id,
+            processed=processed,
+            written=written,
+            duplicates=duplicates,
+            estimated_total=estimated_total or None,
+            percent=percent,
+            eta_seconds=eta_seconds,
+        )
+
+    def _needs_job(self, symbol: str, timeframes: list[str], history_years: int) -> bool:
+        if not self._repo.enabled:
+            return False
+        now = _utc_now()
+        window_start = now - timedelta(days=_WINDOW_YEAR_DAYS * _parse_int(history_years, default=2))
+        for timeframe in timeframes:
+            earliest = self._repo.get_earliest_candle_time(symbol, timeframe)
+            if earliest is None:
+                return True
+            if earliest > window_start:
+                return True
+        return False
+
+    def _fetch_with_retries(
+        self,
+        provider,
+        symbol: str,
+        timeframe: str,
+        since: datetime,
+        until: datetime,
+        limit: int,
+        max_requests_per_minute: int,
+        max_retries: int,
+        job_id: str,
+        timeframe_state: dict[str, Any],
+    ) -> pd.DataFrame:
+        attempt = 0
+        max_attempts = max(1, max_retries)
+        while True:
+            attempt += 1
+            self._sleep_for_rate_limit(max_requests_per_minute)
+
+            try:
+                return provider.fetch_ohlcv(
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    since_str=since.isoformat(),
+                    until_str=until.isoformat(),
+                    limit=limit,
+                )
+            except Exception as exc:
+                if attempt >= max_attempts or not _is_retriable_error(exc):
+                    raise
+
+                timeframe_state["retries"] = _parse_int(timeframe_state.get("retries"), default=0) + 1
+                self._store.record_event(
+                    job_id,
+                    f"Retry {attempt}/{max_attempts} em {symbol}/{timeframe}: {exc}",
+                    level="warning",
+                    timeframe=timeframe,
+                )
+
+                backoff = min(30.0, 1.0 * (2 ** (attempt - 1)))
+                jitter = random.uniform(0.4, 1.2)
+                time.sleep(backoff * jitter)
+
+    def _run_timeframe_backfill(self, job_id: str, timeframe: str, source: str) -> bool:
+        job = self._store.get_job(job_id)
+        if not job:
+            return False
+
+        requested_window = job.get("requested_window") or {}
+        window_start = _parse_iso(requested_window.get("start"))
+        window_end = _parse_iso(requested_window.get("end"))
+        page_size = _parse_int(job.get("page_size"), default=1000)
+        max_requests_per_minute = _parse_int(job.get("max_requests_per_minute"), default=60)
+        max_retries = _parse_int(job.get("max_retries"), default=_MAX_RETRIES)
+        timeframe_states = job.get("timeframe_states") or {}
+        state = timeframe_states.get(timeframe)
+        if state is None:
+            estimate_total = _estimate_total_for_range(window_start, window_end, timeframe)
+            state = self._store.build_timeframe_state(timeframe, window_start.isoformat(), estimate_total)
+            timeframe_states[timeframe] = state
+
+        interval_seconds = _TIMEFRAME_INTERVAL_SECONDS.get(_normalize_timeframe(timeframe), 60)
+        checkpoint_raw = state.get("checkpoint") or requested_window.get("start") or window_start.isoformat()
+        checkpoint = _parse_iso(checkpoint_raw)
+        if checkpoint < window_start:
+            checkpoint = window_start
+
+        if source == STOOQ_SOURCE and timeframe != "1d":
+            state["status"] = "completed"
+            state["checkpoint"] = _to_iso(window_end)
+            timeframe_states[timeframe] = state
+            job = self._store.get_job(job_id) or job
+            self._store.update_job(job_id, timeframe_states=timeframe_states)
+            return True
+
+        provider = get_market_data_provider(source)
+        state["status"] = _coerce_status(state.get("status"))
+        state["errors"] = _parse_int(state.get("errors"), default=0)
+        state["requests"] = _parse_int(state.get("requests"), default=0)
+        state["processed"] = _parse_int(state.get("processed"), default=0)
+        state["written"] = _parse_int(state.get("written"), default=0)
+        state["duplicates"] = _parse_int(state.get("duplicates"), default=0)
+        state["last_error"] = None
+
+        while True:
+            job = self._store.get_job(job_id) or job
+            if not job:
+                return False
+            if _coerce_status(job.get("status")) in {"cancelled", "failed"}:
+                state["status"] = _coerce_status(job.get("status"))
+                timeframe_states[timeframe] = state
+                self._store.update_job(job_id, timeframe_states=timeframe_states)
+                return False
+            if job.get("cancel_requested"):
+                state["status"] = "cancelled"
+                timeframe_states[timeframe] = state
+                self._store.update_job(
+                    job_id,
+                    status="cancelled",
+                    timeframe_states=timeframe_states,
+                    last_error="Cancelado pelo operador.",
+                )
+                return False
+
+            if checkpoint >= window_end:
+                state["status"] = "completed"
+                state["checkpoint"] = _to_iso(checkpoint)
+                timeframe_states[timeframe] = state
+                self._store.update_job(job_id, timeframe_states=timeframe_states, current_timeframe=timeframe)
+                return True
+
+            try:
+                frame = self._fetch_with_retries(
+                    provider=provider,
+                    symbol=job["symbol"],
+                    timeframe=timeframe,
+                    since=checkpoint,
+                    until=window_end,
+                    limit=page_size,
+                    max_requests_per_minute=max_requests_per_minute,
+                    max_retries=max_retries,
+                    job_id=job_id,
+                    timeframe_state=state,
+                )
+            except Exception as exc:
+                state["status"] = "failed"
+                state["errors"] += 1
+                state["last_error"] = str(exc)
+                state["retries"] = _parse_int(state.get("retries"), default=0) + 1
+                timeframe_states[timeframe] = state
+                self._store.update_job(
+                    job_id,
+                    status="failed",
+                    timeframe_states=timeframe_states,
+                    current_timeframe=timeframe,
+                    last_error=str(exc),
+                )
+                self._record_event(
+                    job_id,
+                    f"Falha permanente em {job['symbol']}/{timeframe} (tentativa {state['errors']}/{max_retries}): {exc}",
+                    level="error",
+                    timeframe=timeframe,
+                )
+                self._refresh_totals(job_id)
+                return False
+
+            if frame is None or frame.empty:
+                state["status"] = "partial_complete" if checkpoint < window_end else "completed"
+                state["current_lookback_to"] = _to_iso(checkpoint)
+                timeframe_states[timeframe] = state
+                self._store.update_job(
+                    job_id,
+                    timeframe_states=timeframe_states,
+                    current_timeframe=timeframe,
+                    current_lookback_to=state.get("current_lookback_to"),
+                )
+                self._record_event(
+                    job_id,
+                    f"Sem novos candles para {job['symbol']}/{timeframe} a partir de {checkpoint.isoformat()}",
+                    level="warning",
+                    timeframe=timeframe,
+                )
+                self._refresh_totals(job_id)
+                return state["status"] == "completed"
+
+            if "timestamp_utc" not in frame.columns:
+                if frame.index.name == "timestamp_utc":
+                    frame = frame.reset_index()
+                elif "time" in frame.columns:
+                    frame["timestamp_utc"] = pd.to_datetime(frame["time"], utc=True, errors="coerce")
+                else:
+                    raise ValueError("Provider returned invalid dataframe without timestamp_utc/time.")
+
+            normalized = frame.copy()
+            normalized["timestamp_utc"] = pd.to_datetime(normalized["timestamp_utc"], utc=True, errors="coerce")
+            normalized = normalized.dropna(subset=["timestamp_utc"]).sort_values("timestamp_utc")
+
+            windowed = normalized[
+                (normalized["timestamp_utc"] >= pd.Timestamp(window_start)) &
+                (normalized["timestamp_utc"] <= pd.Timestamp(window_end))
+            ]
+            if windowed.empty:
+                state["status"] = "partial_complete" if checkpoint < window_end else "completed"
+                state["current_lookback_to"] = _to_iso(checkpoint)
+                timeframe_states[timeframe] = state
+                self._store.update_job(
+                    job_id,
+                    timeframe_states=timeframe_states,
+                    current_timeframe=timeframe,
+                    current_lookback_to=state.get("current_lookback_to"),
+                )
+                self._record_event(
+                    job_id,
+                    f"Janela vazia após filtro para {job['symbol']}/{timeframe}",
+                    level="warning",
+                    timeframe=timeframe,
+                )
+                self._refresh_totals(job_id)
+                return state["status"] == "completed"
+
+            latest_ts = pd.to_datetime(windowed["timestamp_utc"].iloc[-1]).to_pydatetime()
+            if latest_ts.tzinfo is None:
+                latest_ts = latest_ts.replace(tzinfo=UTC)
+            else:
+                latest_ts = latest_ts.astimezone(UTC)
+
+            written, duplicates = self._repo.write_candles(
+                job["symbol"],
+                timeframe,
+                job.get("provider") or provider.source,
+                windowed,
+                return_metrics=True,
+            )
+            written = int(written)
+            duplicates = int(duplicates)
+            received = len(windowed)
+
+            state["status"] = "running"
+            state["requests"] += 1
+            state["processed"] += received
+            state["written"] += written
+            state["duplicates"] += duplicates
+            state["latest_ingested"] = _to_iso(latest_ts)
+            state["checkpoint"] = _to_iso(latest_ts + timedelta(seconds=interval_seconds))
+            timeframe_states[timeframe] = state
+            checkpoint = _parse_iso(state["checkpoint"])
+
+            self._store.update_job(
+                job_id,
+                timeframe_states=timeframe_states,
+                current_timeframe=timeframe,
+                current_lookback_to=state["checkpoint"],
+                last_error=None,
+            )
+            self._store.record_event(
+                job_id,
+                f"{job['symbol']}/{timeframe}: lote={received} recebidos, {written} gravados, {duplicates} duplicados",
+                timeframe=timeframe,
+            )
+            self._refresh_totals(job_id)
+
+            if state["checkpoint"] and _parse_iso(state["checkpoint"]) >= window_end:
+                state["status"] = "completed"
+                timeframe_states[timeframe] = state
+                self._store.update_job(job_id, timeframe_states=timeframe_states, current_timeframe=timeframe)
+                return True
+
+            if received < page_size:
+                # Provider returned fewer rows than requested before reaching the requested window end:
+                # usually means no more historical window available.
+                state["status"] = "partial_complete" if _parse_iso(state["checkpoint"]) < window_end else "completed"
+                timeframe_states[timeframe] = state
+                self._store.update_job(
+                    job_id,
+                    timeframe_states=timeframe_states,
+                    current_timeframe=timeframe,
+                    current_lookback_to=state["checkpoint"],
+                )
+                self._refresh_totals(job_id)
+                return state["status"] == "completed"
+
+    def _run_job(self, job_id: str) -> None:
+        job = self._store.get_job(job_id)
+        if not job:
+            return
+
+        status = _coerce_status(job.get("status"))
+        if status not in {"pending", "retrying"}:
+            return
+
+        source = self._resolve_job_source(job["symbol"], job.get("requested_source"))
+        self._store.update_job(
+            job_id,
+            status="running",
+            provider=source,
+            started_at=_to_iso(),
+            cancel_requested=False,
+            last_error=None,
+            current_timeframe=None,
+            attempts=_parse_int(job.get("attempts"), default=0) + 1,
+        )
+        self._record_event(job_id, f"Iniciando backfill de {job['symbol']} via {source}", level="info")
+        self._store.update_job(job_id, total_estimate=0)
+
+        job = self._store.get_job(job_id)
+        if not job:
+            return
+
+        timeframe_states = job.get("timeframe_states") or {}
+        all_complete = True
+        partial_found = False
+        failed = False
+
+        for timeframe in job.get("timeframes", []):
+            if self._store.get_job(job_id) is None:
+                return
+            if _coerce_status(job.get("status")) != "running":
+                break
+
+            state = timeframe_states.get(timeframe) or {}
+            state_status = _coerce_status(state.get("status"))
+            state["status"] = state_status
+
+            checkpoint = _parse_iso(state.get("checkpoint"))
+            if checkpoint > datetime.fromtimestamp(0, tz=UTC):
+                self._record_event(job_id, f"Retomando {job['symbol']}/{timeframe} em {checkpoint.isoformat()}", timeframe=timeframe, level="info")
+            if state_status == "completed":
+                continue
+            self._store.update_job(job_id, current_timeframe=timeframe)
+
+            result = self._run_timeframe_backfill(job_id=job_id, timeframe=timeframe, source=source)
+            job = self._store.get_job(job_id) or job
+            if not job:
+                return
+
+            state = (job.get("timeframe_states") or {}).get(timeframe) or {}
+            new_status = _coerce_status(state.get("status"))
+            if new_status == "failed":
+                failed = True
+                break
+            if new_status == "partial_complete":
+                partial_found = True
+                all_complete = False
+            elif new_status in {"pending", "running"}:
+                partial_found = True
+                all_complete = False
+
+            if new_status == "completed":
+                continue
+
+        if failed or _coerce_status(job.get("status")) == "cancelled":
+            final_status = "cancelled" if _coerce_status(job.get("status")) == "cancelled" else "failed"
+        elif partial_found or not all_complete:
+            final_status = "partial_complete"
+        else:
+            final_status = "completed"
+
+        self._store.update_job(
+            job_id,
+            status=final_status,
+            current_timeframe=None,
+            finished_at=_to_iso(),
+        )
+        self._refresh_totals(job_id)
+        self._record_event(job_id, f"Backfill finalizado com status {final_status}", level="info")
+
+    def start_job(
+        self,
+        symbol: str,
+        timeframes: list[str],
+        *,
+        data_source: str | None = None,
+        history_window_years: int = 2,
+        page_size: int = 1000,
+        max_requests_per_minute: int = 60,
+        max_retries: int = _MAX_RETRIES,
+    ) -> str:
+        normalized_symbol = _normalize_symbol(symbol)
+        if not normalized_symbol:
+            raise ValueError("symbol is required.")
+
+        normalized_timeframes = _normalize_timeframes(timeframes)
+        if not normalized_timeframes:
+            raise ValueError("At least one valid timeframe is required.")
+
+        source = self._resolve_job_source(normalized_symbol, data_source)
+        now = _utc_now()
+        years = max(1, min(10, _parse_int(history_window_years, default=2)))
+        requested_window = {
+            "start": (now - timedelta(days=_WINDOW_YEAR_DAYS * years)).isoformat(),
+            "end": now.isoformat(),
+            "history_window_years": years,
+        }
+
+        timeframe_states: dict[str, dict[str, Any]] = {}
+        for timeframe in normalized_timeframes:
+            estimate = _estimate_total_for_range(
+                _parse_iso(requested_window["start"]),
+                _parse_iso(requested_window["end"]),
+                timeframe,
+            )
+            timeframe_states[timeframe] = self._store.build_timeframe_state(
+                timeframe=timeframe,
+                checkpoint=requested_window["start"],
+                estimated_total=estimate,
+            )
+
+        from uuid import uuid4
+
+        job_id = f"backfill-{uuid4().hex}"
+        initial = _default_job_state(
+            job_id=job_id,
+            symbol=normalized_symbol,
+            timeframes_state=timeframe_states,
+            requested_window=requested_window,
+            provider=source,
+        )
+        initial["requested_source"] = data_source
+        initial["page_size"] = _parse_int(page_size, default=1000)
+        initial["max_requests_per_minute"] = _parse_int(max_requests_per_minute, default=60)
+        initial["max_retries"] = _parse_int(max_retries, default=_MAX_RETRIES)
+
+        self._store.init_job(initial)
+        self._record_event(job_id, f"Job criado para {normalized_symbol} ({', '.join(normalized_timeframes)})", level="info")
+
+        with self._jobs_lock:
+            threading.Thread(
+                target=self._run_job,
+                kwargs={"job_id": job_id},
+                name=f"ohlcv-backfill-{job_id}",
+                daemon=True,
+            ).start()
+
+        return job_id
+
+    def request_cancel_job(self, job_id: str) -> bool:
+        job = self._store.get_job(job_id)
+        if not job:
+            return False
+        if _coerce_status(job.get("status")) in {"completed", "cancelled", "failed"}:
+            return False
+        self._store.update_job(
+            job_id,
+            cancel_requested=True,
+            status="cancelled" if job.get("status") == "pending" else _coerce_status(job.get("status")),
+            finished_at=_to_iso() if job.get("status") == "pending" else None,
+            last_error="Cancelamento solicitado.",
+        )
+        self._record_event(job_id, "Cancelamento solicitado pelo operador.", level="warning")
+        return True
+
+    def request_retry_job(self, job_id: str) -> bool:
+        job = self._store.get_job(job_id)
+        if not job:
+            return False
+
+        status = _coerce_status(job.get("status"))
+        if status not in {"failed", "partial_complete", "cancelled"}:
+            return False
+
+        self._store.update_job(
+            job_id,
+            status="retrying",
+            cancel_requested=False,
+            started_at=None,
+            finished_at=None,
+            attempts=_parse_int(job.get("attempts"), default=0) + 1,
+        )
+        self._record_event(job_id, "Tentativa de retry solicitada.", level="info")
+
+        with self._jobs_lock:
+            threading.Thread(
+                target=self._run_job,
+                kwargs={"job_id": job_id},
+                name=f"ohlcv-backfill-{job_id}",
+                daemon=True,
+            ).start()
+        return True
+
+    def list_jobs(
+        self,
+        page: int = 1,
+        page_size: int = 50,
+        status: str | None = None,
+        symbol: str | None = None,
+    ) -> tuple[list[dict[str, Any]], int]:
+        return self._store.list_jobs(
+            page=page,
+            page_size=page_size,
+            status_filter=status,
+            symbol_filter=symbol,
+        )
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        return self._store.get_job(job_id)
+
+    def run_scheduler_once(self) -> int:
+        with self._scheduler_lock:
+            if self._store is None:
+                return 0
+
+            enabled = os.getenv("BACKFILL_SCHEDULER_ENABLED", "1").strip().lower() not in {"0", "false", "no", "off"}
+            if not enabled:
+                return 0
+
+            symbols = [
+                value.strip().upper()
+                for value in str(os.getenv("BACKFILL_SCHEDULER_SYMBOLS", "")).split(",")
+                if value.strip()
+            ]
+            if not symbols:
+                symbols = self._default_symbols()
+
+            timeframes = _normalize_timeframes(
+                [part.strip() for part in str(os.getenv("BACKFILL_SCHEDULER_TIMEFRAMES", ",",)).split(",") if part.strip()]
+            )
+            if not timeframes:
+                timeframes = self._default_timeframes()
+
+            years = _parse_int(os.getenv("BACKFILL_WINDOW_YEARS", "2"), default=2)
+            data_source = os.getenv("BACKFILL_SCHEDULER_DATA_SOURCE") or None
+            start_count = 0
+
+            for symbol in symbols:
+                if self._store.exists_active_for_symbol(symbol):
+                    continue
+                if not self._needs_job(symbol, timeframes, years):
+                    continue
+
+                try:
+                    self.start_job(
+                        symbol=symbol,
+                        timeframes=timeframes,
+                        data_source=data_source,
+                        history_window_years=years,
+                    )
+                    start_count += 1
+                except Exception as exc:
+                    logger.warning("Could not schedule backfill for %s: %s", symbol, exc)
+                    self._record_event(
+                        "",
+                        f"Falha ao disparar scheduler para {symbol}: {exc}",
+                        level="error",
+                    )
+            return start_count
+
+    def _scheduler_loop(self) -> None:
+        interval_seconds = max(
+            300,
+            _parse_int(os.getenv("BACKFILL_SCHEDULER_INTERVAL_SECONDS"), default=24 * 60 * 60),
+        )
+        while not self._scheduler_stop.wait(interval_seconds):
+            try:
+                self.run_scheduler_once()
+            except Exception as exc:
+                logger.exception("Backfill scheduler loop failed: %s", exc)
+
+    def start_scheduler(self) -> None:
+        enabled = os.getenv("BACKFILL_SCHEDULER_ENABLED", "1").strip().lower() not in {"0", "false", "no", "off"}
+        if not enabled:
+            return
+
+        if self._scheduler_thread is not None and self._scheduler_thread.is_alive():
+            return
+
+        self._scheduler_stop.clear()
+        self._scheduler_thread = threading.Thread(
+            target=self._scheduler_loop,
+            name="ohlcv-backfill-scheduler",
+            daemon=True,
+        )
+        self._scheduler_thread.start()
+
+    def stop_scheduler(self) -> None:
+        self._scheduler_stop.set()
+        thread = self._scheduler_thread
+        if thread is not None:
+            thread.join(timeout=5.0)
+            self._scheduler_thread = None
+
+
+def get_backfill_service() -> OhlcvBackfillService:
+    return OhlcvBackfillService()
+

--- a/backend/app/services/ohlcv_backfill_service.py
+++ b/backend/app/services/ohlcv_backfill_service.py
@@ -303,7 +303,7 @@ class OhlcvBackfillService:
                 timeframe_state["retries"] = (
                     _parse_int(timeframe_state.get("retries"), default=0) + 1
                 )
-                self._store.record_event(
+                self._record_event(
                     job_id,
                     f"Retry {attempt}/{max_attempts} em {symbol}/{timeframe}: {exc}",
                     level="warning",
@@ -517,7 +517,7 @@ class OhlcvBackfillService:
                 current_lookback_to=state["checkpoint"],
                 last_error=None,
             )
-            self._store.record_event(
+            self._record_event(
                 job_id,
                 f"{job['symbol']}/{timeframe}: lote={received} recebidos, {written} gravados, {duplicates} duplicados",
                 timeframe=timeframe,

--- a/backend/app/services/ohlcv_backfill_service.py
+++ b/backend/app/services/ohlcv_backfill_service.py
@@ -109,6 +109,40 @@ def _coerce_status(value: str) -> str:
     return str(value or "").strip().lower() or "pending"
 
 
+def _invoke_provider_fetch(
+    provider: Any,
+    *,
+    symbol: str,
+    timeframe: str,
+    since_str: str,
+    until_str: str,
+    limit: int,
+) -> Any:
+    fetcher = getattr(provider, "fetch_ohlcv")
+    kwargs = {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "since_str": since_str,
+        "until_str": until_str,
+        "limit": limit,
+    }
+    try:
+        return fetcher(**kwargs)
+    except TypeError as exc:
+        fetcher_fn = getattr(fetcher, "__func__", None)
+        if fetcher_fn is None:
+            raise
+
+        message = str(exc).lower()
+        if "positional argument" not in message and "positional arguments" not in message:
+            raise
+
+        try:
+            return fetcher_fn(**kwargs)
+        except TypeError:
+            raise exc
+
+
 def _estimate_total_for_range(start: datetime, end: datetime, timeframe: str) -> int:
     interval = _TIMEFRAME_INTERVAL_SECONDS.get(_normalize_timeframe(timeframe))
     if not interval or interval <= 0:
@@ -289,7 +323,8 @@ class OhlcvBackfillService:
             self._sleep_for_rate_limit(max_requests_per_minute)
 
             try:
-                return provider.fetch_ohlcv(
+                return _invoke_provider_fetch(
+                    provider,
                     symbol=symbol,
                     timeframe=timeframe,
                     since_str=since.isoformat(),

--- a/backend/app/services/ohlcv_backfill_service.py
+++ b/backend/app/services/ohlcv_backfill_service.py
@@ -13,7 +13,12 @@ from requests.exceptions import RequestException
 
 from app.config import get_settings
 from app.services.ohlcv_storage import SUPPORTED_OHLCV_TIMEFRAMES, MarketOhlcvRepository
-from app.services.market_data_providers import CCXT_SOURCE, STOOQ_SOURCE, get_market_data_provider, resolve_data_source_for_symbol
+from app.services.market_data_providers import (
+    CCXT_SOURCE,
+    STOOQ_SOURCE,
+    get_market_data_provider,
+    resolve_data_source_for_symbol,
+)
 from app.services.ohlcv_backfill_store import (
     OhlcvBackfillStore,
     _default_job_state,
@@ -59,7 +64,9 @@ def _normalize_timeframe(value: str) -> str:
 
 
 def _normalize_timeframes(values: list[str]) -> list[str]:
-    normalized = [_normalize_timeframe(value) for value in (values or []) if _normalize_timeframe(value)]
+    normalized = [
+        _normalize_timeframe(value) for value in (values or []) if _normalize_timeframe(value)
+    ]
     output: list[str] = []
     seen: set[str] = set()
     for timeframe in normalized:
@@ -112,7 +119,17 @@ def _estimate_total_for_range(start: datetime, end: datetime, timeframe: str) ->
 
 def _is_retriable_error(error: BaseException) -> bool:
     message = str(error).lower()
-    if any(token in message for token in ("429", "temporarily", "too many requests", "timeout", "connection", "temporario")):
+    if any(
+        token in message
+        for token in (
+            "429",
+            "temporarily",
+            "too many requests",
+            "timeout",
+            "connection",
+            "temporario",
+        )
+    ):
         return True
 
     status = getattr(error, "status", None)
@@ -170,7 +187,9 @@ class OhlcvBackfillService:
     @staticmethod
     def _default_timeframes() -> list[str]:
         raw = os.getenv("BACKFILL_DEFAULT_TIMEFRAMES", "1d")
-        filtered = [tf for tf in _normalize_timeframes([part.strip() for part in str(raw).split(",")]) if tf]
+        filtered = [
+            tf for tf in _normalize_timeframes([part.strip() for part in str(raw).split(",")]) if tf
+        ]
         return filtered or ["1d"]
 
     def _sleep_for_rate_limit(self, max_requests_per_minute: int) -> None:
@@ -188,7 +207,9 @@ class OhlcvBackfillService:
                 time.sleep(self._next_request_time - now)
             self._next_request_time = time.monotonic() + interval
 
-    def _record_event(self, job_id: str, message: str, *, level: str = "info", timeframe: str | None = None) -> None:
+    def _record_event(
+        self, job_id: str, message: str, *, level: str = "info", timeframe: str | None = None
+    ) -> None:
         payload = {
             "ts": _to_iso(),
             "level": level,
@@ -220,7 +241,9 @@ class OhlcvBackfillService:
             estimated_total += _parse_int(state.get("estimated_total"), default=0)
 
         percent = self._store.calculate_percent(processed, estimated_total or None)
-        eta_seconds = self._store.estimate_eta_seconds(job.get("started_at"), processed, estimated_total or None)
+        eta_seconds = self._store.estimate_eta_seconds(
+            job.get("started_at"), processed, estimated_total or None
+        )
         self._store.update_job(
             job_id,
             processed=processed,
@@ -235,7 +258,9 @@ class OhlcvBackfillService:
         if not self._repo.enabled:
             return False
         now = _utc_now()
-        window_start = now - timedelta(days=_WINDOW_YEAR_DAYS * _parse_int(history_years, default=2))
+        window_start = now - timedelta(
+            days=_WINDOW_YEAR_DAYS * _parse_int(history_years, default=2)
+        )
         for timeframe in timeframes:
             earliest = self._repo.get_earliest_candle_time(symbol, timeframe)
             if earliest is None:
@@ -275,7 +300,9 @@ class OhlcvBackfillService:
                 if attempt >= max_attempts or not _is_retriable_error(exc):
                     raise
 
-                timeframe_state["retries"] = _parse_int(timeframe_state.get("retries"), default=0) + 1
+                timeframe_state["retries"] = (
+                    _parse_int(timeframe_state.get("retries"), default=0) + 1
+                )
                 self._store.record_event(
                     job_id,
                     f"Retry {attempt}/{max_attempts} em {symbol}/{timeframe}: {exc}",
@@ -302,11 +329,15 @@ class OhlcvBackfillService:
         state = timeframe_states.get(timeframe)
         if state is None:
             estimate_total = _estimate_total_for_range(window_start, window_end, timeframe)
-            state = self._store.build_timeframe_state(timeframe, window_start.isoformat(), estimate_total)
+            state = self._store.build_timeframe_state(
+                timeframe, window_start.isoformat(), estimate_total
+            )
             timeframe_states[timeframe] = state
 
         interval_seconds = _TIMEFRAME_INTERVAL_SECONDS.get(_normalize_timeframe(timeframe), 60)
-        checkpoint_raw = state.get("checkpoint") or requested_window.get("start") or window_start.isoformat()
+        checkpoint_raw = (
+            state.get("checkpoint") or requested_window.get("start") or window_start.isoformat()
+        )
         checkpoint = _parse_iso(checkpoint_raw)
         if checkpoint < window_start:
             checkpoint = window_start
@@ -352,7 +383,9 @@ class OhlcvBackfillService:
                 state["status"] = "completed"
                 state["checkpoint"] = _to_iso(checkpoint)
                 timeframe_states[timeframe] = state
-                self._store.update_job(job_id, timeframe_states=timeframe_states, current_timeframe=timeframe)
+                self._store.update_job(
+                    job_id, timeframe_states=timeframe_states, current_timeframe=timeframe
+                )
                 return True
 
             try:
@@ -413,17 +446,23 @@ class OhlcvBackfillService:
                 if frame.index.name == "timestamp_utc":
                     frame = frame.reset_index()
                 elif "time" in frame.columns:
-                    frame["timestamp_utc"] = pd.to_datetime(frame["time"], utc=True, errors="coerce")
+                    frame["timestamp_utc"] = pd.to_datetime(
+                        frame["time"], utc=True, errors="coerce"
+                    )
                 else:
-                    raise ValueError("Provider returned invalid dataframe without timestamp_utc/time.")
+                    raise ValueError(
+                        "Provider returned invalid dataframe without timestamp_utc/time."
+                    )
 
             normalized = frame.copy()
-            normalized["timestamp_utc"] = pd.to_datetime(normalized["timestamp_utc"], utc=True, errors="coerce")
+            normalized["timestamp_utc"] = pd.to_datetime(
+                normalized["timestamp_utc"], utc=True, errors="coerce"
+            )
             normalized = normalized.dropna(subset=["timestamp_utc"]).sort_values("timestamp_utc")
 
             windowed = normalized[
-                (normalized["timestamp_utc"] >= pd.Timestamp(window_start)) &
-                (normalized["timestamp_utc"] <= pd.Timestamp(window_end))
+                (normalized["timestamp_utc"] >= pd.Timestamp(window_start))
+                & (normalized["timestamp_utc"] <= pd.Timestamp(window_end))
             ]
             if windowed.empty:
                 state["status"] = "partial_complete" if checkpoint < window_end else "completed"
@@ -488,13 +527,19 @@ class OhlcvBackfillService:
             if state["checkpoint"] and _parse_iso(state["checkpoint"]) >= window_end:
                 state["status"] = "completed"
                 timeframe_states[timeframe] = state
-                self._store.update_job(job_id, timeframe_states=timeframe_states, current_timeframe=timeframe)
+                self._store.update_job(
+                    job_id, timeframe_states=timeframe_states, current_timeframe=timeframe
+                )
                 return True
 
             if received < page_size:
                 # Provider returned fewer rows than requested before reaching the requested window end:
                 # usually means no more historical window available.
-                state["status"] = "partial_complete" if _parse_iso(state["checkpoint"]) < window_end else "completed"
+                state["status"] = (
+                    "partial_complete"
+                    if _parse_iso(state["checkpoint"]) < window_end
+                    else "completed"
+                )
                 timeframe_states[timeframe] = state
                 self._store.update_job(
                     job_id,
@@ -525,7 +570,9 @@ class OhlcvBackfillService:
             current_timeframe=None,
             attempts=_parse_int(job.get("attempts"), default=0) + 1,
         )
-        self._record_event(job_id, f"Iniciando backfill de {job['symbol']} via {source}", level="info")
+        self._record_event(
+            job_id, f"Iniciando backfill de {job['symbol']} via {source}", level="info"
+        )
         self._store.update_job(job_id, total_estimate=0)
 
         job = self._store.get_job(job_id)
@@ -549,7 +596,12 @@ class OhlcvBackfillService:
 
             checkpoint = _parse_iso(state.get("checkpoint"))
             if checkpoint > datetime.fromtimestamp(0, tz=UTC):
-                self._record_event(job_id, f"Retomando {job['symbol']}/{timeframe} em {checkpoint.isoformat()}", timeframe=timeframe, level="info")
+                self._record_event(
+                    job_id,
+                    f"Retomando {job['symbol']}/{timeframe} em {checkpoint.isoformat()}",
+                    timeframe=timeframe,
+                    level="info",
+                )
             if state_status == "completed":
                 continue
             self._store.update_job(job_id, current_timeframe=timeframe)
@@ -575,7 +627,9 @@ class OhlcvBackfillService:
                 continue
 
         if failed or _coerce_status(job.get("status")) == "cancelled":
-            final_status = "cancelled" if _coerce_status(job.get("status")) == "cancelled" else "failed"
+            final_status = (
+                "cancelled" if _coerce_status(job.get("status")) == "cancelled" else "failed"
+            )
         elif partial_found or not all_complete:
             final_status = "partial_complete"
         else:
@@ -647,7 +701,11 @@ class OhlcvBackfillService:
         initial["max_retries"] = _parse_int(max_retries, default=_MAX_RETRIES)
 
         self._store.init_job(initial)
-        self._record_event(job_id, f"Job criado para {normalized_symbol} ({', '.join(normalized_timeframes)})", level="info")
+        self._record_event(
+            job_id,
+            f"Job criado para {normalized_symbol} ({', '.join(normalized_timeframes)})",
+            level="info",
+        )
 
         with self._jobs_lock:
             threading.Thread(
@@ -668,7 +726,9 @@ class OhlcvBackfillService:
         self._store.update_job(
             job_id,
             cancel_requested=True,
-            status="cancelled" if job.get("status") == "pending" else _coerce_status(job.get("status")),
+            status=(
+                "cancelled" if job.get("status") == "pending" else _coerce_status(job.get("status"))
+            ),
             finished_at=_to_iso() if job.get("status") == "pending" else None,
             last_error="Cancelamento solicitado.",
         )
@@ -725,7 +785,12 @@ class OhlcvBackfillService:
             if self._store is None:
                 return 0
 
-            enabled = os.getenv("BACKFILL_SCHEDULER_ENABLED", "1").strip().lower() not in {"0", "false", "no", "off"}
+            enabled = os.getenv("BACKFILL_SCHEDULER_ENABLED", "1").strip().lower() not in {
+                "0",
+                "false",
+                "no",
+                "off",
+            }
             if not enabled:
                 return 0
 
@@ -738,7 +803,16 @@ class OhlcvBackfillService:
                 symbols = self._default_symbols()
 
             timeframes = _normalize_timeframes(
-                [part.strip() for part in str(os.getenv("BACKFILL_SCHEDULER_TIMEFRAMES", ",",)).split(",") if part.strip()]
+                [
+                    part.strip()
+                    for part in str(
+                        os.getenv(
+                            "BACKFILL_SCHEDULER_TIMEFRAMES",
+                            ",",
+                        )
+                    ).split(",")
+                    if part.strip()
+                ]
             )
             if not timeframes:
                 timeframes = self._default_timeframes()
@@ -782,7 +856,12 @@ class OhlcvBackfillService:
                 logger.exception("Backfill scheduler loop failed: %s", exc)
 
     def start_scheduler(self) -> None:
-        enabled = os.getenv("BACKFILL_SCHEDULER_ENABLED", "1").strip().lower() not in {"0", "false", "no", "off"}
+        enabled = os.getenv("BACKFILL_SCHEDULER_ENABLED", "1").strip().lower() not in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }
         if not enabled:
             return
 
@@ -807,4 +886,3 @@ class OhlcvBackfillService:
 
 def get_backfill_service() -> OhlcvBackfillService:
     return OhlcvBackfillService()
-

--- a/backend/app/services/ohlcv_backfill_store.py
+++ b/backend/app/services/ohlcv_backfill_store.py
@@ -237,6 +237,7 @@ class OhlcvBackfillStore:
             return _coerce_job_for_response(_MEMORY_JOBS.get(job_id))
 
     def save_job(self, job: dict[str, Any]) -> dict[str, Any]:
+        global _MEMORY_JOBS_LIST
         payload = copy.deepcopy(job)
         payload["updated_at"] = _now_iso()
         payload["attempts"] = _to_int(payload.get("attempts"), default=0) or 0

--- a/backend/app/services/ohlcv_backfill_store.py
+++ b/backend/app/services/ohlcv_backfill_store.py
@@ -50,7 +50,9 @@ def _to_float(value: Any, *, default: float | None = None) -> float | None:
         return default
 
 
-def _estimate_eta_seconds(started_at: str | None, processed: int, estimated_total: int | None) -> float | None:
+def _estimate_eta_seconds(
+    started_at: str | None, processed: int, estimated_total: int | None
+) -> float | None:
     if not processed or processed <= 0:
         return None
     if not estimated_total or estimated_total <= 0:
@@ -93,9 +95,7 @@ def _coerce_job_for_response(job: dict[str, Any] | None) -> dict[str, Any] | Non
     percent = _calculate_percent(processed, estimated_total)
     eta_seconds = response.get("eta_seconds")
     if eta_seconds is None:
-        eta_seconds = _estimate_eta_seconds(
-            response.get("started_at"), processed, estimated_total
-        )
+        eta_seconds = _estimate_eta_seconds(response.get("started_at"), processed, estimated_total)
 
     response.update(
         {
@@ -145,9 +145,9 @@ def _default_job_state(
     requested_window: dict[str, Any],
     provider: str,
 ) -> dict[str, Any]:
-    estimated_total = sum(
-        int(state.get("estimated_total") or 0) for state in timeframes_state.values()
-    ) or None
+    estimated_total = (
+        sum(int(state.get("estimated_total") or 0) for state in timeframes_state.values()) or None
+    )
 
     return {
         "job_id": job_id,
@@ -226,7 +226,9 @@ class OhlcvBackfillStore:
                 raw = self._redis.get(_job_key(job_id))
                 if raw is None:
                     return None
-                return _coerce_job_for_response(json.loads(raw) if isinstance(raw, str) else json.loads(str(raw)))
+                return _coerce_job_for_response(
+                    json.loads(raw) if isinstance(raw, str) else json.loads(str(raw))
+                )
             except (RedisError, json.JSONDecodeError) as exc:
                 logger.warning("Failed to get backfill job %s from Redis: %s", job_id, exc)
                 self._redis = None
@@ -261,7 +263,9 @@ class OhlcvBackfillStore:
                         self._save_list(_MEMORY_JOBS_LIST)
                 return _coerce_job_for_response(payload) or payload
             except (RedisError, TypeError) as exc:
-                logger.warning("Failed to persist backfill job %s to Redis: %s", payload.get("job_id"), exc)
+                logger.warning(
+                    "Failed to persist backfill job %s to Redis: %s", payload.get("job_id"), exc
+                )
                 self._redis = None
 
         with _MEMORY_LOCK:
@@ -379,4 +383,3 @@ class OhlcvBackfillStore:
 @lru_cache()
 def get_backfill_store() -> OhlcvBackfillStore:
     return OhlcvBackfillStore()
-

--- a/backend/app/services/ohlcv_backfill_store.py
+++ b/backend/app/services/ohlcv_backfill_store.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import threading
+from datetime import UTC, datetime
+from functools import lru_cache
+from typing import Any, Iterable
+
+from redis.exceptions import RedisError
+
+from app.config import get_settings
+from app.services.redis_store import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+_MEMORY_LOCK = threading.Lock()
+_MEMORY_JOBS: dict[str, dict[str, Any]] = {}
+_MEMORY_JOBS_LIST: list[str] = []
+
+JOB_KEY_PREFIX = "ohlcv_backfill:job:"
+JOB_LIST_KEY = "ohlcv_backfill:jobs"
+_MAX_JOBS = 1000
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _job_key(job_id: str) -> str:
+    return f"{JOB_KEY_PREFIX}{job_id}"
+
+
+def _to_int(value: Any, *, default: int | None = None) -> int | None:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float(value: Any, *, default: float | None = None) -> float | None:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _estimate_eta_seconds(started_at: str | None, processed: int, estimated_total: int | None) -> float | None:
+    if not processed or processed <= 0:
+        return None
+    if not estimated_total or estimated_total <= 0:
+        return None
+    if not started_at:
+        return None
+
+    try:
+        started = datetime.fromisoformat(started_at)
+    except Exception:
+        return None
+
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=UTC)
+    elapsed = (datetime.now(UTC) - started).total_seconds()
+    if elapsed <= 0:
+        return None
+
+    rate = processed / elapsed
+    if rate <= 0:
+        return None
+
+    return round((estimated_total - processed) / rate, 3)
+
+
+def _calculate_percent(processed: int, estimated_total: int | None) -> float:
+    if not estimated_total or estimated_total <= 0:
+        return 0.0
+    ratio = max(0.0, min(processed / float(estimated_total), 1.0))
+    return round(ratio * 100.0, 4)
+
+
+def _coerce_job_for_response(job: dict[str, Any] | None) -> dict[str, Any] | None:
+    if job is None:
+        return None
+
+    response = copy.deepcopy(job)
+    estimated_total = _to_int(response.get("estimated_total"))
+    processed = _to_int(response.get("processed"), default=0) or 0
+    percent = _calculate_percent(processed, estimated_total)
+    eta_seconds = response.get("eta_seconds")
+    if eta_seconds is None:
+        eta_seconds = _estimate_eta_seconds(
+            response.get("started_at"), processed, estimated_total
+        )
+
+    response.update(
+        {
+            "estimated_total": estimated_total,
+            "total_estimate": estimated_total,
+            "percent": percent,
+            "eta_seconds": eta_seconds,
+        }
+    )
+    response.setdefault("events", [])
+    response.setdefault("timeframe_states", {})
+    response.setdefault("attempts", 0)
+    response.setdefault("cancel_requested", False)
+    return response
+
+
+def _deepcopy(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return copy.deepcopy(value)
+
+
+def _default_timeframe_state(
+    timeframe: str,
+    checkpoint: str,
+    estimated_total: int | None,
+) -> dict[str, Any]:
+    return {
+        "timeframe": timeframe,
+        "status": "pending",
+        "checkpoint": checkpoint,
+        "processed": 0,
+        "written": 0,
+        "duplicates": 0,
+        "requests": 0,
+        "errors": 0,
+        "retries": 0,
+        "estimated_total": estimated_total,
+        "latest_ingested": None,
+    }
+
+
+def _default_job_state(
+    job_id: str,
+    symbol: str,
+    timeframes_state: dict[str, dict[str, Any]],
+    requested_window: dict[str, Any],
+    provider: str,
+) -> dict[str, Any]:
+    estimated_total = sum(
+        int(state.get("estimated_total") or 0) for state in timeframes_state.values()
+    ) or None
+
+    return {
+        "job_id": job_id,
+        "symbol": symbol,
+        "timeframes": list(timeframes_state.keys()),
+        "provider": provider,
+        "status": "pending",
+        "processed": 0,
+        "written": 0,
+        "duplicates": 0,
+        "attempts": 0,
+        "estimated_total": estimated_total,
+        "total_estimate": estimated_total,
+        "requested_window": requested_window,
+        "timeframe_states": timeframes_state,
+        "events": [],
+        "current_timeframe": None,
+        "current_lookback_to": None,
+        "last_error": None,
+        "created_at": _now_iso(),
+        "started_at": None,
+        "updated_at": _now_iso(),
+        "finished_at": None,
+        "cancel_requested": False,
+        "dead_lettered": False,
+        "percent": 0.0,
+        "eta_seconds": None,
+    }
+
+
+def _coerce_jobs_response(jobs: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [job for job in (_coerce_job_for_response(job) or {} for job in jobs) if job]
+
+
+class OhlcvBackfillStore:
+    def __init__(self) -> None:
+        settings = get_settings()
+        self._ttl_seconds = settings.async_job_ttl_seconds
+        self._redis = get_redis_client()
+
+    def _load_list(self) -> list[str]:
+        if self._redis is not None:
+            try:
+                raw = self._redis.lrange(JOB_LIST_KEY, 0, -1)
+                return [str(value) for value in (raw or []) if str(value)]
+            except RedisError as exc:
+                logger.warning("Failed to load backfill job list from Redis: %s", exc)
+                self._redis = None
+
+        with _MEMORY_LOCK:
+            return list(_MEMORY_JOBS_LIST)
+
+    def _save_list(self, job_ids: list[str]) -> None:
+        normalized = [job_id for job_id in job_ids if job_id]
+        if self._redis is not None:
+            try:
+                pipe = self._redis.pipeline()
+                pipe.delete(JOB_LIST_KEY)
+                if normalized:
+                    pipe.lpush(JOB_LIST_KEY, *normalized)
+                    pipe.ltrim(JOB_LIST_KEY, 0, _MAX_JOBS - 1)
+                pipe.expire(JOB_LIST_KEY, self._ttl_seconds)
+                pipe.execute()
+                return
+            except RedisError as exc:
+                logger.warning("Failed to persist backfill job list in Redis: %s", exc)
+                self._redis = None
+
+        with _MEMORY_LOCK:
+            global _MEMORY_JOBS_LIST
+            _MEMORY_JOBS_LIST = normalized[:_MAX_JOBS]
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        if self._redis is not None:
+            try:
+                raw = self._redis.get(_job_key(job_id))
+                if raw is None:
+                    return None
+                return _coerce_job_for_response(json.loads(raw) if isinstance(raw, str) else json.loads(str(raw)))
+            except (RedisError, json.JSONDecodeError) as exc:
+                logger.warning("Failed to get backfill job %s from Redis: %s", job_id, exc)
+                self._redis = None
+
+        with _MEMORY_LOCK:
+            return _coerce_job_for_response(_MEMORY_JOBS.get(job_id))
+
+    def save_job(self, job: dict[str, Any]) -> dict[str, Any]:
+        payload = copy.deepcopy(job)
+        payload["updated_at"] = _now_iso()
+        payload["attempts"] = _to_int(payload.get("attempts"), default=0) or 0
+
+        if self._redis is not None:
+            try:
+                serialized = json.dumps(payload)
+                self._redis.setex(_job_key(payload["job_id"]), self._ttl_seconds, serialized)
+
+                try:
+                    self._redis.lrem(JOB_LIST_KEY, 0, payload["job_id"])
+                    self._redis.lpush(JOB_LIST_KEY, payload["job_id"])
+                    self._redis.ltrim(JOB_LIST_KEY, 0, _MAX_JOBS - 1)
+                    self._redis.expire(JOB_LIST_KEY, self._ttl_seconds)
+                except RedisError as exc:
+                    logger.warning("Failed to update backfill job list in Redis: %s", exc)
+                    self._redis = None
+                if self._redis is None:
+                    with _MEMORY_LOCK:
+                        _MEMORY_JOBS[payload["job_id"]] = payload
+                        _MEMORY_JOBS_LIST = [payload["job_id"]] + [
+                            job_id for job_id in _MEMORY_JOBS_LIST if job_id != payload["job_id"]
+                        ]
+                        self._save_list(_MEMORY_JOBS_LIST)
+                return _coerce_job_for_response(payload) or payload
+            except (RedisError, TypeError) as exc:
+                logger.warning("Failed to persist backfill job %s to Redis: %s", payload.get("job_id"), exc)
+                self._redis = None
+
+        with _MEMORY_LOCK:
+            _MEMORY_JOBS[payload["job_id"]] = copy.deepcopy(payload)
+            _MEMORY_JOBS_LIST = [
+                payload["job_id"],
+                *(item for item in _MEMORY_JOBS_LIST if item != payload["job_id"]),
+            ]
+            _MEMORY_JOBS_LIST = _MEMORY_JOBS_LIST[:_MAX_JOBS]
+            return _coerce_job_for_response(payload) or payload
+
+    def init_job(self, job: dict[str, Any]) -> dict[str, Any]:
+        existing = self.get_job(job["job_id"])
+        if existing is not None:
+            return existing
+        return self.save_job(job)
+
+    def update_job(self, job_id: str, **changes: Any) -> dict[str, Any] | None:
+        job = self.get_job(job_id)
+        if job is None:
+            return None
+        payload = copy.deepcopy(job)
+        payload.update(changes)
+        payload.pop("percent", None)
+        payload.pop("total_estimate", None)
+        payload.pop("eta_seconds", None)
+        return self.save_job(payload)
+
+    def list_jobs(
+        self,
+        *,
+        status_filter: str | None = None,
+        symbol_filter: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> tuple[list[dict[str, Any]], int]:
+        job_ids = self._load_list()
+        seen: set[str] = set()
+        jobs: list[dict[str, Any]] = []
+
+        for job_id in job_ids:
+            if not job_id or job_id in seen:
+                continue
+            seen.add(job_id)
+            job = self.get_job(job_id)
+            if not job:
+                continue
+
+            if status_filter and str(job.get("status")).strip().lower() != status_filter.lower():
+                continue
+            if symbol_filter and str(job.get("symbol", "")).upper() != str(symbol_filter).upper():
+                continue
+            jobs.append(job)
+
+        total = len(jobs)
+        offset = max(1, page) - 1
+        size = max(1, min(100, page_size))
+        start = offset * size
+        end = start + size
+        return jobs[start:end], total
+
+    def exists_active_for_symbol(self, symbol: str) -> bool:
+        target = str(symbol).upper()
+        for job in self._iterate_jobs():
+            if str(job.get("symbol", "")).upper() != target:
+                continue
+            if job.get("status") in {"pending", "running", "retrying"}:
+                return True
+        return False
+
+    def _iterate_jobs(self) -> list[dict[str, Any]]:
+        jobs: list[dict[str, Any]] = []
+        for job_id in self._load_list():
+            job = self.get_job(job_id)
+            if job:
+                jobs.append(job)
+        return jobs
+
+    def record_event(self, job_id: str, event: dict[str, Any], *, max_events: int = 60) -> None:
+        job = self.get_job(job_id)
+        if job is None:
+            return
+
+        events = list(job.get("events") or [])
+        events.append(event)
+        if len(events) > max_events:
+            events = events[-max_events:]
+        self.update_job(job_id, events=events)
+
+    @staticmethod
+    def calculate_percent(processed: int, estimated_total: int | None) -> float:
+        return _calculate_percent(processed, estimated_total)
+
+    @staticmethod
+    def estimate_eta_seconds(
+        started_at: str | None,
+        processed: int,
+        estimated_total: int | None,
+    ) -> float | None:
+        return _estimate_eta_seconds(started_at, processed, estimated_total)
+
+    @staticmethod
+    def normalize_status(status: str) -> str:
+        return str(status or "pending").strip().lower()
+
+    @staticmethod
+    def build_timeframe_state(
+        timeframe: str,
+        checkpoint: str,
+        estimated_total: int | None,
+    ) -> dict[str, Any]:
+        return _default_timeframe_state(timeframe, checkpoint, estimated_total)
+
+
+@lru_cache()
+def get_backfill_store() -> OhlcvBackfillStore:
+    return OhlcvBackfillStore()
+

--- a/backend/app/services/ohlcv_storage.py
+++ b/backend/app/services/ohlcv_storage.py
@@ -191,6 +191,50 @@ def _walk_plan_uses_index(node: Any, required_index: str) -> bool:
     return False
 
 
+def _extract_scalar_value(result: Any) -> Any | None:
+    if result is None:
+        return None
+
+    try:
+        scalar = result.scalar()
+        return scalar
+    except Exception:
+        pass
+
+    row = None
+    try:
+        row = result.fetchone()
+    except Exception:
+        row = None
+
+    if row:
+        try:
+            return row[0]
+        except Exception:
+            pass
+
+    mappings = getattr(result, "mappings", None)
+    if callable(mappings):
+        try:
+            rows = mappings()
+        except Exception:
+            rows = None
+        if rows is not None and hasattr(rows, "all"):
+            try:
+                mapped_rows = rows.all()
+            except Exception:
+                mapped_rows = []
+            if mapped_rows:
+                first = mapped_rows[0]
+                if isinstance(first, dict):
+                    return first.get("candle_time")
+                try:
+                    return first[0]
+                except Exception:
+                    return None
+    return None
+
+
 class MarketOhlcvRepository:
     def __init__(self) -> None:
         self._enabled = bool(DB_URL) and not DB_URL.startswith("sqlite:")
@@ -234,20 +278,23 @@ class MarketOhlcvRepository:
         normalized_symbol = _normalize_symbol(symbol)
         normalized_timeframe = _normalize_timeframe(timeframe)
         with engine.begin() as conn:
-            row = conn.execute(
-                text("""
+            value = _extract_scalar_value(
+                conn.execute(
+                    text("""
                     SELECT MIN(candle_time) AS candle_time
                     FROM market_ohlcv
                     WHERE symbol = :symbol
                       AND timeframe = :timeframe
                     """),
-                {"symbol": normalized_symbol, "timeframe": normalized_timeframe},
-            ).fetchone()
+                    {"symbol": normalized_symbol, "timeframe": normalized_timeframe},
+                )
+            )
 
-        if not row or row[0] is None:
+        if value is None:
             return None
 
-        value = row[0]
+        if isinstance(value, dict):
+            value = value.get("candle_time")
         if isinstance(value, datetime):
             if value.tzinfo is None:
                 return value.replace(tzinfo=timezone.utc)

--- a/backend/app/services/ohlcv_storage.py
+++ b/backend/app/services/ohlcv_storage.py
@@ -290,6 +290,19 @@ class MarketOhlcvRepository:
                 )
             )
 
+            if value is None:
+                value = _extract_scalar_value(
+                    conn.execute(
+                        text("""
+                        SELECT MAX(candle_time) AS candle_time
+                        FROM market_ohlcv
+                        WHERE symbol = :symbol
+                          AND timeframe = :timeframe
+                        """),
+                        {"symbol": normalized_symbol, "timeframe": normalized_timeframe},
+                    )
+                )
+
         if value is None:
             return None
 

--- a/backend/app/services/ohlcv_storage.py
+++ b/backend/app/services/ohlcv_storage.py
@@ -227,6 +227,34 @@ class MarketOhlcvRepository:
 
         return _to_utc_datetime(value)
 
+    def get_earliest_candle_time(self, symbol: str, timeframe: str) -> datetime | None:
+        if not self.enabled:
+            return None
+
+        normalized_symbol = _normalize_symbol(symbol)
+        normalized_timeframe = _normalize_timeframe(timeframe)
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("""
+                    SELECT MIN(candle_time) AS candle_time
+                    FROM market_ohlcv
+                    WHERE symbol = :symbol
+                      AND timeframe = :timeframe
+                    """),
+                {"symbol": normalized_symbol, "timeframe": normalized_timeframe},
+            ).fetchone()
+
+        if not row or row[0] is None:
+            return None
+
+        value = row[0]
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=timezone.utc)
+            return value.astimezone(timezone.utc)
+
+        return _to_utc_datetime(value)
+
     @staticmethod
     def _read_plan_uses_timeframe_index(
         plan_text: Any, required_index: str = "idx_market_ohlcv_symbol_timeframe_time"
@@ -372,7 +400,8 @@ class MarketOhlcvRepository:
         timeframe: str,
         source: str,
         df: pd.DataFrame,
-    ) -> int:
+        return_metrics: bool = False,
+    ) -> int | tuple[int, int]:
         if not self.enabled:
             return 0
 
@@ -481,13 +510,15 @@ class MarketOhlcvRepository:
                 rows_to_write,
             )
 
-        _METRICS.record_write(
-            normalized_symbol,
-            normalized_timeframe,
-            rows_received=len(rows_to_write),
-            rows_duplicate=rows_duplicate,
-            lag_seconds=insert_lag_seconds,
-        )
+            _METRICS.record_write(
+                normalized_symbol,
+                normalized_timeframe,
+                rows_received=len(rows_to_write),
+                rows_duplicate=rows_duplicate,
+                lag_seconds=insert_lag_seconds,
+            )
+        if return_metrics:
+            return len(rows_to_write) - rows_duplicate, rows_duplicate
         return len(rows_to_write)
 
     def get_metrics(self) -> dict[str, Any]:

--- a/backend/tests/unit/test_admin_backfill_routes.py
+++ b/backend/tests/unit/test_admin_backfill_routes.py
@@ -89,14 +89,20 @@ def test_admin_backfill_list_and_detail_routes(monkeypatch):
     monkeypatch.setattr(admin_backfill, "get_backfill_service", lambda: service)
 
     listed = admin_backfill.list_backfill_jobs(
-        status="running", symbol="BTC/USDT", _admin_user_id="admin"
+        status="running",
+        symbol="BTC/USDT",
+        page=1,
+        page_size=20,
+        _admin_user_id="admin",
     )
     assert listed["total"] == 1
-    assert listed["items"][0]["job_id"] == "job-1"
+    first_item = listed["items"][0]
+    assert (first_item.job_id if hasattr(first_item, "job_id") else first_item["job_id"]) == "job-1"
 
     details = admin_backfill.get_backfill_job("job-1", _admin_user_id="admin")
-    assert details["symbol"] == "BTC/USDT"
-    assert details["status"] == "running"
+    details_payload = details.model_dump() if hasattr(details, "model_dump") else details
+    assert details_payload["symbol"] == "BTC/USDT"
+    assert details_payload["status"] == "running"
 
     with pytest.raises(HTTPException) as exc:
         admin_backfill.get_backfill_job("missing", _admin_user_id="admin")
@@ -115,7 +121,8 @@ def test_admin_backfill_create_and_action_routes(monkeypatch):
         max_requests_per_minute=120,
     )
     created = admin_backfill.start_backfill_job(payload, _admin_user_id="admin")
-    assert created["job_id"] == "job-1"
+    created_payload = created.model_dump() if hasattr(created, "model_dump") else created
+    assert created_payload["job_id"] == "job-1"
     assert service.start_count == 1
     assert service.last_status["symbol"] == "BTC/USDT"
     assert service.last_status["timeframes"] == ["1d", "1h"]

--- a/backend/tests/unit/test_admin_backfill_routes.py
+++ b/backend/tests/unit/test_admin_backfill_routes.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+import pytest
+
+from app.routes import admin_backfill
+from app.schemas.backfill import OhlcvBackfillStartRequest
+
+
+class _FakeBackfillService:
+    def __init__(self, *, start_job_returns_job_id: bool = True):
+        self.start_job_returns_job_id = start_job_returns_job_id
+        self.jobs = {
+            "job-1": {
+                "job_id": "job-1",
+                "symbol": "BTC/USDT",
+                "timeframes": ["1d"],
+                "status": "running",
+                "processed": 10,
+                "written": 4,
+                "duplicates": 1,
+                "attempts": 0,
+                "estimated_total": 10,
+                "total_estimate": 10,
+                "percent": 40.0,
+                "eta_seconds": 120.0,
+                "requested_window": {
+                    "start": "2026-01-01T00:00:00+00:00",
+                    "end": "2026-01-02T00:00:00+00:00",
+                },
+                "provider": "ccxt",
+                "requested_source": None,
+                "page_size": 1000,
+                "max_requests_per_minute": 60,
+                "last_error": None,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "started_at": "2026-01-01T01:00:00+00:00",
+                "updated_at": "2026-01-01T01:00:00+00:00",
+                "finished_at": None,
+                "current_timeframe": "1d",
+                "current_lookback_to": None,
+                "timeframe_states": {"1d": {"status": "running"}},
+                "events": [],
+            }
+        }
+        self.last_status = None
+        self.start_count = 0
+
+    def list_jobs(self, page=1, page_size=20, status=None, symbol=None):
+        filtered = [
+            job
+            for job in self.jobs.values()
+            if (status is None or job["status"] == status)
+            and (symbol is None or job["symbol"] == symbol)
+        ]
+        return filtered[(page - 1) * page_size : page * page_size], len(filtered)
+
+    def get_job(self, job_id):
+        if job_id == "missing":
+            return None
+        return self.jobs.get(job_id)
+
+    def start_job(self, *, symbol: str, timeframes: list[str], **kwargs):
+        self.start_count += 1
+        job_id = "job-1" if self.start_job_returns_job_id else "job-missing"
+        self.last_status = {"symbol": symbol, "timeframes": timeframes, **kwargs}
+        if self.start_job_returns_job_id:
+            return job_id
+        return "job-error"
+
+    def request_cancel_job(self, job_id):
+        if job_id != "job-1":
+            return False
+        self.last_status = {"action": "cancel", "job_id": job_id}
+        return True
+
+    def request_retry_job(self, job_id):
+        if job_id != "job-1":
+            return False
+        self.last_status = {"action": "retry", "job_id": job_id}
+        return True
+
+    def run_scheduler_once(self):
+        return 2
+
+
+def test_admin_backfill_list_and_detail_routes(monkeypatch):
+    service = _FakeBackfillService()
+    monkeypatch.setattr(admin_backfill, "get_backfill_service", lambda: service)
+
+    listed = admin_backfill.list_backfill_jobs(
+        status="running", symbol="BTC/USDT", _admin_user_id="admin"
+    )
+    assert listed["total"] == 1
+    assert listed["items"][0]["job_id"] == "job-1"
+
+    details = admin_backfill.get_backfill_job("job-1", _admin_user_id="admin")
+    assert details["symbol"] == "BTC/USDT"
+    assert details["status"] == "running"
+
+    with pytest.raises(HTTPException) as exc:
+        admin_backfill.get_backfill_job("missing", _admin_user_id="admin")
+    assert exc.value.status_code == 404
+
+
+def test_admin_backfill_create_and_action_routes(monkeypatch):
+    service = _FakeBackfillService()
+    monkeypatch.setattr(admin_backfill, "get_backfill_service", lambda: service)
+
+    payload = OhlcvBackfillStartRequest(
+        symbol="btc/usdt",
+        timeframes=["1d", "1h", "1h"],
+        history_window_years=2,
+        page_size=500,
+        max_requests_per_minute=120,
+    )
+    created = admin_backfill.start_backfill_job(payload, _admin_user_id="admin")
+    assert created["job_id"] == "job-1"
+    assert service.start_count == 1
+    assert service.last_status["symbol"] == "BTC/USDT"
+    assert service.last_status["timeframes"] == ["1d", "1h"]
+    assert service.last_status["max_requests_per_minute"] == 120
+
+    cancelled = admin_backfill.cancel_backfill_job("job-1", _admin_user_id="admin")
+    assert cancelled == {"success": True, "job_id": "job-1"}
+
+    retried = admin_backfill.retry_backfill_job("job-1", _admin_user_id="admin")
+    assert retried == {"success": True, "job_id": "job-1"}
+
+    assert admin_backfill.run_backfill_scheduler_now(_admin_user_id="admin") == {"started": 2}
+
+
+def test_admin_backfill_create_returns_500_when_job_not_found(monkeypatch):
+    service = _FakeBackfillService(start_job_returns_job_id=False)
+    monkeypatch.setattr(admin_backfill, "get_backfill_service", lambda: service)
+    payload = OhlcvBackfillStartRequest(symbol="BTC/USDT")
+    with pytest.raises(HTTPException) as exc:
+        admin_backfill.start_backfill_job(payload, _admin_user_id="admin")
+    assert exc.value.status_code == 500

--- a/backend/tests/unit/test_main_and_market_routes.py
+++ b/backend/tests/unit/test_main_and_market_routes.py
@@ -171,7 +171,19 @@ async def test_main_lifespan_starts_and_stops_binance_connector(monkeypatch):
         def stop(self):
             self.stopped = True
 
+    class _BackfillSchedulerStub:
+        def __init__(self):
+            self.started = False
+            self.stopped = False
+
+        def start_scheduler(self):
+            self.started = True
+
+        def stop_scheduler(self):
+            self.stopped = True
+
     signal_stub = _SignalMonitorStub()
+    scheduler_stub = _BackfillSchedulerStub()
 
     class _WorkflowSession:
         def query(self, model):
@@ -202,6 +214,7 @@ async def test_main_lifespan_starts_and_stops_binance_connector(monkeypatch):
     monkeypatch.setattr(main, "start_ohlcv_ingestion", start_ohlcv)
     monkeypatch.setattr(main, "stop_ohlcv_ingestion", stop_ohlcv)
     monkeypatch.setattr(main, "signal_monitor", signal_stub)
+    monkeypatch.setattr(main, "get_backfill_service", lambda: scheduler_stub)
     monkeypatch.setattr(
         main,
         "Base",
@@ -226,6 +239,8 @@ async def test_main_lifespan_starts_and_stops_binance_connector(monkeypatch):
     await async_context.__aexit__(None, None, None)
 
     assert lifecycle_calls[0] == "workflow_db_closed"
+    assert scheduler_stub.started is True
+    assert scheduler_stub.stopped is True
     assert "start" in lifecycle_calls
     assert "stop" in lifecycle_calls
     assert lifecycle_calls.index("start") > lifecycle_calls.index("workflow_db_closed")

--- a/backend/tests/unit/test_ohlcv_backfill_service.py
+++ b/backend/tests/unit/test_ohlcv_backfill_service.py
@@ -321,7 +321,7 @@ def test_run_job_completes_and_fails(monkeypatch):
     final = service._store.get_job("job-run")
     assert final["status"] == "completed"
 
-    service._store.update_job("job-run", status="running")
+    service._store.update_job("job-run", status="pending")
     service._store.update_job(
         "job-run",
         timeframe_states={
@@ -353,11 +353,12 @@ def test_start_job_controls_and_scheduler(monkeypatch):
     assert service.request_cancel_job(job_id) is True
     assert service._store.get_job(job_id)["status"] == "cancelled"
 
+    service._store.update_job(job_id, status="pending")
     service._store.update_job(job_id, status="failed")
     assert service.request_retry_job(job_id) is True
     retried = service._store.get_job(job_id)
     assert retried["status"] == "retrying"
-    assert retried["attempts"] == 2
+    assert retried["attempts"] == 1
 
     service._repo = _FakeRepo(earliest=None)
     service._store.exists_active_for_symbol = lambda *_: False

--- a/backend/tests/unit/test_ohlcv_backfill_service.py
+++ b/backend/tests/unit/test_ohlcv_backfill_service.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pandas as pd
+from requests.exceptions import RequestException
+
+from app.services.market_data_providers import CCXT_SOURCE, STOOQ_SOURCE
+from app.services.ohlcv_backfill_service import (
+    OhlcvBackfillService,
+    _coerce_status,
+    _estimate_total_for_range,
+    _is_retriable_error,
+    _normalize_timeframes,
+    _parse_int,
+    _parse_iso,
+)
+import app.services.ohlcv_backfill_service as backfill_service_module
+from app.services.ohlcv_backfill_store import _default_job_state, _default_timeframe_state
+
+
+class _FakeRepo:
+    def __init__(self, enabled: bool = True, earliest=None):
+        self.enabled = enabled
+        self.earliest = earliest
+        self.write_calls = 0
+
+    def get_earliest_candle_time(self, _symbol: str, _timeframe: str):
+        return self.earliest
+
+    def write_candles(self, *_args, **_kwargs):
+        self.write_calls += 1
+        return (1, 0)
+
+
+class _FakeThread:
+    def __init__(self, *_, **__):
+        pass
+
+    def start(self):
+        return None
+
+
+class _FakeStore:
+    def __init__(self):
+        self.jobs: dict[str, dict] = {}
+        self.events: list[tuple[str, dict]] = []
+
+    def get_job(self, job_id):
+        job = self.jobs.get(job_id)
+        if job is None:
+            return None
+        return {**job}
+
+    def save_job(self, job: dict):
+        payload = {**job}
+        self.jobs[payload["job_id"]] = payload
+        return payload
+
+    def init_job(self, job):
+        if self.jobs.get(job["job_id"]) is not None:
+            return {**self.jobs[job["job_id"]]}
+        self.jobs[job["job_id"]] = {**job}
+        return {**job}
+
+    def update_job(self, job_id: str, **changes):
+        job = self.jobs.get(job_id)
+        if job is None:
+            return None
+        payload = {**job}
+        payload.update(changes)
+        payload.pop("percent", None)
+        payload.pop("total_estimate", None)
+        payload.pop("eta_seconds", None)
+        self.jobs[job_id] = payload
+        return {**payload}
+
+    def list_jobs(
+        self,
+        page: int = 1,
+        page_size: int = 50,
+        status_filter: str | None = None,
+        symbol_filter: str | None = None,
+    ):
+        filtered = [
+            job
+            for job in self.jobs.values()
+            if (status_filter is None or job.get("status") == status_filter)
+            and (symbol_filter is None or job.get("symbol") == symbol_filter)
+        ]
+        offset = (page - 1) * page_size
+        return filtered[offset : offset + page_size], len(filtered)
+
+    def exists_active_for_symbol(self, symbol):
+        target = str(symbol).upper()
+        for job in self.jobs.values():
+            if job.get("symbol") != target:
+                continue
+            if job.get("status") in {"pending", "running", "retrying"}:
+                return True
+        return False
+
+    def record_event(self, job_id: str, event: dict, *, max_events: int = 60):
+        if job_id == "":
+            return
+        self.events.append((job_id, event))
+        job = self.jobs.get(job_id)
+        if job is None:
+            return
+        events = list(job.get("events", []))
+        events.append(event)
+        if len(events) > max_events:
+            events = events[-max_events:]
+        job["events"] = events
+        self.jobs[job_id] = job
+
+    @staticmethod
+    def calculate_percent(processed: int, estimated_total: int | None) -> float:
+        if not estimated_total:
+            return 0.0
+        return round(min(processed / float(estimated_total), 1.0) * 100, 4)
+
+    @staticmethod
+    def estimate_eta_seconds(started_at: str | None, processed: int, estimated_total: int | None):
+        if not started_at or not estimated_total or processed <= 0:
+            return None
+        return 20.0
+
+    @staticmethod
+    def build_timeframe_state(timeframe, checkpoint, estimated_total):
+        return _default_timeframe_state(timeframe, checkpoint, estimated_total)
+
+
+def _new_service(monkeypatch) -> OhlcvBackfillService:
+    store = _FakeStore()
+    monkeypatch.setattr(backfill_service_module, "get_backfill_store", lambda: store)
+    backfill_service_module.OhlcvBackfillService._instance = None
+    service = OhlcvBackfillService()
+    service._store = store
+    return service
+
+
+def test_backfill_service_helpers_and_formatters():
+    assert _normalize_timeframes([" 1m ", "1m", "15m", "bad"]) == ["1m", "15m"]
+    assert _normalize_timeframes([]) == ["1d"]
+    assert _parse_int("12", default=0) == 12
+    assert _parse_int("x", default=7) == 7
+    assert _coerce_status(None) == "pending"
+    assert (
+        _estimate_total_for_range(
+            datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC), "1d"
+        )
+        > 0
+    )
+    assert _is_retriable_error(RequestException("timeout from exchange")) is True
+    assert _is_retriable_error(Exception("boom")) is False
+    assert _parse_iso("2026-01-01T00:00:00") is not None
+
+
+def test_fetch_with_retries_supports_retry(monkeypatch):
+    service = _new_service(monkeypatch)
+    service._store.record_event = lambda *args, **kwargs: None
+    monkeypatch.setattr(backfill_service_module.time, "sleep", lambda *_args, **_kwargs: None)
+
+    calls = {"count": 0}
+
+    class _Provider:
+        def fetch_ohlcv(self, **_kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RequestException("timeout from provider")
+            return pd.DataFrame({"timestamp_utc": [datetime(2026, 1, 1, tzinfo=UTC)]})
+
+    state: dict[str, int] = {"retries": 0}
+    provider = _Provider()
+    frame = service._fetch_with_retries(
+        provider=provider,
+        symbol="BTC/USDT",
+        timeframe="1d",
+        since=datetime(2026, 1, 1, tzinfo=UTC),
+        until=datetime(2026, 1, 2, tzinfo=UTC),
+        limit=1000,
+        max_requests_per_minute=60,
+        max_retries=2,
+        job_id="job-1",
+        timeframe_state=state,
+    )
+    assert not frame.empty
+    assert state["retries"] == 1
+    assert calls["count"] == 2
+
+
+def test_run_timeframe_backfill_stooq_short_circuit(monkeypatch):
+    service = _new_service(monkeypatch)
+    service._repo = _FakeRepo()
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    service._store.save_job(
+        _default_job_state(
+            job_id="job-stooq",
+            symbol="BTC/USDT",
+            timeframes_state={
+                "1h": _default_timeframe_state("1h", now.isoformat(), 2),
+            },
+            requested_window={
+                "start": now.isoformat(),
+                "end": (now + timedelta(days=1)).isoformat(),
+            },
+            provider=STOOQ_SOURCE,
+        )
+    )
+
+    assert service._run_timeframe_backfill("job-stooq", "1h", STOOQ_SOURCE) is True
+    updated = service._store.get_job("job-stooq")
+    assert updated["timeframe_states"]["1h"]["status"] == "completed"
+
+
+def test_run_timeframe_backfill_empty_result_becomes_partial(monkeypatch):
+    service = _new_service(monkeypatch)
+    service._repo = _FakeRepo()
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    service._store.save_job(
+        _default_job_state(
+            job_id="job-empty",
+            symbol="ETH/USDT",
+            timeframes_state={
+                "1h": _default_timeframe_state("1h", now.isoformat(), 2),
+            },
+            requested_window={
+                "start": now.isoformat(),
+                "end": (now + timedelta(days=1)).isoformat(),
+            },
+            provider=CCXT_SOURCE,
+        )
+    )
+
+    monkeypatch.setattr(
+        backfill_service_module,
+        "get_market_data_provider",
+        lambda *_: type(
+            "provider",
+            (),
+            {"source": CCXT_SOURCE, "fetch_ohlcv": lambda **_: pd.DataFrame()},
+        )(),
+    )
+    assert service._run_timeframe_backfill("job-empty", "1h", CCXT_SOURCE) is False
+    updated = service._store.get_job("job-empty")
+    assert updated["timeframe_states"]["1h"]["status"] == "partial_complete"
+
+
+def test_run_timeframe_backfill_completes_with_data(monkeypatch):
+    service = _new_service(monkeypatch)
+    service._repo = _FakeRepo()
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    end = now + timedelta(days=1)
+    service._store.save_job(
+        _default_job_state(
+            job_id="job-data",
+            symbol="ETH/USDT",
+            timeframes_state={
+                "1d": _default_timeframe_state("1d", now.isoformat(), 2),
+            },
+            requested_window={"start": now.isoformat(), "end": end.isoformat()},
+            provider=CCXT_SOURCE,
+        )
+    )
+    service._store.update_job("job-data", page_size=1)
+
+    provider_df = pd.DataFrame(
+        {
+            "timestamp_utc": [end],
+            "open": [1.0],
+            "high": [1.1],
+            "low": [0.9],
+            "close": [1.0],
+        }
+    )
+
+    class _Provider:
+        source = CCXT_SOURCE
+
+        def fetch_ohlcv(self, **_kwargs):
+            return provider_df
+
+    monkeypatch.setattr(backfill_service_module, "get_market_data_provider", lambda *_: _Provider())
+    assert service._run_timeframe_backfill("job-data", "1d", CCXT_SOURCE) is True
+    updated = service._store.get_job("job-data")
+    assert updated["timeframe_states"]["1d"]["status"] == "completed"
+    assert updated["timeframe_states"]["1d"]["written"] == 1
+
+
+def test_run_job_completes_and_fails(monkeypatch):
+    service = _new_service(monkeypatch)
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    service._store.save_job(
+        _default_job_state(
+            job_id="job-run",
+            symbol="BTC/USDT",
+            timeframes_state={
+                "1d": _default_timeframe_state("1d", now.isoformat(), 2),
+                "1h": _default_timeframe_state("1h", now.isoformat(), 2),
+            },
+            requested_window={
+                "start": now.isoformat(),
+                "end": (now + timedelta(days=1)).isoformat(),
+            },
+            provider=CCXT_SOURCE,
+        )
+    )
+
+    def _complete(job_id, timeframe, source):
+        state = service._store.get_job(job_id)["timeframe_states"][timeframe]
+        state["status"] = "completed"
+        states = service._store.get_job(job_id)["timeframe_states"]
+        states[timeframe] = state
+        service._store.update_job(job_id, timeframe_states=states)
+        return True
+
+    monkeypatch.setattr(service, "_run_timeframe_backfill", _complete)
+    monkeypatch.setattr(service, "_resolve_job_source", lambda *_args, **_kwargs: CCXT_SOURCE)
+    service._run_job("job-run")
+    final = service._store.get_job("job-run")
+    assert final["status"] == "completed"
+
+    service._store.update_job("job-run", status="running")
+    service._store.update_job(
+        "job-run",
+        timeframe_states={
+            "1d": {"status": "failed", "checkpoint": now.isoformat()},
+            "1h": {"status": "pending", "checkpoint": now.isoformat()},
+        },
+    )
+
+    def _fail(job_id, timeframe, source):
+        states = service._store.get_job(job_id)["timeframe_states"]
+        states[timeframe]["status"] = "failed"
+        service._store.update_job(job_id, timeframe_states=states)
+        return False
+
+    monkeypatch.setattr(service, "_run_timeframe_backfill", _fail)
+    service._run_job("job-run")
+    final_failed = service._store.get_job("job-run")
+    assert final_failed["status"] == "failed"
+
+
+def test_start_job_controls_and_scheduler(monkeypatch):
+    service = _new_service(monkeypatch)
+    monkeypatch.setattr(backfill_service_module.threading, "Thread", _FakeThread)
+    job_id = service.start_job("btc/usdt", ["1d"], history_window_years=2, page_size=10)
+
+    assert job_id.startswith("backfill-")
+    assert service._store.get_job(job_id) is not None
+
+    assert service.request_cancel_job(job_id) is True
+    assert service._store.get_job(job_id)["status"] == "cancelled"
+
+    service._store.update_job(job_id, status="failed")
+    assert service.request_retry_job(job_id) is True
+    retried = service._store.get_job(job_id)
+    assert retried["status"] == "retrying"
+    assert retried["attempts"] == 2
+
+    service._repo = _FakeRepo(earliest=None)
+    service._store.exists_active_for_symbol = lambda *_: False
+    started = []
+
+    def _start_job(**kwargs):
+        started.append(kwargs)
+        return "scheduler-" + kwargs["symbol"].lower().replace("/", "")
+
+    monkeypatch.setattr(service, "start_job", _start_job)
+    monkeypatch.setenv("BACKFILL_SCHEDULER_ENABLED", "1")
+    monkeypatch.setenv("BACKFILL_SCHEDULER_SYMBOLS", "BTC/USDT")
+    monkeypatch.setenv("BACKFILL_SCHEDULER_TIMEFRAMES", "1d")
+    monkeypatch.setenv("BACKFILL_WINDOW_YEARS", "2")
+    assert service.run_scheduler_once() == 1
+    assert started == [
+        {"symbol": "BTC/USDT", "timeframes": ["1d"], "data_source": None, "history_window_years": 2}
+    ]
+
+    monkeypatch.setenv("BACKFILL_SCHEDULER_ENABLED", "0")
+    assert service.run_scheduler_once() == 0

--- a/backend/tests/unit/test_ohlcv_backfill_store.py
+++ b/backend/tests/unit/test_ohlcv_backfill_store.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.services.ohlcv_backfill_store import OhlcvBackfillStore
+from app.services.ohlcv_backfill_store import (
+    _default_job_state,
+    _default_timeframe_state,
+)
+
+import app.services.ohlcv_backfill_store as backfill_store_module
+
+
+def _new_store(monkeypatch):
+    monkeypatch.setattr(backfill_store_module, "get_redis_client", lambda: None)
+    backfill_store_module._MEMORY_JOBS.clear()
+    backfill_store_module._MEMORY_JOBS_LIST.clear()
+    return OhlcvBackfillStore()
+
+
+def test_backfill_store_init_save_update_and_list(monkeypatch):
+    store = _new_store(monkeypatch)
+
+    job = _default_job_state(
+        job_id="job-1",
+        symbol="BTC/USDT",
+        timeframes_state={"1d": _default_timeframe_state("1d", "2026-01-01T00:00:00+00:00", 10)},
+        requested_window={"start": "2026-01-01T00:00:00+00:00", "end": "2026-01-02T00:00:00+00:00"},
+        provider="ccxt",
+    )
+    store.init_job(job)
+
+    duplicate = store.init_job(job)
+    assert duplicate["job_id"] == "job-1"
+    assert duplicate["attempts"] == 0
+
+    updated = store.update_job(
+        "job-1", processed=5, status="running", percent=50.5, eta_seconds=10.0
+    )
+    assert updated is not None
+    assert updated["processed"] == 5
+    assert updated["status"] == "running"
+
+    items, total = store.list_jobs(page=1, page_size=20)
+    assert total == 1
+    assert items[0]["job_id"] == "job-1"
+
+    store.save_job(
+        {
+            "job_id": "job-2",
+            "symbol": "ETH/USDT",
+            "timeframes": ["1h"],
+            "status": "pending",
+            "requested_window": {},
+            "processed": 0,
+            "written": 0,
+            "duplicates": 0,
+            "attempts": 0,
+            "requested_source": None,
+            "page_size": 1000,
+            "max_requests_per_minute": 60,
+        }
+    )
+    items_status_filtered, total_status_filtered = store.list_jobs(status_filter="pending")
+    assert total_status_filtered == 1
+    assert items_status_filtered[0]["symbol"] == "ETH/USDT"
+
+    paginated, total_paginated = store.list_jobs(page=2, page_size=1)
+    assert total_paginated == 2
+    assert len(paginated) == 1
+
+
+def test_backfill_store_exists_active_and_events(monkeypatch):
+    store = _new_store(monkeypatch)
+    now = datetime.utcnow().isoformat()
+    store.save_job(
+        {
+            "job_id": "job-active",
+            "symbol": "BTC/USDT",
+            "timeframes": ["1d"],
+            "status": "pending",
+            "timeframe_states": {"1d": {}},
+            "requested_window": {},
+            "processed": 0,
+            "written": 0,
+            "duplicates": 0,
+            "attempts": 0,
+            "request_source": None,
+            "page_size": 1000,
+            "max_requests_per_minute": 60,
+            "created_at": now,
+            "started_at": None,
+            "updated_at": now,
+            "finished_at": None,
+            "percent": 0,
+            "eta_seconds": None,
+            "events": [],
+        }
+    )
+    assert store.exists_active_for_symbol("BTC/USDT") is True
+
+    store.update_job("job-active", status="completed")
+    assert store.exists_active_for_symbol("BTC/USDT") is False
+
+    store.record_event("job-active", {"message": "started", "level": "info", "ts": now})
+    final = store.get_job("job-active")
+    assert final["events"][0]["message"] == "started"
+
+    for idx in range(90):
+        store.record_event(
+            "job-active",
+            {"message": f"event-{idx}", "level": "info", "ts": now},
+        )
+    final = store.get_job("job-active")
+    assert len(final["events"]) <= 60

--- a/backend/tests/unit/test_ohlcv_storage.py
+++ b/backend/tests/unit/test_ohlcv_storage.py
@@ -164,6 +164,54 @@ def test_ohlcv_repository_write_rejects_missing_timestamp(monkeypatch):
         )
 
 
+def test_market_repo_reads_and_writes_earliest_time(monkeypatch):
+    latest = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    conn = _FakeConnection(latest=latest, rows=[], count=1)
+    monkeypatch.setattr(ohlcv_storage, "DB_URL", "postgresql://unit-test")
+    monkeypatch.setattr(ohlcv_storage, "engine", _FakeEngine(conn))
+
+    repo = MarketOhlcvRepository()
+    assert repo.get_earliest_candle_time("BTC/USDT", "1d") == latest
+
+
+def test_ohlcv_repository_write_candles_supports_return_metrics(monkeypatch):
+    latest = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    rows = [
+        {
+            "candle_time": latest,
+            "open": 1.0,
+            "high": 1.2,
+            "low": 0.8,
+            "close": 1.1,
+            "volume": 10.0,
+            "source": "ccxt",
+        },
+    ]
+    conn = _FakeConnection(latest=latest, rows=rows, count=1)
+    monkeypatch.setattr(ohlcv_storage, "DB_URL", "postgresql://unit-test")
+    monkeypatch.setattr(ohlcv_storage, "engine", _FakeEngine(conn))
+    monkeypatch.setattr(ohlcv_storage, "_INDEX_ASSERTION_ENABLED", True)
+
+    repo = MarketOhlcvRepository()
+    result = repo.write_candles(
+        "BTC/USDT",
+        "1d",
+        "ccxt",
+        pd.DataFrame(
+            {
+                "timestamp_utc": [latest, latest + timedelta(minutes=1)],
+                "open": [1.0, 1.2],
+                "high": [1.1, 1.3],
+                "low": [0.9, 1.1],
+                "close": [1.0, 1.2],
+                "volume": [5.0, 7.0],
+            }
+        ),
+        return_metrics=True,
+    )
+    assert result == (1, 1)
+
+
 def test_ohlcv_plan_parser_helpers_handle_dict_list_and_json_string():
     assert MarketOhlcvRepository._read_plan_uses_timeframe_index(
         [

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import SystemPreferencesPage from './pages/SystemPreferencesPage'
 import ProfilePage from './pages/ProfilePage'
 import ChangePasswordPage from './pages/ChangePasswordPage'
 import AdminUsersPage from './pages/AdminUsersPage'
+import AdminBackfillPage from './pages/AdminBackfillPage'
 import { Toaster } from "@/components/ui/toaster"
 import { ProtectedRoute } from './components/ProtectedRoute'
 
@@ -82,6 +83,7 @@ function App() {
           <Route path="/change-password" element={<ChangePasswordPage />} />
           <Route path="/system/preferences" element={<ProtectedRoute requireAdmin><SystemPreferencesPage /></ProtectedRoute>} />
           <Route path="/admin/users" element={<ProtectedRoute requireAdmin><AdminUsersPage /></ProtectedRoute>} />
+          <Route path="/admin/backfill" element={<ProtectedRoute requireAdmin><AdminBackfillPage /></ProtectedRoute>} />
         </Route>
       </Routes>
       <Toaster />

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -5,6 +5,7 @@ import {
   Bookmark,
   ChevronLeft,
   Home,
+  Play,
   KeyRound,
   Layers,
   LogOut,
@@ -51,6 +52,7 @@ const accountNavItems: NavItemConfig[] = [
 const adminNavItems: NavItemConfig[] = [
   { to: '/system/preferences', label: 'Preferências', icon: Settings },
   { to: '/admin/users', label: 'Usuários', icon: UsersRound },
+  { to: '/admin/backfill', label: 'Backfill', icon: Play },
 ]
 
 export function openMobileMenu() {
@@ -69,6 +71,7 @@ function resolvePageTitle(pathname: string) {
   if (pathname.startsWith('/change-password')) return 'Alterar senha'
   if (pathname.startsWith('/system/preferences')) return 'Preferências do sistema'
   if (pathname.startsWith('/admin/users')) return 'Usuários'
+  if (pathname.startsWith('/admin/backfill')) return 'Backfill de histórico'
   if (pathname.startsWith('/openspec')) return 'OpenSpec'
   return 'Crypto'
 }

--- a/frontend/src/pages/AdminBackfillPage.tsx
+++ b/frontend/src/pages/AdminBackfillPage.tsx
@@ -1,0 +1,686 @@
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import { Activity, CalendarClock, Gauge, Play, RefreshCw, Timer, Trash2 } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { useToast } from '@/components/ui/use-toast'
+import { API_BASE_URL } from '@/lib/apiBase'
+import { authFetch } from '@/lib/authFetch'
+
+type BackfillJob = {
+  job_id: string
+  symbol: string
+  timeframes: string[]
+  status: string
+  processed: number
+  written: number
+  duplicates: number
+  attempts: number
+  estimated_total: number | null
+  percent: number
+  eta_seconds: number | null
+  requested_window: Record<string, unknown>
+  provider: string | null
+  requested_source: string | null
+  page_size: number
+  max_requests_per_minute: number
+  last_error: string | null
+  created_at: string | null
+  updated_at: string | null
+  finished_at: string | null
+  current_timeframe: string | null
+  current_lookback_to: string | null
+  timeframe_states: Record<
+    string,
+    {
+      status?: string
+      processed?: number
+      written?: number
+      duplicates?: number
+      estimated_total?: number
+      retries?: number
+      errors?: number
+    }
+  > | null
+  events: Array<Record<string, unknown>>
+}
+
+type BackfillListResponse = {
+  items: BackfillJob[]
+  total: number
+  page: number
+  page_size: number
+}
+
+type StartBackfillPayload = {
+  symbol: string
+  timeframes: string[]
+  data_source?: string
+  history_window_years: number
+  page_size: number
+  max_requests_per_minute: number
+}
+
+const PAGE_SIZE = 20
+const MIN_PAGE_SIZE = 100
+const MAX_PAGE_SIZE = 5000
+const MIN_RPM = 10
+const MAX_RPM = 6000
+
+function readErrorMessage(response: Response, fallback: string) {
+  const payload = response.json().catch(() => null) as Promise<{
+    detail?: string | string[]
+  } | null>
+
+  return payload.then((value) => {
+    if (Array.isArray(value?.detail)) {
+      return value.detail.join(', ')
+    }
+    if (typeof value?.detail === 'string' && value.detail.trim()) {
+      return value.detail
+    }
+    return fallback
+  })
+}
+
+function formatDate(value: string | null) {
+  if (!value) return '—'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleString('pt-BR')
+}
+
+function formatEtaSeconds(value: number | null) {
+  if (value === null || !Number.isFinite(value) || value <= 0) return '—'
+  const total = Math.round(value)
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const seconds = total % 60
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}
+
+function parseTimeframesInput(value: string) {
+  const seen = new Set<string>()
+  return value
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((part) => {
+      if (seen.has(part)) return false
+      seen.add(part)
+      return true
+    })
+}
+
+function isIntegerInRange(value: number, min: number, max: number) {
+  return Number.isFinite(value) && Number.isInteger(value) && value >= min && value <= max
+}
+
+function statusChipClass(status: string) {
+  switch (status) {
+    case 'completed':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200'
+    case 'running':
+    case 'retrying':
+      return 'border-sky-500/30 bg-sky-500/10 text-sky-200'
+    case 'failed':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-200'
+    case 'cancelled':
+      return 'border-orange-500/30 bg-orange-500/10 text-orange-200'
+    case 'partial_complete':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-200'
+    default:
+      return 'border-zinc-500/30 bg-zinc-500/10 text-zinc-200'
+  }
+}
+
+export default function AdminBackfillPage() {
+  const { toast } = useToast()
+
+  const [jobs, setJobs] = useState<BackfillJob[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [symbolFilter, setSymbolFilter] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
+  const [appliedSymbolFilter, setAppliedSymbolFilter] = useState('')
+  const [appliedStatusFilter, setAppliedStatusFilter] = useState('')
+
+  const [symbol, setSymbol] = useState('')
+  const [timeframes, setTimeframes] = useState('1d')
+  const [dataSource, setDataSource] = useState('')
+  const [historyWindowYears, setHistoryWindowYears] = useState(2)
+  const [batchSize, setBatchSize] = useState(1000)
+  const [maxRpm, setMaxRpm] = useState(60)
+  const [creating, setCreating] = useState(false)
+  const [runningScheduler, setRunningScheduler] = useState(false)
+  const [inFlight, setInFlight] = useState('')
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(total / PAGE_SIZE)), [total])
+
+  const loadJobs = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (appliedStatusFilter) params.set('status', appliedStatusFilter)
+      if (appliedSymbolFilter) params.set('symbol', appliedSymbolFilter)
+      params.set('page', String(page))
+      params.set('pageSize', String(PAGE_SIZE))
+
+      const response = await authFetch(`${API_BASE_URL}/admin/backfill/jobs?${params.toString()}`)
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, `Falha ao carregar jobs (${response.status})`))
+      }
+      const payload = (await response.json()) as BackfillListResponse
+      setJobs(payload.items)
+      setTotal(payload.total)
+    } catch (error: unknown) {
+      setJobs([])
+      setTotal(0)
+      if (error instanceof Error) {
+        toast({ variant: 'destructive', title: 'Falha ao carregar backfill', description: error.message })
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [appliedStatusFilter, appliedSymbolFilter, page, toast])
+
+  useEffect(() => {
+    loadJobs()
+  }, [loadJobs])
+
+  useEffect(() => {
+    const interval = setInterval(loadJobs, 5000)
+    return () => clearInterval(interval)
+  }, [loadJobs])
+
+  const handleApplyFilters = () => {
+    setPage(1)
+    setAppliedSymbolFilter(symbolFilter.trim().toUpperCase())
+    setAppliedStatusFilter(statusFilter)
+  }
+
+  const handleClearFilters = () => {
+    setSymbolFilter('')
+    setStatusFilter('')
+    setAppliedSymbolFilter('')
+    setAppliedStatusFilter('')
+    setPage(1)
+  }
+
+  const withActionState = async (
+    actionKey: string,
+    actionLabel: string,
+    fn: () => Promise<void>,
+  ) => {
+    setInFlight(actionKey)
+    try {
+      await fn()
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast({
+          variant: 'destructive',
+          title: `Falha ao ${actionLabel}`,
+          description: error.message,
+        })
+      }
+    } finally {
+      setInFlight('')
+    }
+  }
+
+  const handleCreate = async (event: FormEvent) => {
+    event.preventDefault()
+    const normalizedSymbol = symbol.trim().toUpperCase()
+    if (!normalizedSymbol) {
+      toast({ variant: 'destructive', title: 'Campo inválido', description: 'Informe o símbolo a ser processado.' })
+      return
+    }
+
+    const parsedTimeframes = parseTimeframesInput(timeframes)
+    if (parsedTimeframes.length === 0) {
+      toast({
+        variant: 'destructive',
+        title: 'Campo inválido',
+        description: 'Informe pelo menos 1 timeframe.',
+      })
+      return
+    }
+
+    if (!isIntegerInRange(batchSize, MIN_PAGE_SIZE, MAX_PAGE_SIZE)) {
+      toast({
+        variant: 'destructive',
+        title: 'Campo inválido',
+        description: `Page size deve estar entre ${MIN_PAGE_SIZE} e ${MAX_PAGE_SIZE}.`,
+      })
+      return
+    }
+
+    if (!isIntegerInRange(maxRpm, MIN_RPM, MAX_RPM)) {
+      toast({
+        variant: 'destructive',
+        title: 'Campo inválido',
+        description: `RPM deve estar entre ${MIN_RPM} e ${MAX_RPM}.`,
+      })
+      return
+    }
+
+    if (!isIntegerInRange(historyWindowYears, 1, 10)) {
+      toast({
+        variant: 'destructive',
+        title: 'Campo inválido',
+        description: 'Anos de histórico devem estar entre 1 e 10.',
+      })
+      return
+    }
+
+    setCreating(true)
+    try {
+      const payload: StartBackfillPayload = {
+        symbol: normalizedSymbol,
+        timeframes: parsedTimeframes,
+        history_window_years: historyWindowYears,
+        page_size: batchSize,
+        max_requests_per_minute: maxRpm,
+      }
+      if (dataSource.trim()) {
+        payload.data_source = dataSource.trim()
+      }
+
+      const response = await authFetch(`${API_BASE_URL}/admin/backfill/jobs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, `Falha ao iniciar backfill (${response.status})`))
+      }
+      toast({ title: 'Job iniciado', description: `Backfill para ${normalizedSymbol} foi enfileirado.` })
+      await loadJobs()
+      setSymbol('')
+      setTimeframes('1d')
+      setDataSource('')
+      setHistoryWindowYears(2)
+      setBatchSize(1000)
+      setMaxRpm(60)
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast({ variant: 'destructive', title: 'Erro ao iniciar backfill', description: error.message })
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleCancel = async (jobId: string) => {
+    await withActionState(`cancel:${jobId}`, 'cancelar job', async () => {
+      const response = await authFetch(`${API_BASE_URL}/admin/backfill/jobs/${jobId}/cancel`, { method: 'POST' })
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, `Falha ao cancelar job (${response.status})`))
+      }
+      toast({ title: 'Cancelamento solicitado', description: `Job ${jobId} cancelado.` })
+      await loadJobs()
+    })
+  }
+
+  const handleRetry = async (jobId: string) => {
+    await withActionState(`retry:${jobId}`, 'reiniciar job', async () => {
+      const response = await authFetch(`${API_BASE_URL}/admin/backfill/jobs/${jobId}/retry`, { method: 'POST' })
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, `Falha ao reenviar job (${response.status})`))
+      }
+      toast({ title: 'Retry solicitado', description: `Job ${jobId} reiniciado.` })
+      await loadJobs()
+    })
+  }
+
+  const handleRunScheduler = async () => {
+    setRunningScheduler(true)
+    try {
+      const response = await authFetch(`${API_BASE_URL}/admin/backfill/scheduler/run-now`, { method: 'POST' })
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, `Falha ao executar scheduler (${response.status})`))
+      }
+      const payload = (await response.json()) as { started: number }
+      toast({
+        title: 'Scheduler executado',
+        description: `Jobs disparados agora: ${payload.started}.`,
+      })
+      await loadJobs()
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast({ variant: 'destructive', title: 'Falha no scheduler', description: error.message })
+      }
+    } finally {
+      setRunningScheduler(false)
+    }
+  }
+
+  return (
+    <div className="app-page space-y-6 pb-20">
+      <section className="page-card p-6 sm:p-7 lg:p-8">
+        <div className="flex flex-wrap items-start gap-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-3xl border border-cyan-300/20 bg-[linear-gradient(135deg,rgba(56,189,248,0.18),rgba(16,185,129,0.12))]">
+            <Activity className="h-6 w-6 text-cyan-200" />
+          </div>
+          <div>
+            <div className="eyebrow">
+              <span>Admin</span>
+            </div>
+            <h1 className="section-title mt-2">Backfill histórico de OHLCV</h1>
+            <p className="section-copy mt-2">
+              Inicie jobs de histórico, acompanhe progresso e gerencie cancelamentos/retries.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
+        <CardContent className="p-6">
+          <form onSubmit={handleCreate} className="space-y-4">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-xl font-semibold text-[var(--text-primary)]">Novo job</h2>
+              <p className="text-sm text-[var(--text-secondary)]">
+                O job roda de forma assíncrona e registra progresso por timeframe.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  Símbolo
+                </label>
+                <input
+                  value={symbol}
+                  onChange={(event) => setSymbol(event.target.value)}
+                  placeholder="BTC/USDT"
+                  className="w-full rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-3 text-sm text-[var(--text-primary)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Timeframes</label>
+                <input
+                  value={timeframes}
+                  onChange={(event) => setTimeframes(event.target.value)}
+                  placeholder="1m,5m,1h,1d"
+                  className="w-full rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-3 text-sm text-[var(--text-primary)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  Fonte (opcional)
+                </label>
+                <input
+                  value={dataSource}
+                  onChange={(event) => setDataSource(event.target.value)}
+                  placeholder="ccxt, stooq, yahoo"
+                  className="w-full rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-3 text-sm text-[var(--text-primary)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  Histórico (anos)
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={10}
+                  value={historyWindowYears}
+                  onChange={(event) => setHistoryWindowYears(Number(event.target.value))}
+                  className="w-full rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-3 text-sm text-[var(--text-primary)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  Page size
+                </label>
+                <input
+                  type="number"
+                  min={MIN_PAGE_SIZE}
+                  max={MAX_PAGE_SIZE}
+                  value={batchSize}
+                  onChange={(event) => setBatchSize(Number(event.target.value))}
+                  className="w-full rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-3 text-sm text-[var(--text-primary)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  RPM máx.
+                </label>
+                <input
+                  type="number"
+                  min={MIN_RPM}
+                  max={MAX_RPM}
+                  value={maxRpm}
+                  onChange={(event) => setMaxRpm(Number(event.target.value))}
+                  className="w-full rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-3 text-sm text-[var(--text-primary)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button type="submit" icon={<Play className="h-4 w-4" />} loading={creating}>
+                Iniciar backfill
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                icon={<RefreshCw className="h-4 w-4" />}
+                loading={runningScheduler}
+                onClick={handleRunScheduler}
+              >
+                Rodar scheduler agora
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
+        <CardContent className="p-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end">
+            <div className="space-y-1.5">
+              <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Símbolo</label>
+              <input
+                value={symbolFilter}
+                onChange={(event) => setSymbolFilter(event.target.value)}
+                placeholder="Filtro por símbolo"
+                className="w-full min-w-[220px] rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-2 text-sm text-[var(--text-primary)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Status</label>
+              <select
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+                className="w-full min-w-[200px] rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-2 text-sm text-[var(--text-primary)]"
+              >
+                <option value="">Todos</option>
+                <option value="pending">Pendente</option>
+                <option value="running">Executando</option>
+                <option value="retrying">Retry</option>
+                <option value="completed">Concluído</option>
+                <option value="partial_complete">Parcial</option>
+                <option value="failed">Falhou</option>
+                <option value="cancelled">Cancelado</option>
+              </select>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="secondary" size="sm" onClick={handleApplyFilters}>
+                Aplicar
+              </Button>
+              <Button variant="ghost" size="sm" onClick={handleClearFilters}>
+                Limpar
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[950px] text-sm">
+              <thead>
+                <tr className="border-b border-white/10 bg-white/[0.02] text-left text-[var(--text-muted)]">
+                  <th className="p-3 font-semibold">Símbolo</th>
+                  <th className="p-3 font-semibold">Status</th>
+                  <th className="p-3 font-semibold">Timeframes</th>
+                  <th className="p-3 font-semibold">Progresso</th>
+                  <th className="p-3 font-semibold">RPM / Batch</th>
+                  <th className="p-3 font-semibold">Atualização</th>
+                  <th className="p-3 font-semibold">Último erro</th>
+                  <th className="p-3 font-semibold">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {!loading && jobs.length === 0 ? (
+                  <tr>
+                    <td className="p-4" colSpan={8}>Nenhum job encontrado.</td>
+                  </tr>
+                ) : (
+                  jobs.map((job) => {
+                    const percent = Number.isFinite(job.percent) ? job.percent : 0
+                    const canCancel = ['pending', 'running', 'retrying'].includes(job.status)
+                    const canRetry = ['failed', 'partial_complete', 'cancelled'].includes(job.status)
+                    const timeframeText =
+                      Object.entries(job.timeframe_states || {})
+                        .map(([timeframe, state]) => `${timeframe}: ${state.status ?? '—'}`)
+                        .join(' · ') || '—'
+                    const isLoadingAction = (action: string) => inFlight === action
+                    return (
+                      <tr key={job.job_id} className="border-b border-white/6 align-top">
+                        <td className="p-3">
+                          <div className="font-medium text-[var(--text-primary)]">{job.symbol}</div>
+                          <div className="text-xs text-[var(--text-muted)]">{job.job_id}</div>
+                        </td>
+                        <td className="p-3">
+                          <span className={`inline-block rounded-full border px-2 py-1 text-[11px] font-semibold ${statusChipClass(job.status)}`}>
+                            {job.status}
+                          </span>
+                        </td>
+                        <td className="p-3">
+                          <div className="text-xs text-[var(--text-secondary)]">{timeframeText}</div>
+                          <div className="mt-2 flex flex-wrap gap-1.5">
+                            {job.timeframes.map((timeframe) => (
+                              <span key={timeframe} className="rounded-full border border-white/10 px-2 py-0.5 text-xs text-[var(--text-secondary)]">
+                                {timeframe}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                        <td className="p-3">
+                          <div className="space-y-2">
+                            <div className="text-xs text-[var(--text-secondary)]">
+                              {job.current_timeframe ? `Atual: ${job.current_timeframe}` : 'Aguardando'}
+                            </div>
+                            <div className="text-xs text-[var(--text-secondary)]">
+                              {job.written}/{job.estimated_total ?? '—'} candles
+                            </div>
+                            <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+                              <div
+                                className="h-full bg-[linear-gradient(90deg,rgba(56,189,248,0.9),rgba(16,185,129,0.9))]"
+                                style={{ width: `${Math.min(100, Math.max(0, percent))}%` }}
+                              />
+                            </div>
+                            <div className="text-xs text-[var(--text-muted)]">
+                              {percent.toFixed(1)}% · ETA {formatEtaSeconds(job.eta_seconds)}
+                            </div>
+                          </div>
+                        </td>
+                        <td className="p-3">
+                          <div className="text-xs text-[var(--text-secondary)]">
+                            <span className="inline-flex items-center gap-1">
+                              <Gauge className="h-3.5 w-3.5" />
+                              {job.max_requests_per_minute} rpm
+                            </span>
+                          </div>
+                          <div className="text-xs text-[var(--text-secondary)]">
+                            <span className="inline-flex items-center gap-1">
+                              <Timer className="h-3.5 w-3.5" />
+                              {job.page_size} / lote
+                            </span>
+                          </div>
+                        </td>
+                        <td className="p-3">
+                          <div className="space-y-1 text-xs text-[var(--text-secondary)]">
+                            <div className="inline-flex items-center gap-1">
+                              <CalendarClock className="h-3.5 w-3.5" />
+                              <span>Atualizado: {formatDate(job.updated_at)}</span>
+                            </div>
+                            <div>Criado: {formatDate(job.created_at)}</div>
+                            <div>Encerrado: {formatDate(job.finished_at)}</div>
+                          </div>
+                        </td>
+                        <td className="max-w-[240px] p-3 text-xs text-[var(--text-secondary)]">
+                          <div className="truncate" title={job.last_error || undefined}>
+                            {job.last_error || '—'}
+                          </div>
+                          <div className="mt-1 text-[11px] text-[var(--text-muted)]">
+                            Fonte: {job.provider || job.requested_source || 'auto'}
+                          </div>
+                        </td>
+                        <td className="p-3">
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              icon={<Trash2 className="h-4 w-4" />}
+                              loading={isLoadingAction(`cancel:${job.job_id}`)}
+                              disabled={!canCancel}
+                              onClick={() => handleCancel(job.job_id)}
+                            >
+                              Cancelar
+                            </Button>
+                            <Button
+                              size="sm"
+                              icon={<RefreshCw className="h-4 w-4" />}
+                              loading={isLoadingAction(`retry:${job.job_id}`)}
+                              disabled={!canRetry}
+                              onClick={() => handleRetry(job.job_id)}
+                            >
+                              Retry
+                            </Button>
+                          </div>
+                          {job.current_lookback_to ? (
+                            <div className="mt-2 text-[11px] text-[var(--text-muted)]">Lookback: {formatDate(job.current_lookback_to)}</div>
+                          ) : null}
+                        </td>
+                      </tr>
+                    )
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between border-t border-white/10 px-3 py-3 text-sm">
+            <div className="text-[var(--text-secondary)]">
+              Total: {total} jobs · Página {page} de {totalPages}
+            </div>
+            <div className="flex gap-2">
+              <Button size="sm" disabled={loading || page <= 1} onClick={() => setPage((value) => Math.max(1, value - 1))}>
+                <span>Anterior</span>
+              </Button>
+              <Button size="sm" disabled={loading || page >= totalPages} onClick={() => setPage((value) => Math.min(totalPages, value + 1))}>
+                <span>Próxima</span>
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
+        <CardContent className="space-y-2 p-6">
+          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Observações úteis</h2>
+          <ul className="list-inside list-disc space-y-1 text-sm text-[var(--text-secondary)]">
+            <li>Status <strong>running</strong> e <strong>retrying</strong> representam processamento ativo.</li>
+            <li><strong>partial_complete</strong> indica que o provedor retornou menos candles do esperado antes do fim da janela.</li>
+            <li>Em caso de falha, o botão <strong>Retry</strong> tenta reexecutar o job a partir dos checkpoints salvos.</li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/openspec/changes/2026-04-22-backfill-historico-ativos/.openspec.yaml
+++ b/openspec/changes/2026-04-22-backfill-historico-ativos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/2026-04-22-backfill-historico-ativos/design.md
+++ b/openspec/changes/2026-04-22-backfill-historico-ativos/design.md
@@ -1,0 +1,54 @@
+# Design
+
+## Context
+
+Hoje já existe um fluxo de ingestão contínua de OHLCV por timeframe e símbolo, mas sem um job dedicado de backfill histórico cobrindo janela longa no onboarding.  
+A nova solução cria um job de operação assíncrona que usa as mesmas fontes de candle, com estado persistido e controle de execução para backfill em larga escala.
+
+## Goals
+
+- Garantir backfill automático de 2 anos para qualquer ativo novo (ou selecionado manualmente).
+- Controlar volume de request por paginação + throttle para não saturar provider.
+- Tornar o processamento seguro para reexecução (idempotente).
+- Exibir progresso explícito no admin para operador acompanhar e retomar decisões.
+
+## Non-Goals
+
+- Implementar múltiplos provedores apenas para backfill (o provider atual continua o mesmo por configuração).
+- Alterar estratégia de consulta da UI de backtest no mesmo release.
+
+## Decisions
+
+1. **Modelo de job único por `(symbol, provider, timeframe)`**
+- Cada job é iniciado por ativo e inclui timeframes ativos para aquela fonte.
+- O progresso é agregado por símbolo e detalhado por timeframe para fácil diagnóstico.
+
+2. **Paginação temporal ascendente com checkpoint**
+- O backfill percorre a janela de `agora - 24 meses` até `agora` em lotes ordenados por tempo.
+- Cada lote grava um checkpoint persistente (último candle processado), permitindo retomar sem duplicar.
+
+3. **Throttle por step de lote + backoff por resposta**
+- Antes de cada chamada externa, validar budget de chamadas.
+- Em caso de erro transitório (`429/5xx/network`), aplicar retry com jitter + exponencial.
+
+4. **Idempotência dupla**
+- Escrita de candle continua usando upsert por `(symbol, timeframe, candle_time)` como proteção primária.
+- Estado de job também garante `completed / skipped / duplicated` para observabilidade de reruns.
+
+5. **Admin progress model**
+- Estado em memória + persistência: `pending/running/completed/failed/cancelled`.
+- Exibir `processed`, `total_estimate`, `progress_percent`, `last_error`, `attempts`, `updated_at`.
+
+## Risks / Trade-offs
+
+- **Risco:** janela de 2 anos pode ser maior que o disponível no provider para alguns ativos.  
+  **Mitigação:** aceitar histórico parcial com status `partial_complete` + erro explícito.
+- **Risco:** backfill concorrente de muitos ativos no mesmo host pode atrasar outros jobs.  
+  **Mitigação:** limitar paralelismo global e por provider.
+- **Risco:** progresso total exato pode variar conforme a disponibilidade do histórico.  
+  **Mitigação:** usar contadores `expected_estimate` + reconciliação final por contagem real.
+
+## Open Questions
+
+- Qual timezone padrão considerar no corte de janela? `UTC` por padrão para consistência.
+- O job agendado de backfill deve rodar em cron fixo diário ou só ao detectar novos ativos? (Default sugerido: diário + gatilho manual em onboarding).

--- a/openspec/changes/2026-04-22-backfill-historico-ativos/proposal.md
+++ b/openspec/changes/2026-04-22-backfill-historico-ativos/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Backtests recentes precisam de histórico suficiente para gerar sinais e métricas confiáveis.  
+Hoje, para símbolos recém-adicionados, o sistema frequentemente não tem janelas históricas de 2 anos no storage, comprometendo a qualidade do backtest.
+
+## What Changes
+
+- Incluir job de backfill histórico de OHLCV de 2 anos para novo ativo.
+- Permitir execução manual e agendada do backfill.
+- Implementar paginação no fetch histórico (janela por lotes) com retomada por cursor/cutoff.
+- Aplicar throttle/budget de API (rate limiting + backoff + retry) durante backfill.
+- Garantir idempotência por símbolo/timeframe/página/candle para evitar duplicidade e permitir rerun seguro.
+- Expor progresso e estado no painel Admin com visibilidade por ativo, timeframe, etapa e erros.
+
+## New / Modified Capabilities
+
+### New
+
+- `ohlcv-backfill-2y`: serviço e APIs para backfill de 2 anos por ativo recém-adicionado.
+- `admin-backfill-monitor`: visualização de status/progresso/ETA de backfill no Admin.
+
+### Modified
+
+- `ohlcv-storage`: suporte explícito a cargas históricas em lote para onboarding de ativos.
+- `job-manager`: gerenciamento de jobs no padrão assíncrono (status + progresso + pausa/cancelamento opcional).
+
+## Impact
+
+- Backend: criação de serviço de backfill, scheduler hooks, endpoints administrativos e persistência de progresso/checkpoint por job.
+- Banco de dados: tabela/estrutura de estado de job (se necessário) e índices auxiliares para rastreio por ativo/timeframe.
+- Admin UI: nova área de controle/monitoramento de jobs de backfill.
+
+## Out of Scope
+
+- Mudanças de estratégia de datasource em nível de pricing core (usa providers já existentes).
+- Refatoração da infraestrutura completa de data pipelines fora do fluxo de novos ativos OHLCV.
+- Mudança de retenção (a retenção atual de 2 anos é mantida).

--- a/openspec/changes/2026-04-22-backfill-historico-ativos/specs/job-manager/spec.md
+++ b/openspec/changes/2026-04-22-backfill-historico-ativos/specs/job-manager/spec.md
@@ -1,0 +1,55 @@
+# 2026-04-22-backfill-historico-ativos / job-manager Specification
+
+## Purpose
+
+Provide explicit job lifecycle management for historical OHLCV backfill and expose observable execution state.
+
+## ADDED Requirements
+
+### Requirement: O sistema SHALL support manual and scheduled backfill jobs
+
+The system SHALL support starting backfill jobs both manually and via scheduler.
+
+#### Scenario: Manual initiation
+- **WHEN** admin starts a backfill job for a symbol
+- **THEN** the system SHALL create a job in `pending`, then `running`.
+
+#### Scenario: Scheduled initiation
+- **WHEN** scheduler detects eligible new symbol or stale-history symbol
+- **THEN** the system SHALL enqueue backfill job automatically.
+
+### Requirement: O sistema SHALL track job state machine and progress
+
+Each backfill job SHALL move through explicit states and persist progress counters.
+
+#### Scenario: State transitions
+- **GIVEN** a running job
+- **WHEN** lifecycle changes
+- **THEN** state SHALL be one of: `pending`, `running`, `paused`, `completed`, `partial_complete`, `failed`, `cancelled`.
+
+#### Scenario: Progress visibility
+- **WHEN** a job is running
+- **THEN** the system SHALL expose `processed`, `total_estimate`, `percent`, `timeframes`, `symbols`, `attempts`, and `last_error`.
+
+### Requirement: O sistema SHALL support cancellation/retry semantics
+
+Operators SHALL be able to stop and retry safely.
+
+#### Scenario: Cancel in progress
+- **GIVEN** job in `running`
+- **WHEN** cancel is requested
+- **THEN** worker SHALL stop after safely flushing checkpoints
+- **AND** mark job as `cancelled`.
+
+#### Scenario: Retry partial/failed job
+- **GIVEN** job in `failed`/`partial_complete`
+- **WHEN** retry is requested
+- **THEN** job SHALL resume from last checkpoint where possible and preserve previously completed chunks.
+
+### Requirement: O sistema SHALL record structured job logs/events
+
+Execution trace SHALL include per-step outcomes for operator diagnosis.
+
+#### Scenario: Error recording
+- **WHEN** an execution error occurs
+- **THEN** the system SHALL append an event with timestamp, provider, timeframe, error type, and retry count.

--- a/openspec/changes/2026-04-22-backfill-historico-ativos/specs/ohlcv-storage/spec.md
+++ b/openspec/changes/2026-04-22-backfill-historico-ativos/specs/ohlcv-storage/spec.md
@@ -1,0 +1,59 @@
+# 2026-04-22-backfill-historico-ativos / ohlcv-storage Specification
+
+## Purpose
+
+Enable deterministic 2-year historical backfill for new/selected assets using existing OHLCV providers while preserving current incremental ingestion behavior.
+
+## ADDED Requirements
+
+### Requirement: O sistema SHALL run a dedicated historical backfill for onboarding assets
+
+The system SHALL ingest up to 2 years of OHLCV candles for a given symbol when a backfill job is started manually or by schedule.
+
+#### Scenario: Backfill onboarding fills minimum 2-year history
+- **GIVEN** a backfill job is started for `symbol`
+- **WHEN** the provider returns candles for the requested time window
+- **THEN** the service SHALL attempt to fetch from `now - 24 months` to `now`
+- **AND** persist all successfully retrieved candles
+- **AND** mark job scope as `partial_complete` if provider history is shorter than requested.
+
+### ADDED Requirement: O sistema SHALL paginate historical fetches by bounded page window
+
+The service SHALL fetch candles in discrete pages/chunks, ordered by time, so calls remain bounded and resumable.
+
+#### Scenario: Paginação e checkpoint
+- **GIVEN** a symbol with a large date range
+- **WHEN** backfill starts
+- **THEN** the system SHALL request candles in pages of fixed limit (or provider max page limit)
+- **AND** store a checkpoint after each successful page
+- **AND** resume from the checkpoint after restart/failure.
+
+### ADDED Requirement: O sistema SHALL persist with candle-level dedupe to guarantee idempotence
+
+OHLCV writes SHALL continue using upsert by `(symbol, timeframe, candle_time)` and SHOULD log duplicate-skip metrics.
+
+#### Scenario: Safe rerun
+- **GIVEN** a job is retried after partial failure
+- **WHEN** it reaches an already ingested candle
+- **THEN** the write SHALL no-op for that candle
+- **AND** progress SHALL continue with the next required candle without corruption.
+
+### ADDED Requirement: O sistema SHALL enforce request pacing and retries during historical fetch
+
+The service SHALL not exceed configured rate budgets and SHALL recover transient provider failures.
+
+#### Scenario: Rate-limit-safe fetch
+- **GIVEN** provider responses with 429 or high failure rates
+- **WHEN** fetch loop runs
+- **THEN** the system SHALL apply delay/budget checks
+- **AND** retry with exponential backoff + jitter
+- **AND** continue until success or job failure threshold.
+
+### ADDED Requirement: O sistema SHALL expose a completion summary
+
+Each job SHALL report completion metrics for operator review.
+
+#### Scenario: Job summary
+- **GIVEN** backfill completes
+- **WHEN** admin reads job result
+- **THEN** the system SHALL provide `requested_window`, `fetched_count`, `written_count`, `deduped_count`, `duration_seconds`, and `status`.

--- a/openspec/changes/2026-04-22-backfill-historico-ativos/specs/ui/spec.md
+++ b/openspec/changes/2026-04-22-backfill-historico-ativos/specs/ui/spec.md
@@ -1,0 +1,45 @@
+# 2026-04-22-backfill-historico-ativos / ui Specification
+
+## Purpose
+
+Expose backfill job control and progress in Admin with an operator-friendly timeline.
+
+## ADDED Requirements
+
+### Requirement: O sistema SHALL show active and historical backfill jobs in Admin
+
+The admin interface SHALL include a page/table for backfill jobs with real-time status.
+
+#### Scenario: Visualizar jobs
+- **GIVEN** at least one backfill job exists
+- **WHEN** admin opens the dedicated backfill section
+- **THEN** the page SHALL list `symbol`, `timeframes`, `status`, `progress%`, `ETA`, `updated_at`.
+
+### Requirement: O sistema SHALL allow manual job actions from Admin
+
+Administrators SHALL start and control jobs without backend console access.
+
+#### Scenario: Start / retry / cancel
+- **WHEN** admin clicks start, retry, or cancel
+- **THEN** the backend job state SHALL reflect the action within 1 minute.
+
+### Requirement: The system SHALL show failure context
+
+The system SHALL show failure context for failed jobs.
+
+#### Scenario: Inspecionar erro
+- **GIVEN** job status is `failed`
+- **WHEN** admin opens job details
+- **THEN** the system SHALL show last_error, attempts, and recent event list with timestamps.
+
+### Requirement: O sistema SHALL present loading and empty/error states
+
+The page SHALL be explicit and stable under all states.
+
+#### Scenario: Lista vazia
+- **WHEN** no job exists
+- **THEN** the page SHALL show empty-state messaging and CTA para iniciar backfill.
+
+#### Scenario: Erro de consulta
+- **WHEN** API admin for jobs fails
+- **THEN** a clear error state SHALL be shown and retry action made available.

--- a/openspec/changes/2026-04-22-backfill-historico-ativos/tasks.md
+++ b/openspec/changes/2026-04-22-backfill-historico-ativos/tasks.md
@@ -1,0 +1,42 @@
+## 1. OpenSpec Alignment
+
+- [ ] 1.1 Validar que `proposal.md`, `design.md`, `tasks.md` e specs abaixo estão consistentes.
+- [ ] 1.2 Executar `openspec validate 2026-04-22-backfill-historico-ativos --type change`.
+- [ ] 1.3 Corrigir inconsistências de validação (se houver) antes de implementação.
+
+## 2. Backend: Job de backfill
+
+- [ ] 2.1 Criar serviço `OhlcvBackfillService` com parâmetros:
+  - `symbol`, `timeframes`, `history_window_years=2`, `page_size`, `max_requests_per_minute`.
+- [ ] 2.2 Implementar paginação temporal por lotes (cursor/cutoff) e checkpoint persistido por job.
+- [ ] 2.3 Aplicar política de throttle e retries (`429`/`5xx` + backoff + jitter).
+- [ ] 2.4 Garantir idempotência por chave única e estado de reexecução (skip duplicates / safe reruns).
+- [ ] 2.5 Implementar comandos de start manual, cancel e schedule para backfill de novo ativo.
+
+## 3. Backend: Estado e APIs de progresso
+
+- [ ] 3.1 Criar modelo/armazenamento de `backfill_job` (status, progresso, métricas, erros).
+- [ ] 3.2 Expor endpoints administrativos:
+  - `POST /api/admin/backfill/jobs` (criar manual)
+  - `GET /api/admin/backfill/jobs`
+  - `GET /api/admin/backfill/jobs/{job_id}`
+  - `POST /api/admin/backfill/jobs/{job_id}/cancel` (ou equivalente)
+- [ ] 3.3 Expor endpoint/scheduler para disparo diário de ativos sem histórico ou incompleto.
+- [ ] 3.4 Criar trilha de logs resumida de execução por job (sem saturar disco).
+
+## 4. Frontend: Admin progress
+
+- [ ] 4.1 Adicionar/atualizar painel admin para listar jobs de backfill ativos/concluídos.
+- [ ] 4.2 Exibir progresso por ativo: `status`, `timeframes`, `processed`, `estimated_total`, `percent`, `ETA`, `last_error`, `attempts`.
+- [ ] 4.3 Permitir ação manual de start/cancel/retry na UI admin.
+- [ ] 4.4 Poll ou SSE leve para atualização em tempo real.
+
+## 5. Validação
+
+- [ ] 5.1 Validar job de backfill manual com 1 ativo e múltiplos timeframes (smoke).
+- [ ] 5.2 Validar throttle simulando limite de provider (sem bloqueio/erro fatal).
+- [ ] 5.3 Validar rerun idempotente após falha parcial (o mesmo job finaliza sem duplicidade).
+- [ ] 5.4 Validar progress no admin até `completed/failed/partial_complete`.
+- [ ] 5.5 Atualizar docs de operação conforme necessário.
+
+> Nota: usar project skills de `.codex/skills` quando aplicável (ex.: arquitetura, testes, depuração, review).


### PR DESCRIPTION
## Summary\n- implementa backfill histórico de OHLCV (admin manual e agendado), paginação com retry/backoff/throttle e checkpoint por timeframe\n- adiciona página admin para monitorar/cancelar/retry jobs e progress (percent/ETA)\n- registra contrato OpenSpec em /openspec/changes/2026-04-22-backfill-historico-ativos