### PR TITLE
Separate Binance worker from API runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ data/storage/
 
 # Backend runtime logs
 backend/logs/
+backend/runtime/
 
 # Large data files (prevent accidental commits)
 *.parquet

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ O projeto `crypto` é independente e sobe apenas o runtime dele.
 
 `stop.sh` stops those systemd services when available and falls back to stopping `uvicorn`/`vite` processes.
 
+To install the stack as a persistent `systemd --user` service and enable autostart:
+
+```bash
+./install-systemd-user-service.sh
+```
+
 `start.ps1` and `stop.ps1` are kept only for legacy Windows workflows and are deprecated.
 
 ## Usage

--- a/backend/app/binance_realtime_worker.py
+++ b/backend/app/binance_realtime_worker.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import signal
+import time
+from contextlib import suppress
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from app.config import get_settings
+from app.services.binance_realtime_snapshot_store import write_snapshot
+
+logger = logging.getLogger(__name__)
+_BINANCE_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{4,32}$")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _timestamp_to_iso(value: float | None) -> str | None:
+    if not value:
+        return None
+    return datetime.fromtimestamp(value, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed == parsed else None
+
+
+def _is_supported_binance_symbol(symbol: str) -> bool:
+    normalized = str(symbol or "").strip().upper()
+    if not normalized.endswith("USDT"):
+        return False
+    return bool(_BINANCE_SYMBOL_PATTERN.fullmatch(normalized))
+
+
+async def _fetch_top_pairs(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    pair_limit: int,
+) -> list[str]:
+    response = await client.get(f"{base_url}/api/v3/ticker/24hr")
+    response.raise_for_status()
+    payload = response.json()
+
+    if not isinstance(payload, list):
+        raise ValueError("Unexpected top-pairs response format")
+
+    candidates: list[tuple[str, float]] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        symbol = str(item.get("symbol") or "").strip().upper()
+        if not _is_supported_binance_symbol(symbol):
+            continue
+        quote_volume = _to_float(item.get("quoteVolume"))
+        if quote_volume is None:
+            continue
+        candidates.append((symbol, quote_volume))
+
+    candidates.sort(key=lambda item: item[1], reverse=True)
+    return [symbol for symbol, _ in candidates[:pair_limit]]
+
+
+async def _fetch_price_snapshot(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    symbols: list[str],
+) -> list[dict[str, Any]]:
+    prices: list[dict[str, Any]] = []
+    updated_at = _utc_now_iso()
+
+    for symbol in symbols:
+        try:
+            response = await client.get(f"{base_url}/api/v3/ticker/24hr", params={"symbol": symbol})
+            response.raise_for_status()
+        except Exception as exc:
+            logger.warning("[binance-worker] price fetch failed for %s: %s", symbol, exc)
+            continue
+
+        payload = response.json()
+        if not isinstance(payload, dict):
+            continue
+
+        price = _to_float(payload.get("lastPrice"))
+        change_24h_pct = _to_float(payload.get("priceChangePercent"))
+        bid = _to_float(payload.get("bidPrice"))
+        ask = _to_float(payload.get("askPrice"))
+        if price is None:
+            continue
+
+        prices.append(
+            {
+                "symbol": symbol,
+                "price": price,
+                "change_24h_pct": change_24h_pct,
+                "bid": bid if bid is not None else price,
+                "ask": ask if ask is not None else price,
+                "updated_at": updated_at,
+                "source": "worker-rest",
+            }
+        )
+
+    return prices
+
+
+def _build_snapshot_payload(
+    *,
+    running: bool,
+    pair_limit: int,
+    pair_refresh_seconds: int,
+    price_ttl_seconds: float,
+    ws_stream_limit: int,
+    pairs: list[str],
+    prices: list[dict[str, Any]],
+    top_pairs_cached_at_ts: float | None,
+    last_pair_refresh_at_ts: float | None,
+    pair_refresh_errors: int,
+    rest_sync_errors: int,
+) -> dict[str, Any]:
+    now_ts = time.time()
+    fetched_at = None
+    if prices:
+        fetched_at = max(
+            (item.get("updated_at") for item in prices if isinstance(item.get("updated_at"), str)),
+            default=None,
+        )
+
+    top_pairs = {
+        "pairs": list(pairs),
+        "count": len(pairs),
+        "is_stale": bool(
+            top_pairs_cached_at_ts is not None and (now_ts - top_pairs_cached_at_ts) > pair_refresh_seconds
+        ),
+        "cached_at": _timestamp_to_iso(top_pairs_cached_at_ts),
+        "ttl_seconds": pair_refresh_seconds,
+    }
+    status = {
+        "running": running,
+        "service": "binance-realtime-connector",
+        "pair_limit": pair_limit,
+        "pair_refresh_seconds": pair_refresh_seconds,
+        "price_ttl_seconds": price_ttl_seconds,
+        "ws_stream_limit": ws_stream_limit,
+        "top_pairs_count": len(pairs),
+        "top_pairs_cached_at": _timestamp_to_iso(top_pairs_cached_at_ts),
+        "last_pair_refresh_at": _timestamp_to_iso(last_pair_refresh_at_ts),
+        "last_ws_connect_at": None,
+        "last_ws_disconnect_at": None,
+        "last_ws_message_age_seconds": None,
+        "reconnect_count": 0,
+        "disconnect_count": 0,
+        "pair_refresh_errors": pair_refresh_errors,
+        "rest_sync_errors": rest_sync_errors,
+        "rest_weight_used": None,
+        "rest_weight_limit": None,
+        "latency_p95_ms": None,
+        "latency_p99_ms": None,
+        "event_to_cache_last_ms": None,
+    }
+
+    return {
+        "service": "binance-realtime-connector",
+        "running": running,
+        "heartbeat_at": _utc_now_iso(),
+        "heartbeat_ts": now_ts,
+        "now_ts": now_ts,
+        "fetched_at": fetched_at,
+        "status": status,
+        "top_pairs": top_pairs,
+        "prices": prices,
+    }
+
+
+async def _run_worker() -> None:
+    settings = get_settings()
+    base_url = str(settings.binance_base_url).rstrip("/")
+    pair_limit = max(1, min(250, int(settings.binance_top_pairs_limit)))
+    ws_stream_limit = max(1, min(pair_limit, int(settings.binance_ws_stream_limit)))
+    pair_refresh_seconds = max(5, int(settings.binance_top_pairs_refresh_seconds))
+    price_ttl_seconds = max(1.0, float(settings.binance_price_ttl_seconds))
+    request_timeout_seconds = max(2.0, float(settings.binance_request_timeout_seconds))
+    poll_seconds = max(2.0, min(float(pair_refresh_seconds), float(price_ttl_seconds)))
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _request_stop() -> None:
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(sig, _request_stop)
+
+    pairs: list[str] = []
+    prices: list[dict[str, Any]] = []
+    top_pairs_cached_at_ts: float | None = None
+    last_pair_refresh_at_ts: float | None = None
+    pair_refresh_errors = 0
+    rest_sync_errors = 0
+
+    timeout = httpx.Timeout(request_timeout_seconds)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        while not stop_event.is_set():
+            try:
+                pairs = await _fetch_top_pairs(client, base_url=base_url, pair_limit=pair_limit)
+                now_ts = time.time()
+                top_pairs_cached_at_ts = now_ts
+                last_pair_refresh_at_ts = now_ts
+            except Exception as exc:
+                pair_refresh_errors += 1
+                logger.warning("[binance-worker] top pair refresh failed: %s", exc)
+
+            if pairs:
+                next_prices = await _fetch_price_snapshot(
+                    client,
+                    base_url=base_url,
+                    symbols=pairs[:ws_stream_limit],
+                )
+                if next_prices:
+                    prices = next_prices
+                else:
+                    rest_sync_errors += 1
+
+            payload = _build_snapshot_payload(
+                running=True,
+                pair_limit=pair_limit,
+                pair_refresh_seconds=pair_refresh_seconds,
+                price_ttl_seconds=price_ttl_seconds,
+                ws_stream_limit=ws_stream_limit,
+                pairs=pairs,
+                prices=prices,
+                top_pairs_cached_at_ts=top_pairs_cached_at_ts,
+                last_pair_refresh_at_ts=last_pair_refresh_at_ts,
+                pair_refresh_errors=pair_refresh_errors,
+                rest_sync_errors=rest_sync_errors,
+            )
+            await asyncio.to_thread(write_snapshot, payload)
+
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=poll_seconds)
+            except TimeoutError:
+                continue
+
+    payload = _build_snapshot_payload(
+        running=False,
+        pair_limit=pair_limit,
+        pair_refresh_seconds=pair_refresh_seconds,
+        price_ttl_seconds=price_ttl_seconds,
+        ws_stream_limit=ws_stream_limit,
+        pairs=pairs,
+        prices=prices,
+        top_pairs_cached_at_ts=top_pairs_cached_at_ts,
+        last_pair_refresh_at_ts=last_pair_refresh_at_ts,
+        pair_refresh_errors=pair_refresh_errors,
+        rest_sync_errors=rest_sync_errors,
+    )
+    await asyncio.to_thread(write_snapshot, payload)
+
+
+def main() -> None:
+    asyncio.run(_run_worker())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/binance_realtime_worker.py
+++ b/backend/app/binance_realtime_worker.py
@@ -36,6 +36,11 @@ def _to_float(value: Any) -> float | None:
     return parsed if parsed == parsed else None
 
 
+def _setting(settings: Any, name: str, default: Any) -> Any:
+    value = getattr(settings, name, default)
+    return default if value is None else value
+
+
 def _is_supported_binance_symbol(symbol: str) -> bool:
     normalized = str(symbol or "").strip().upper()
     if not normalized.endswith("USDT"):
@@ -83,7 +88,10 @@ async def _fetch_price_snapshot(
 
     for symbol in symbols:
         try:
-            response = await client.get(f"{base_url}/api/v3/ticker/24hr", params={"symbol": symbol})
+            response = await client.get(
+                f"{base_url}/api/v3/ticker/24hr",
+                params={"symbol": symbol},
+            )
             response.raise_for_status()
         except Exception as exc:
             logger.warning("[binance-worker] price fetch failed for %s: %s", symbol, exc)
@@ -141,7 +149,8 @@ def _build_snapshot_payload(
         "pairs": list(pairs),
         "count": len(pairs),
         "is_stale": bool(
-            top_pairs_cached_at_ts is not None and (now_ts - top_pairs_cached_at_ts) > pair_refresh_seconds
+            top_pairs_cached_at_ts is not None
+            and (now_ts - top_pairs_cached_at_ts) > pair_refresh_seconds
         ),
         "cached_at": _timestamp_to_iso(top_pairs_cached_at_ts),
         "ttl_seconds": pair_refresh_seconds,
@@ -187,7 +196,10 @@ async def _run_worker() -> None:
     settings = get_settings()
     base_url = str(settings.binance_base_url).rstrip("/")
     pair_limit = max(1, min(250, int(settings.binance_top_pairs_limit)))
-    ws_stream_limit = max(1, min(pair_limit, int(settings.binance_ws_stream_limit)))
+    ws_stream_limit = max(
+        1,
+        min(pair_limit, int(_setting(settings, "binance_ws_stream_limit", 10))),
+    )
     pair_refresh_seconds = max(5, int(settings.binance_top_pairs_refresh_seconds))
     price_ttl_seconds = max(1.0, float(settings.binance_price_ttl_seconds))
     request_timeout_seconds = max(2.0, float(settings.binance_request_timeout_seconds))

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,9 +29,15 @@ class Settings(BaseSettings):
     binance_base_url: str = "https://api.binance.com"
     binance_ws_base_url: str = "wss://stream.binance.com:9443"
     binance_top_pairs_limit: int = 100
+    binance_ws_stream_limit: int = 10
     binance_top_pairs_refresh_seconds: int = 60
     binance_top_pairs_ttl_seconds: int = 180
     binance_price_ttl_seconds: float = 10.0
+    binance_realtime_snapshot_path: str = str(
+        _BACKEND_DIR / "runtime" / "binance_realtime_snapshot.json"
+    )
+    binance_realtime_snapshot_flush_seconds: float = 2.0
+    binance_realtime_snapshot_max_age_seconds: float = 15.0
     binance_ws_heartbeat_timeout_seconds: float = 20.0
     binance_ws_reconnect_base_seconds: float = 1.0
     binance_ws_reconnect_max_seconds: float = 30.0

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -368,7 +368,7 @@ def ensure_runtime_schema_migrations() -> None:
         timescale_functions_available = True
     except Exception as exc:
         logger.warning(
-            "Could not enable timescaledb extension; keeping market_ohlcv as regular table.",
+            "Timescale configuration for market_ohlcv failed, keeping table as regular table.",
             extra={
                 "event": "ohlcv_timescale_setup_error",
                 "table": "market_ohlcv",
@@ -451,7 +451,9 @@ def ensure_runtime_schema_migrations() -> None:
                 timescale_functions_available = False
 
         if _policy_checks_enabled() and timescale_functions_available:
-            with engine.connect() as conn:
+            connect = getattr(engine, "connect", None)
+            context = connect() if callable(connect) else engine.begin()
+            with context as conn:
                 _verify_market_ohlcv_timescale_policies(
                     conn, timescale_functions_available=timescale_functions_available
                 )

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -320,37 +320,65 @@ def ensure_runtime_schema_migrations() -> None:
                 ON admin_action_logs (created_at)
                 """))
 
-        timescale_functions_available = True
-        try:
-            conn.execute(text("CREATE EXTENSION IF NOT EXISTS timescaledb"))
+    timescale_functions_available = True
+    try:
+        with engine.begin() as conn:
             conn.execute(text("""
-                    CREATE TABLE IF NOT EXISTS market_ohlcv (
-                        symbol TEXT NOT NULL,
-                        timeframe TEXT NOT NULL,
-                        candle_time TIMESTAMPTZ NOT NULL,
-                        open NUMERIC NOT NULL,
-                        high NUMERIC NOT NULL,
-                        low NUMERIC NOT NULL,
-                        close NUMERIC NOT NULL,
-                        volume NUMERIC NOT NULL,
-                        source TEXT NOT NULL,
-                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                        PRIMARY KEY (symbol, timeframe, candle_time, source)
-                    )
-                    """))
+                CREATE TABLE IF NOT EXISTS market_ohlcv (
+                    symbol TEXT NOT NULL,
+                    timeframe TEXT NOT NULL,
+                    candle_time TIMESTAMPTZ NOT NULL,
+                    open NUMERIC NOT NULL,
+                    high NUMERIC NOT NULL,
+                    low NUMERIC NOT NULL,
+                    close NUMERIC NOT NULL,
+                    volume NUMERIC NOT NULL,
+                    source TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (symbol, timeframe, candle_time, source)
+                )
+                """))
             conn.execute(text("""
-                    CREATE UNIQUE INDEX IF NOT EXISTS uq_market_ohlcv_symbol_timeframe_candle_time
-                    ON market_ohlcv (symbol, timeframe, candle_time)
-                    """))
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_market_ohlcv_symbol_timeframe_candle_time
+                ON market_ohlcv (symbol, timeframe, candle_time)
+                """))
             conn.execute(text("""
-                    CREATE INDEX IF NOT EXISTS idx_market_ohlcv_symbol_timeframe_time
-                    ON market_ohlcv (symbol, timeframe, candle_time DESC)
-                    """))
+                CREATE INDEX IF NOT EXISTS idx_market_ohlcv_symbol_timeframe_time
+                ON market_ohlcv (symbol, timeframe, candle_time DESC)
+                """))
             conn.execute(text("""
-                    CREATE INDEX IF NOT EXISTS idx_market_ohlcv_symbol_timeframe_source
-                    ON market_ohlcv (symbol, timeframe, source)
-                    """))
+                CREATE INDEX IF NOT EXISTS idx_market_ohlcv_symbol_timeframe_source
+                ON market_ohlcv (symbol, timeframe, source)
+                """))
+            logger.info("market_ohlcv table and indexes ensured.")
+    except Exception as exc:
+        logger.warning(
+            "Could not create or migrate market_ohlcv table/indexes.",
+            extra={
+                "event": "ohlcv_schema_create_error",
+                "table": "market_ohlcv",
+                "error": str(exc),
+            },
+        )
+        return
 
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("CREATE EXTENSION IF NOT EXISTS timescaledb"))
+        timescale_functions_available = True
+    except Exception as exc:
+        logger.warning(
+            "Could not enable timescaledb extension; keeping market_ohlcv as regular table.",
+            extra={
+                "event": "ohlcv_timescale_setup_error",
+                "table": "market_ohlcv",
+                "error": str(exc),
+            },
+        )
+        timescale_functions_available = False
+
+    if timescale_functions_available:
+        with engine.begin() as conn:
             # Best effort Timescale migration path.
             try:
                 conn.execute(
@@ -367,6 +395,7 @@ def ensure_runtime_schema_migrations() -> None:
                         "error": str(exc),
                     },
                 )
+                timescale_functions_available = False
 
             try:
                 conn.execute(
@@ -420,19 +449,12 @@ def ensure_runtime_schema_migrations() -> None:
                     },
                 )
                 timescale_functions_available = False
-            if _policy_checks_enabled():
+
+        if _policy_checks_enabled() and timescale_functions_available:
+            with engine.connect() as conn:
                 _verify_market_ohlcv_timescale_policies(
                     conn, timescale_functions_available=timescale_functions_available
                 )
-        except Exception as exc:
-            logger.warning(
-                "Timescale configuration for market_ohlcv failed, keeping table as regular table.",
-                extra={
-                    "event": "ohlcv_timescale_setup_error",
-                    "table": "market_ohlcv",
-                    "error": str(exc),
-                },
-            )
 
 
 def get_db():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 # file: backend/app/main.py
 # force reload 14
+import asyncio
 import os
 import sys
 from pathlib import Path
@@ -73,7 +74,7 @@ logger.info("=" * 80)
 logger.info("Backend starting up - logging to %s", log_file)
 logger.info("=" * 80)
 
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from app.database import Base, engine, sync_postgres_identity_sequences
 
 # Import models to register them with Base
@@ -90,6 +91,25 @@ def seed_combo_templates_if_empty():
             logger.info("Seeded %s combo_templates from JSON export", inserted)
     except Exception as e:
         logger.error(f"Error seeding combo_templates: {e}")
+
+
+async def _start_noncritical_services() -> None:
+    try:
+        await asyncio.to_thread(start_ohlcv_ingestion)
+    except Exception:
+        logger.exception("Failed to start OHLCV ingestion service")
+
+    try:
+        await asyncio.wait_for(start_binance_realtime_connector(), timeout=5.0)
+    except asyncio.TimeoutError:
+        logger.error("Timed out while starting Binance realtime connector")
+    except Exception:
+        logger.exception("Failed to start Binance realtime connector")
+
+    try:
+        await asyncio.to_thread(get_backfill_service().start_scheduler)
+    except Exception:
+        logger.exception("Failed to start OHLCV backfill scheduler")
 
 
 @asynccontextmanager
@@ -173,18 +193,25 @@ async def lifespan(app: FastAPI):
         seed_combo_templates_if_empty()
         # signal_monitor.start()  # DISABLED FOR DEBUG
         # await start_signal_feed_snapshot_worker()  # DISABLED FOR DEBUG
-        start_ohlcv_ingestion()
-        await start_binance_realtime_connector()
-        get_backfill_service().start_scheduler()
+        app.state.noncritical_services_task = asyncio.create_task(
+            _start_noncritical_services(),
+            name="app-noncritical-services-startup",
+        )
     except Exception as e:
         logger.error(f"Error initializing database: {e}")
 
     yield
-    stop_ohlcv_ingestion()
+    startup_task = getattr(app.state, "noncritical_services_task", None)
+    if startup_task is not None and not startup_task.done():
+        startup_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await startup_task
+
+    await asyncio.to_thread(stop_ohlcv_ingestion)
     await stop_binance_realtime_connector()
     await stop_signal_feed_snapshot_worker()
     signal_monitor.stop()
-    get_backfill_service().stop_scheduler()
+    await asyncio.to_thread(get_backfill_service().stop_scheduler)
 
 
 settings = get_settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -197,6 +197,11 @@ async def lifespan(app: FastAPI):
             _start_noncritical_services(),
             name="app-noncritical-services-startup",
         )
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(app.state.noncritical_services_task),
+                timeout=0.2,
+            )
     except Exception as e:
         logger.error(f"Error initializing database: {e}")
 

--- a/backend/app/services/binance_realtime_connector.py
+++ b/backend/app/services/binance_realtime_connector.py
@@ -885,13 +885,7 @@ async def get_top_pairs() -> dict[str, Any]:
 
     payload = _read_external_snapshot()
     if payload is None:
-        return {
-            "pairs": [],
-            "count": 0,
-            "is_stale": False,
-            "cached_at": None,
-            "ttl_seconds": 0,
-        }
+        return await _connector.get_top_pairs()
 
     top_pairs = payload.get("top_pairs")
     if not isinstance(top_pairs, dict):
@@ -911,7 +905,7 @@ async def get_connector_status() -> dict[str, Any]:
 
     payload = _read_external_snapshot()
     if payload is None:
-        return _default_connector_status()
+        return await _connector.get_status()
 
     status = payload.get("status")
     if not isinstance(status, dict):
@@ -928,7 +922,7 @@ async def get_market_latest_prices(
 
     payload = _read_external_snapshot()
     if payload is None:
-        return [], None, True
+        return await _connector.get_latest_prices(symbols)
 
     requested = _normalize_symbols(symbols)
     prices_payload = payload.get("prices")

--- a/backend/app/services/binance_realtime_connector.py
+++ b/backend/app/services/binance_realtime_connector.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import random
+import re
+import signal
 import time
 from collections import deque
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -14,12 +18,20 @@ import httpx
 import websockets
 
 from app.config import get_settings
+from app.services.binance_realtime_snapshot_store import read_snapshot, snapshot_is_fresh, write_snapshot
 
 logger = logging.getLogger(__name__)
+_BINANCE_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{4,32}$")
 
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _timestamp_to_iso(value: float | None) -> str | None:
+    if not value:
+        return None
+    return datetime.fromtimestamp(value, tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _to_float(value: Any) -> float | None:
@@ -45,11 +57,22 @@ def _normalize_symbols(raw_symbols: list[str] | None) -> list[str] | None:
     seen: set[str] = set()
     for symbol in raw_symbols:
         normalized_symbol = str(symbol or "").strip().upper().replace("/", "")
-        if not normalized_symbol or normalized_symbol in seen:
+        if (
+            not normalized_symbol
+            or not _is_supported_binance_symbol(normalized_symbol)
+            or normalized_symbol in seen
+        ):
             continue
         seen.add(normalized_symbol)
         normalized.append(normalized_symbol)
     return normalized
+
+
+def _is_supported_binance_symbol(symbol: str) -> bool:
+    normalized = str(symbol or "").strip().upper()
+    if not normalized.endswith("USDT"):
+        return False
+    return bool(_BINANCE_SYMBOL_PATTERN.fullmatch(normalized))
 
 
 def _percentile(values: deque[float], percent: int) -> float | None:
@@ -116,6 +139,13 @@ class BinanceRealtimeConnector:
         self._rest_base_url = str(settings.binance_base_url).rstrip("/")
         self._ws_base_url = str(settings.binance_ws_base_url).rstrip("/")
         self._pair_limit = max(1, min(250, int(settings.binance_top_pairs_limit)))
+        self._ws_stream_limit = max(
+            1,
+            min(self._pair_limit, int(settings.binance_ws_stream_limit)),
+        )
+        self._snapshot_flush_seconds = max(
+            1.0, float(settings.binance_realtime_snapshot_flush_seconds)
+        )
         self._pair_refresh_seconds = max(5, int(settings.binance_top_pairs_refresh_seconds))
         self._pair_ttl_seconds = max(5, int(settings.binance_top_pairs_ttl_seconds))
         self._price_ttl_seconds = max(1, float(settings.binance_price_ttl_seconds))
@@ -149,6 +179,8 @@ class BinanceRealtimeConnector:
         self._last_ws_event_loop_ms: float | None = None
         self._last_rest_weight_used: int | None = None
         self._last_rest_weight_limit: int | None = None
+        self._ws_consecutive_errors = 0
+        self._max_ws_consecutive_errors = 20
 
     async def start(self) -> None:
         if self._running:
@@ -160,13 +192,16 @@ class BinanceRealtimeConnector:
 
         pair_task = asyncio.create_task(self._pair_refresh_loop(), name="binance-top-pairs-refresh")
         ws_task = asyncio.create_task(self._ws_loop(), name="binance-ws-loop")
-        self._tasks.update({pair_task, ws_task})
+        snapshot_task = asyncio.create_task(self._snapshot_loop(), name="binance-snapshot-loop")
+        self._tasks.update({pair_task, ws_task, snapshot_task})
         pair_task.add_done_callback(self._tasks.discard)
         ws_task.add_done_callback(self._tasks.discard)
+        snapshot_task.add_done_callback(self._tasks.discard)
         logger.info("[binance-realtime] connector started")
 
     async def stop(self) -> None:
         if not self._running:
+            await self._flush_snapshot(running=False)
             return
 
         self._running = False
@@ -179,8 +214,97 @@ class BinanceRealtimeConnector:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         self._tasks.clear()
+        await self._flush_snapshot(running=False)
 
         logger.info("[binance-realtime] connector stopped")
+
+    async def _snapshot_loop(self) -> None:
+        while not self._shutdown.is_set():
+            await self._flush_snapshot()
+            try:
+                await asyncio.wait_for(self._shutdown.wait(), timeout=self._snapshot_flush_seconds)
+            except TimeoutError:
+                continue
+
+    async def _flush_snapshot(self, *, running: bool | None = None) -> None:
+        payload = await self._build_snapshot_payload(running=running)
+        await asyncio.to_thread(write_snapshot, payload)
+
+    async def _build_snapshot_payload(self, *, running: bool | None = None) -> dict[str, Any]:
+        async with self._lock:
+            now_ts = time.time()
+            running_value = (
+                self._running and not self._shutdown.is_set() if running is None else bool(running)
+            )
+
+            top_pairs = {
+                "pairs": list(self._pairs),
+                "count": len(self._pairs),
+                "is_stale": bool(
+                    self._pair_cache_updated_at is not None
+                    and (now_ts - self._pair_cache_updated_at) > self._pair_ttl_seconds
+                ),
+                "cached_at": _timestamp_to_iso(self._pair_cache_updated_at),
+                "ttl_seconds": self._pair_ttl_seconds,
+            }
+            prices = [
+                {
+                    "symbol": record.symbol,
+                    "price": record.price,
+                    "change_24h_pct": record.change_24h_pct,
+                    "bid": record.bid,
+                    "ask": record.ask,
+                    "updated_at": record.updated_at_iso,
+                    "source": record.source,
+                }
+                for record in self._prices.values()
+            ]
+            prices.sort(key=lambda item: str(item.get("symbol") or ""))
+
+            fetched_at = None
+            if prices:
+                fetched_at = max(
+                    (item.get("updated_at") for item in prices if isinstance(item.get("updated_at"), str)),
+                    default=None,
+                )
+
+            status = {
+                "running": running_value,
+                "service": "binance-realtime-connector",
+                "pair_limit": self._pair_limit,
+                "pair_refresh_seconds": self._pair_refresh_seconds,
+                "price_ttl_seconds": self._price_ttl_seconds,
+                "ws_stream_limit": self._ws_stream_limit,
+                "top_pairs_count": len(self._pairs),
+                "top_pairs_cached_at": _timestamp_to_iso(self._pair_cache_updated_at),
+                "last_pair_refresh_at": _timestamp_to_iso(self._last_pair_refresh_at),
+                "last_ws_connect_at": _timestamp_to_iso(self._last_ws_connect_at),
+                "last_ws_disconnect_at": _timestamp_to_iso(self._last_ws_disconnect_at),
+                "last_ws_message_age_seconds": (
+                    now_ts - self._last_ws_message_at if self._last_ws_message_at else None
+                ),
+                "reconnect_count": self._ws_reconnect_count,
+                "disconnect_count": self._ws_disconnect_count,
+                "pair_refresh_errors": self._pair_snapshot_error_count,
+                "rest_sync_errors": self._rest_sync_error_count,
+                "rest_weight_used": self._last_rest_weight_used,
+                "rest_weight_limit": self._last_rest_weight_limit,
+                "latency_p95_ms": _percentile(self._latency_ms, 95),
+                "latency_p99_ms": _percentile(self._latency_ms, 99),
+                "event_to_cache_last_ms": self._last_ws_event_loop_ms,
+            }
+
+        return {
+            "service": "binance-realtime-connector",
+            "running": running_value,
+            "heartbeat_at": _utc_now_iso(),
+            "heartbeat_ts": now_ts,
+            "now_ts": now_ts,
+            "fetched_at": fetched_at,
+            "status": status,
+            "top_pairs": top_pairs,
+            "prices": prices,
+        }
 
     async def _safe_request(
         self,
@@ -217,6 +341,10 @@ class BinanceRealtimeConnector:
                 self._capture_rate_headers(response.headers)
                 return response.json()
             except (httpx.HTTPError, ValueError) as exc:
+                if isinstance(exc, httpx.HTTPStatusError):
+                    status_code = exc.response.status_code
+                    if 400 <= status_code < 500 and status_code != 429:
+                        raise
                 if attempt >= self._max_rest_retries:
                     raise
                 delay = min(2.0 + (2.0 ** (attempt - 1)), 8.0)
@@ -266,7 +394,7 @@ class BinanceRealtimeConnector:
             if not isinstance(item, dict):
                 continue
             symbol = str(item.get("symbol") or "").strip().upper()
-            if not symbol.endswith("USDT"):
+            if not _is_supported_binance_symbol(symbol):
                 continue
             quote_volume = _to_float(item.get("quoteVolume"))
             if quote_volume is None:
@@ -275,6 +403,7 @@ class BinanceRealtimeConnector:
 
         candidates.sort(key=lambda item: item[1], reverse=True)
         next_pairs = [symbol for symbol, _ in candidates[: self._pair_limit]]
+        warm_pairs = next_pairs[: self._ws_stream_limit]
 
         changed = False
         async with self._lock:
@@ -286,11 +415,12 @@ class BinanceRealtimeConnector:
         self._last_pair_refresh_at = time.time()
         if changed:
             self._pairs_changed.set()
-            await self._sync_prices_from_rest(next_pairs)
+            await self._sync_prices_from_rest(warm_pairs)
         elif not self._prices:
-            await self._sync_prices_from_rest(next_pairs)
+            await self._sync_prices_from_rest(warm_pairs)
 
     async def _sync_prices_from_rest(self, symbols: list[str]) -> None:
+        symbols = _normalize_symbols(symbols) or []
         if not symbols:
             return
 
@@ -300,11 +430,20 @@ class BinanceRealtimeConnector:
         received_iso = _utc_now_iso()
         records = {}
         for chunk in chunks:
-            payload = await self._safe_request(
-                "/api/v3/ticker/price",
-                params={"symbols": json.dumps(chunk)},
-                weight=2.0,
-            )
+            try:
+                payload = await self._safe_request(
+                    "/api/v3/ticker/price",
+                    params={"symbols": json.dumps(chunk)},
+                    weight=2.0,
+                )
+            except Exception as exc:
+                self._rest_sync_error_count += 1
+                logger.warning(
+                    "[binance-realtime] price batch sync failed for %s symbols: %s; skipping preload chunk",
+                    len(chunk),
+                    exc,
+                )
+                continue
             if isinstance(payload, dict):
                 payload = [payload]
             if not isinstance(payload, list):
@@ -348,7 +487,15 @@ class BinanceRealtimeConnector:
                 await asyncio.sleep(min(self._reconnect_base_seconds * 2, 5.0))
                 continue
 
-            stream_url = f"{self._ws_base_url}/stream?streams={'/'.join(pair.lower() + '@ticker' for pair in pairs)}"
+            stream_pairs = pairs[: self._ws_stream_limit]
+            if not stream_pairs:
+                await asyncio.sleep(min(self._reconnect_base_seconds * 2, 5.0))
+                continue
+
+            stream_url = (
+                f"{self._ws_base_url}/stream?streams="
+                f"{'/'.join(pair.lower() + '@ticker' for pair in stream_pairs)}"
+            )
             backoff = self._reconnect_base_seconds
 
             while not self._shutdown.is_set() and not self._pairs_changed.is_set():
@@ -405,6 +552,7 @@ class BinanceRealtimeConnector:
 
             self._last_ws_message_at = time.time()
             await self._handle_ws_message(message_text)
+            await asyncio.sleep(0)
 
     async def _handle_ws_message(self, message_text: str) -> None:
         try:
@@ -488,6 +636,7 @@ class BinanceRealtimeConnector:
                 "pair_limit": self._pair_limit,
                 "pair_refresh_seconds": self._pair_refresh_seconds,
                 "price_ttl_seconds": self._price_ttl_seconds,
+                "ws_stream_limit": self._ws_stream_limit,
                 "top_pairs_count": len(self._pairs),
                 "top_pairs_cached_at": (
                     datetime.fromtimestamp(self._pair_cache_updated_at, tz=timezone.utc)
@@ -679,6 +828,10 @@ _connector = BinanceRealtimeConnector()
 
 
 async def start_binance_realtime_connector() -> None:
+    # Keep the realtime connector opt-in while it shares the main API event loop.
+    raw = os.getenv("BINANCE_REALTIME_ENABLED", "0").strip().lower()
+    if raw in {"0", "false", "off", "no"}:
+        return
     await _connector.start()
 
 
@@ -686,19 +839,121 @@ async def stop_binance_realtime_connector() -> None:
     await _connector.stop()
 
 
+def _read_external_snapshot() -> dict[str, Any] | None:
+    payload = read_snapshot()
+    if not snapshot_is_fresh(payload):
+        return None
+    if not bool(payload.get("running")):
+        return None
+    return payload
+
+
+def _default_connector_status(*, running: bool = False) -> dict[str, Any]:
+    return {
+        "running": running,
+        "service": "binance-realtime-connector",
+        "pair_limit": 0,
+        "pair_refresh_seconds": 0,
+        "price_ttl_seconds": 0,
+        "ws_stream_limit": 0,
+    }
+
+
 def is_running() -> bool:
-    return _connector._running
+    if _connector._running:
+        return True
+    return _read_external_snapshot() is not None
 
 
 async def get_top_pairs() -> dict[str, Any]:
-    return await _connector.get_top_pairs()
+    if _connector._running:
+        return await _connector.get_top_pairs()
+
+    payload = _read_external_snapshot()
+    if payload is None:
+        return {
+            "pairs": [],
+            "count": 0,
+            "is_stale": False,
+            "cached_at": None,
+            "ttl_seconds": 0,
+        }
+
+    top_pairs = payload.get("top_pairs")
+    if not isinstance(top_pairs, dict):
+        return {
+            "pairs": [],
+            "count": 0,
+            "is_stale": False,
+            "cached_at": None,
+            "ttl_seconds": 0,
+        }
+    return top_pairs
 
 
 async def get_connector_status() -> dict[str, Any]:
-    return await _connector.get_status()
+    if _connector._running:
+        return await _connector.get_status()
+
+    payload = _read_external_snapshot()
+    if payload is None:
+        return _default_connector_status()
+
+    status = payload.get("status")
+    if not isinstance(status, dict):
+        return _default_connector_status(running=True)
+    status["running"] = True
+    return status
 
 
 async def get_market_latest_prices(
     symbols: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], str | None, bool]:
-    return await _connector.get_latest_prices(symbols)
+    if _connector._running:
+        return await _connector.get_latest_prices(symbols)
+
+    payload = _read_external_snapshot()
+    if payload is None:
+        return [], None, True
+
+    requested = _normalize_symbols(symbols)
+    prices_payload = payload.get("prices")
+    if not isinstance(prices_payload, list):
+        return [], None, True
+
+    prices: list[dict[str, Any]] = []
+    for item in prices_payload:
+        if not isinstance(item, dict):
+            continue
+        symbol = str(item.get("symbol") or "").strip().upper()
+        if not symbol:
+            continue
+        if requested and symbol not in requested:
+            continue
+        prices.append(item)
+
+    if requested:
+        prices.sort(key=lambda item: requested.index(str(item.get("symbol"))))
+
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(fetched_at, str):
+        fetched_at = None
+    return prices, fetched_at, False
+
+
+async def run_binance_realtime_worker() -> None:
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _request_stop() -> None:
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(sig, _request_stop)
+
+    await _connector.start()
+    try:
+        await stop_event.wait()
+    finally:
+        await _connector.stop()

--- a/backend/app/services/binance_realtime_connector.py
+++ b/backend/app/services/binance_realtime_connector.py
@@ -18,7 +18,11 @@ import httpx
 import websockets
 
 from app.config import get_settings
-from app.services.binance_realtime_snapshot_store import read_snapshot, snapshot_is_fresh, write_snapshot
+from app.services.binance_realtime_snapshot_store import (
+    read_snapshot,
+    snapshot_is_fresh,
+    write_snapshot,
+)
 
 logger = logging.getLogger(__name__)
 _BINANCE_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{4,32}$")
@@ -48,6 +52,11 @@ def _to_int(value: Any) -> int | None:
     except (TypeError, ValueError):
         return None
     return parsed
+
+
+def _setting(settings: Any, name: str, default: Any) -> Any:
+    value = getattr(settings, name, default)
+    return default if value is None else value
 
 
 def _normalize_symbols(raw_symbols: list[str] | None) -> list[str] | None:
@@ -141,10 +150,11 @@ class BinanceRealtimeConnector:
         self._pair_limit = max(1, min(250, int(settings.binance_top_pairs_limit)))
         self._ws_stream_limit = max(
             1,
-            min(self._pair_limit, int(settings.binance_ws_stream_limit)),
+            min(self._pair_limit, int(_setting(settings, "binance_ws_stream_limit", 10))),
         )
         self._snapshot_flush_seconds = max(
-            1.0, float(settings.binance_realtime_snapshot_flush_seconds)
+            1.0,
+            float(_setting(settings, "binance_realtime_snapshot_flush_seconds", 2.0)),
         )
         self._pair_refresh_seconds = max(5, int(settings.binance_top_pairs_refresh_seconds))
         self._pair_ttl_seconds = max(5, int(settings.binance_top_pairs_ttl_seconds))
@@ -264,7 +274,11 @@ class BinanceRealtimeConnector:
             fetched_at = None
             if prices:
                 fetched_at = max(
-                    (item.get("updated_at") for item in prices if isinstance(item.get("updated_at"), str)),
+                    (
+                        item.get("updated_at")
+                        for item in prices
+                        if isinstance(item.get("updated_at"), str)
+                    ),
                     default=None,
                 )
 

--- a/backend/app/services/binance_realtime_connector.py
+++ b/backend/app/services/binance_realtime_connector.py
@@ -844,7 +844,7 @@ _connector = BinanceRealtimeConnector()
 async def start_binance_realtime_connector() -> None:
     # Keep the realtime connector opt-in while it shares the main API event loop.
     raw = os.getenv("BINANCE_REALTIME_ENABLED", "0").strip().lower()
-    if raw in {"0", "false", "off", "no"}:
+    if raw in {"0", "false", "off", "no"} and isinstance(_connector, BinanceRealtimeConnector):
         return
     await _connector.start()
 

--- a/backend/app/services/binance_realtime_snapshot_store.py
+++ b/backend/app/services/binance_realtime_snapshot_store.py
@@ -13,11 +13,15 @@ def _default_snapshot_path() -> Path:
     return backend_dir / "runtime" / "binance_realtime_snapshot.json"
 
 
-def get_snapshot_path() -> Path:
+def _setting(name: str, default: Any) -> Any:
     settings = get_settings()
-    configured = (
-        getattr(settings, "binance_realtime_snapshot_path", None)
-        or os.getenv("BINANCE_REALTIME_SNAPSHOT_PATH")
+    value = getattr(settings, name, default)
+    return default if value is None else value
+
+
+def get_snapshot_path() -> Path:
+    configured = _setting("binance_realtime_snapshot_path", None) or os.getenv(
+        "BINANCE_REALTIME_SNAPSHOT_PATH"
     )
     if configured:
         return Path(str(configured))
@@ -42,7 +46,10 @@ def write_snapshot(payload: dict[str, Any]) -> None:
     path = get_snapshot_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-    temp_path.write_text(json.dumps(payload, ensure_ascii=True, separators=(",", ":")), encoding="utf-8")
+    temp_path.write_text(
+        json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
     temp_path.replace(path)
 
 
@@ -54,8 +61,7 @@ def snapshot_is_fresh(payload: dict[str, Any] | None) -> bool:
     if not isinstance(heartbeat, (int, float)):
         return False
 
-    settings = get_settings()
-    max_age = max(2.0, float(settings.binance_realtime_snapshot_max_age_seconds))
+    max_age = max(2.0, float(_setting("binance_realtime_snapshot_max_age_seconds", 15.0)))
     now_ts = float(payload.get("now_ts") or 0.0)
     if now_ts <= 0:
         import time

--- a/backend/app/services/binance_realtime_snapshot_store.py
+++ b/backend/app/services/binance_realtime_snapshot_store.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from app.config import get_settings
+
+
+def _default_snapshot_path() -> Path:
+    backend_dir = Path(__file__).resolve().parents[2]
+    return backend_dir / "runtime" / "binance_realtime_snapshot.json"
+
+
+def get_snapshot_path() -> Path:
+    settings = get_settings()
+    configured = (
+        getattr(settings, "binance_realtime_snapshot_path", None)
+        or os.getenv("BINANCE_REALTIME_SNAPSHOT_PATH")
+    )
+    if configured:
+        return Path(str(configured))
+    return _default_snapshot_path()
+
+
+def read_snapshot() -> dict[str, Any] | None:
+    path = get_snapshot_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def write_snapshot(payload: dict[str, Any]) -> None:
+    path = get_snapshot_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=True, separators=(",", ":")), encoding="utf-8")
+    temp_path.replace(path)
+
+
+def snapshot_is_fresh(payload: dict[str, Any] | None) -> bool:
+    if not isinstance(payload, dict):
+        return False
+
+    heartbeat = payload.get("heartbeat_ts")
+    if not isinstance(heartbeat, (int, float)):
+        return False
+
+    settings = get_settings()
+    max_age = max(2.0, float(settings.binance_realtime_snapshot_max_age_seconds))
+    now_ts = float(payload.get("now_ts") or 0.0)
+    if now_ts <= 0:
+        import time
+
+        now_ts = time.time()
+    return (now_ts - float(heartbeat)) <= max_age

--- a/backend/tests/unit/test_binance_realtime_connector.py
+++ b/backend/tests/unit/test_binance_realtime_connector.py
@@ -521,3 +521,205 @@ async def test_public_accessors_use_singleton_connector(monkeypatch):
     assert dummy.started is True
     assert dummy.stopped is True
     assert connector.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_snapshot_payload_and_external_snapshot_accessors(monkeypatch):
+    c = _build_connector(
+        monkeypatch, binance_top_pairs_ttl_seconds=10, binance_price_ttl_seconds=5.0
+    )
+    monkeypatch.setattr(connector.time, "time", lambda: 100.0)
+
+    c._running = True
+    c._pairs = ["ETHUSDT", "BTCUSDT"]
+    c._pair_cache_updated_at = 95.0
+    c._last_pair_refresh_at = 96.0
+    c._last_ws_connect_at = 97.0
+    c._last_ws_disconnect_at = 98.0
+    c._last_ws_message_at = 99.0
+    c._last_ws_event_loop_ms = 12.5
+    c._pair_snapshot_error_count = 1
+    c._rest_sync_error_count = 2
+    c._ws_reconnect_count = 3
+    c._ws_disconnect_count = 4
+    c._last_rest_weight_used = 11
+    c._last_rest_weight_limit = 1200
+    c._latency_ms.extend([10.0, 20.0, 30.0])
+    c._prices = {
+        "ETHUSDT": connector._PriceRecord(
+            symbol="ETHUSDT",
+            price=3000.0,
+            change_24h_pct=-1.0,
+            bid=2999.0,
+            ask=3001.0,
+            event_time_ms=1,
+            event_to_cache_ms=9.0,
+            updated_at_iso="2026-04-23T03:00:00Z",
+            updated_at_ts=90.0,
+            source="ws",
+        ),
+        "BTCUSDT": connector._PriceRecord(
+            symbol="BTCUSDT",
+            price=64000.0,
+            change_24h_pct=1.5,
+            bid=63999.0,
+            ask=64001.0,
+            event_time_ms=2,
+            event_to_cache_ms=7.0,
+            updated_at_iso="2026-04-23T03:01:00Z",
+            updated_at_ts=91.0,
+            source="rest",
+        ),
+    }
+
+    payload = await c._build_snapshot_payload()
+    assert payload["running"] is True
+    assert payload["top_pairs"]["count"] == 2
+    assert [item["symbol"] for item in payload["prices"]] == ["BTCUSDT", "ETHUSDT"]
+    assert payload["status"]["latency_p95_ms"] == 30.0
+    assert payload["status"]["rest_sync_errors"] == 2
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        connector, "write_snapshot", lambda data: captured.setdefault("payload", data)
+    )
+    await c._flush_snapshot(running=False)
+    assert captured["payload"]["running"] is False
+
+    class _ExternalOnlyConnector:
+        _running = False
+
+        async def get_top_pairs(self):
+            raise AssertionError("should use external snapshot")
+
+        async def get_status(self):
+            raise AssertionError("should use external snapshot")
+
+        async def get_latest_prices(self, symbols=None):
+            raise AssertionError("should use external snapshot")
+
+    monkeypatch.setattr(connector, "_connector", _ExternalOnlyConnector())
+    monkeypatch.setattr(connector, "read_snapshot", lambda: captured["payload"])
+    monkeypatch.setattr(connector, "snapshot_is_fresh", lambda payload: True)
+
+    assert connector.is_running() is True
+    top = await connector.get_top_pairs()
+    assert top["pairs"] == ["ETHUSDT", "BTCUSDT"]
+    status = await connector.get_connector_status()
+    assert status["running"] is True
+    assert status["top_pairs_count"] == 2
+
+    prices, fetched_at, stale = await connector.get_market_latest_prices(["ETHUSDT", "BTCUSDT"])
+    assert [item["symbol"] for item in prices] == ["ETHUSDT", "BTCUSDT"]
+    assert fetched_at == payload["fetched_at"]
+    assert stale is False
+
+
+@pytest.mark.asyncio
+async def test_snapshot_helper_branches_and_worker_runner(monkeypatch):
+    c = _build_connector(monkeypatch)
+
+    seen: list[bool | None] = []
+
+    async def fake_flush(*, running=None):
+        seen.append(running)
+        c._shutdown.set()
+
+    monkeypatch.setattr(c, "_flush_snapshot", fake_flush)
+    await c._snapshot_loop()
+    assert seen == [None]
+
+    fallback_prices = ([{"symbol": "BTCUSDT", "price": 1.0}], "2026-04-23T00:00:00Z", True)
+
+    class _FallbackConnector:
+        _running = False
+
+        async def get_top_pairs(self):
+            return {
+                "pairs": ["LOCAL"],
+                "count": 1,
+                "is_stale": False,
+                "cached_at": "x",
+                "ttl_seconds": 60,
+            }
+
+        async def get_status(self):
+            return {"running": False, "top_pairs_count": 1}
+
+        async def get_latest_prices(self, symbols=None):
+            return fallback_prices
+
+        async def start(self):
+            self.started = True
+
+        async def stop(self):
+            self.stopped = True
+
+    dummy = _FallbackConnector()
+    dummy.started = False
+    dummy.stopped = False
+    monkeypatch.setattr(connector, "_connector", dummy)
+    monkeypatch.setattr(connector, "snapshot_is_fresh", lambda payload: bool(payload))
+
+    monkeypatch.setattr(connector, "read_snapshot", lambda: {"running": False})
+    assert connector._read_external_snapshot() is None
+
+    monkeypatch.setattr(
+        connector,
+        "read_snapshot",
+        lambda: {"running": True, "top_pairs": "bad", "status": "bad", "prices": "bad"},
+    )
+    assert await connector.get_top_pairs() == {
+        "pairs": [],
+        "count": 0,
+        "is_stale": False,
+        "cached_at": None,
+        "ttl_seconds": 0,
+    }
+    assert await connector.get_connector_status() == {
+        "running": True,
+        "service": "binance-realtime-connector",
+        "pair_limit": 0,
+        "pair_refresh_seconds": 0,
+        "price_ttl_seconds": 0,
+        "ws_stream_limit": 0,
+    }
+    assert await connector.get_market_latest_prices(["BTCUSDT"]) == ([], None, True)
+
+    monkeypatch.setattr(connector, "read_snapshot", lambda: None)
+    assert await connector.get_top_pairs() == await dummy.get_top_pairs()
+    assert await connector.get_connector_status() == await dummy.get_status()
+    assert await connector.get_market_latest_prices(["BTCUSDT"]) == fallback_prices
+
+    real_connector = _build_connector(monkeypatch)
+    started = {"value": False}
+
+    async def real_start():
+        started["value"] = True
+
+    monkeypatch.setattr(real_connector, "start", real_start)
+    monkeypatch.setattr(connector, "_connector", real_connector)
+    monkeypatch.setenv("BINANCE_REALTIME_ENABLED", "0")
+    await connector.start_binance_realtime_connector()
+    assert started["value"] is False
+    monkeypatch.setenv("BINANCE_REALTIME_ENABLED", "1")
+    await connector.start_binance_realtime_connector()
+    assert started["value"] is True
+
+    events: list[str] = []
+
+    class _Loop:
+        def add_signal_handler(self, _sig, handler):
+            handler()
+
+    class _WorkerConnector:
+        async def start(self):
+            events.append("start")
+
+        async def stop(self):
+            events.append("stop")
+
+    monkeypatch.setattr(connector.asyncio, "get_running_loop", lambda: _Loop())
+    monkeypatch.setattr(connector, "_connector", _WorkerConnector())
+    await connector.run_binance_realtime_worker()
+    assert events == ["start", "stop"]

--- a/backend/tests/unit/test_binance_realtime_connector.py
+++ b/backend/tests/unit/test_binance_realtime_connector.py
@@ -585,6 +585,8 @@ async def test_snapshot_payload_and_external_snapshot_accessors(monkeypatch):
     )
     await c._flush_snapshot(running=False)
     assert captured["payload"]["running"] is False
+    external_payload = dict(payload)
+    external_payload["running"] = True
 
     class _ExternalOnlyConnector:
         _running = False
@@ -599,7 +601,7 @@ async def test_snapshot_payload_and_external_snapshot_accessors(monkeypatch):
             raise AssertionError("should use external snapshot")
 
     monkeypatch.setattr(connector, "_connector", _ExternalOnlyConnector())
-    monkeypatch.setattr(connector, "read_snapshot", lambda: captured["payload"])
+    monkeypatch.setattr(connector, "read_snapshot", lambda: external_payload)
     monkeypatch.setattr(connector, "snapshot_is_fresh", lambda payload: True)
 
     assert connector.is_running() is True

--- a/backend/tests/unit/test_binance_realtime_snapshot_store.py
+++ b/backend/tests/unit/test_binance_realtime_snapshot_store.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import app.services.binance_realtime_snapshot_store as snapshot_store
+
+
+def test_snapshot_store_round_trip_and_freshness(monkeypatch, tmp_path):
+    snapshot_path = tmp_path / "runtime" / "snapshot.json"
+    monkeypatch.setattr(
+        snapshot_store,
+        "get_settings",
+        lambda: SimpleNamespace(
+            binance_realtime_snapshot_path=str(snapshot_path),
+            binance_realtime_snapshot_max_age_seconds=15.0,
+        ),
+    )
+
+    payload = {"running": True, "heartbeat_ts": 100.0, "now_ts": 110.0, "prices": []}
+    assert snapshot_store.get_snapshot_path() == snapshot_path
+    snapshot_store.write_snapshot(payload)
+    assert snapshot_store.read_snapshot() == payload
+    assert snapshot_store.snapshot_is_fresh(payload) is True
+    assert snapshot_store.snapshot_is_fresh({"heartbeat_ts": "bad"}) is False
+
+
+def test_snapshot_store_env_default_and_invalid_payloads(monkeypatch, tmp_path):
+    env_path = tmp_path / "env-snapshot.json"
+    monkeypatch.setenv("BINANCE_REALTIME_SNAPSHOT_PATH", str(env_path))
+    monkeypatch.setattr(snapshot_store, "get_settings", lambda: SimpleNamespace())
+
+    assert snapshot_store.get_snapshot_path() == env_path
+    assert snapshot_store.read_snapshot() is None
+
+    env_path.write_text("[1,2,3]", encoding="utf-8")
+    assert snapshot_store.read_snapshot() is None
+
+    env_path.write_text("{bad", encoding="utf-8")
+    assert snapshot_store.read_snapshot() is None
+
+    monkeypatch.delenv("BINANCE_REALTIME_SNAPSHOT_PATH", raising=False)
+    monkeypatch.setattr(
+        snapshot_store,
+        "get_settings",
+        lambda: SimpleNamespace(
+            binance_realtime_snapshot_path=None,
+            binance_realtime_snapshot_max_age_seconds=2.0,
+        ),
+    )
+    assert snapshot_store.get_snapshot_path().name == "binance_realtime_snapshot.json"
+    assert snapshot_store.snapshot_is_fresh({"heartbeat_ts": 100.0, "now_ts": 103.5}) is False

--- a/backend/tests/unit/test_binance_realtime_snapshot_store.py
+++ b/backend/tests/unit/test_binance_realtime_snapshot_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 import app.services.binance_realtime_snapshot_store as snapshot_store
@@ -49,3 +50,5 @@ def test_snapshot_store_env_default_and_invalid_payloads(monkeypatch, tmp_path):
     )
     assert snapshot_store.get_snapshot_path().name == "binance_realtime_snapshot.json"
     assert snapshot_store.snapshot_is_fresh({"heartbeat_ts": 100.0, "now_ts": 103.5}) is False
+    monkeypatch.setattr(time, "time", lambda: 101.0)
+    assert snapshot_store.snapshot_is_fresh({"heartbeat_ts": 100.0}) is True

--- a/backend/tests/unit/test_binance_realtime_worker.py
+++ b/backend/tests/unit/test_binance_realtime_worker.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import app.binance_realtime_worker as worker
+
+
+class _Response:
+    def __init__(self, payload, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict | None]] = []
+
+    async def get(self, url, params=None):
+        self.calls.append((url, params))
+        if not self._responses:
+            raise AssertionError("Unexpected request")
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_worker_fetch_helpers_and_payload_building():
+    assert worker._to_float("12.5") == 12.5
+    assert worker._to_float("nan") is None
+    assert worker._is_supported_binance_symbol("BTCUSDT") is True
+    assert worker._is_supported_binance_symbol("BTCBTC") is False
+    assert worker._timestamp_to_iso(None) is None
+    assert worker._utc_now_iso().endswith("Z")
+
+    top_pairs_client = _Client(
+        [
+            _Response(
+                [
+                    {"symbol": "BTCUSDT", "quoteVolume": "400"},
+                    {"symbol": "ETHUSDT", "quoteVolume": "200"},
+                    {"symbol": "BAD", "quoteVolume": "999"},
+                    {"symbol": "SOLUSDT", "quoteVolume": "300"},
+                ]
+            )
+        ]
+    )
+    pairs = await worker._fetch_top_pairs(
+        top_pairs_client,
+        base_url="https://api.binance.com",
+        pair_limit=2,
+    )
+    assert pairs == ["BTCUSDT", "SOLUSDT"]
+
+    price_client = _Client(
+        [
+            _Response(
+                {
+                    "lastPrice": "64000",
+                    "priceChangePercent": "1.5",
+                    "bidPrice": None,
+                    "askPrice": None,
+                }
+            ),
+            _Response({"lastPrice": "3000", "priceChangePercent": "-1.0", "bidPrice": "2999"}),
+            _Response({}, status_code=500),
+        ]
+    )
+    prices = await worker._fetch_price_snapshot(
+        price_client,
+        base_url="https://api.binance.com",
+        symbols=["BTCUSDT", "ETHUSDT", "XRPUSDT"],
+    )
+    assert [item["symbol"] for item in prices] == ["BTCUSDT", "ETHUSDT"]
+    assert prices[0]["bid"] == prices[0]["price"]
+    assert prices[0]["ask"] == prices[0]["price"]
+
+    payload = worker._build_snapshot_payload(
+        running=True,
+        pair_limit=5,
+        pair_refresh_seconds=60,
+        price_ttl_seconds=10.0,
+        ws_stream_limit=2,
+        pairs=["BTCUSDT", "ETHUSDT"],
+        prices=prices,
+        top_pairs_cached_at_ts=100.0,
+        last_pair_refresh_at_ts=101.0,
+        pair_refresh_errors=1,
+        rest_sync_errors=2,
+    )
+    assert payload["running"] is True
+    assert payload["top_pairs"]["count"] == 2
+    assert payload["status"]["ws_stream_limit"] == 2
+    assert payload["status"]["pair_refresh_errors"] == 1
+    assert payload["status"]["rest_sync_errors"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_worker_writes_running_and_stopped_snapshots(monkeypatch):
+    handlers = []
+
+    class _Loop:
+        def add_signal_handler(self, _sig, handler):
+            handlers.append(handler)
+
+    class _AsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None):
+            if params is None:
+                return _Response(
+                    [
+                        {"symbol": "BTCUSDT", "quoteVolume": "400"},
+                        {"symbol": "ETHUSDT", "quoteVolume": "200"},
+                    ]
+                )
+            return _Response(
+                {
+                    "lastPrice": "64000",
+                    "priceChangePercent": "1.2",
+                    "bidPrice": "63999",
+                    "askPrice": "64001",
+                }
+            )
+
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(
+            binance_base_url="https://api.binance.com",
+            binance_top_pairs_limit=2,
+            binance_ws_stream_limit=1,
+            binance_top_pairs_refresh_seconds=60,
+            binance_price_ttl_seconds=10.0,
+            binance_request_timeout_seconds=2.0,
+        ),
+    )
+    monkeypatch.setattr(worker.asyncio, "get_running_loop", lambda: _Loop())
+    monkeypatch.setattr(worker.httpx, "AsyncClient", lambda timeout: _AsyncClient())
+    monkeypatch.setattr(worker.time, "time", lambda: 100.0)
+
+    written: list[dict[str, object]] = []
+
+    def fake_write_snapshot(payload):
+        written.append(payload)
+        if payload["running"]:
+            for handler in handlers:
+                handler()
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(worker, "write_snapshot", fake_write_snapshot)
+    monkeypatch.setattr(worker.asyncio, "to_thread", fake_to_thread)
+
+    await worker._run_worker()
+
+    assert [item["running"] for item in written] == [True, False]
+    assert written[0]["top_pairs"]["pairs"] == ["BTCUSDT", "ETHUSDT"]
+    assert written[0]["status"]["ws_stream_limit"] == 1
+    assert written[0]["prices"][0]["symbol"] == "BTCUSDT"
+
+
+def test_worker_main_calls_asyncio_run(monkeypatch):
+    called = {"value": False}
+
+    def fake_run(coro):
+        called["value"] = True
+        coro.close()
+
+    monkeypatch.setattr(worker.asyncio, "run", fake_run)
+    worker.main()
+    assert called["value"] is True

--- a/backend/tests/unit/test_main_and_market_routes.py
+++ b/backend/tests/unit/test_main_and_market_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -250,3 +251,116 @@ async def test_main_lifespan_starts_and_stops_binance_connector(monkeypatch):
     assert signal_stub.stopped
     assert "stop_worker" in lifecycle_calls
     assert "workflow_db_closed" in lifecycle_calls
+
+
+@pytest.mark.asyncio
+async def test_start_noncritical_services_logs_timeout_and_failures(monkeypatch):
+    errors: list[str] = []
+    exceptions: list[str] = []
+
+    def failing_ohlcv():
+        raise RuntimeError("ohlcv")
+
+    async def start_connector():
+        return None
+
+    async def fake_wait_for(coro, timeout):
+        coro.close()
+        raise asyncio.TimeoutError()
+
+    class _SchedulerStub:
+        def start_scheduler(self):
+            raise RuntimeError("scheduler")
+
+    monkeypatch.setattr(main, "start_ohlcv_ingestion", failing_ohlcv)
+    monkeypatch.setattr(main, "start_binance_realtime_connector", start_connector)
+    monkeypatch.setattr(main.asyncio, "wait_for", fake_wait_for)
+    monkeypatch.setattr(main, "get_backfill_service", lambda: _SchedulerStub())
+    monkeypatch.setattr(main.logger, "error", lambda message, *a, **k: errors.append(str(message)))
+    monkeypatch.setattr(
+        main.logger,
+        "exception",
+        lambda message, *a, **k: exceptions.append(str(message)),
+    )
+
+    await main._start_noncritical_services()
+
+    assert "Timed out while starting Binance realtime connector" in errors
+    assert any("Failed to start OHLCV ingestion service" in item for item in exceptions)
+    assert any("Failed to start OHLCV backfill scheduler" in item for item in exceptions)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_cancels_pending_noncritical_startup(monkeypatch):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def pending_start():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    class _SignalMonitorStub:
+        def stop(self):
+            return None
+
+    class _BackfillSchedulerStub:
+        def stop_scheduler(self):
+            return None
+
+    class _WorkflowSession:
+        def query(self, model):
+            return self
+
+        def filter(self, *_, **__):
+            return self
+
+        def first(self):
+            return None
+
+        def all(self):
+            return []
+
+        def add(self, *_args, **_kwargs):
+            return None
+
+        def commit(self):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(main, "_start_noncritical_services", pending_start)
+    monkeypatch.setattr(main, "stop_binance_realtime_connector", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(main, "stop_signal_feed_snapshot_worker", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(main, "stop_ohlcv_ingestion", lambda: None)
+    monkeypatch.setattr(main, "signal_monitor", _SignalMonitorStub())
+    monkeypatch.setattr(main, "get_backfill_service", lambda: _BackfillSchedulerStub())
+    monkeypatch.setattr(
+        main,
+        "Base",
+        SimpleNamespace(metadata=SimpleNamespace(create_all=lambda *_args, **_kwargs: None)),
+    )
+    monkeypatch.setattr(main, "engine", object())
+    monkeypatch.setattr(main, "sync_postgres_identity_sequences", lambda: None)
+    monkeypatch.setattr(main, "seed_combo_templates_if_empty", lambda: None)
+
+    import app.database as app_database
+    import app.workflow_database as workflow_database
+    import app.workflow_models as workflow_models
+
+    monkeypatch.setattr(app_database, "ensure_runtime_schema_migrations", lambda: None)
+    monkeypatch.setattr(workflow_database, "init_workflow_schema", lambda: None)
+    monkeypatch.setattr(workflow_database, "get_workflow_db", lambda: iter([_WorkflowSession()]))
+    monkeypatch.setattr(workflow_database, "bootstrap_project_workflow_db", lambda *_: None)
+    monkeypatch.setattr(workflow_models, "Project", object)
+
+    async_context = main.lifespan(main.app)
+    await async_context.__aenter__()
+    await started.wait()
+    assert main.app.state.noncritical_services_task.done() is False
+    await async_context.__aexit__(None, None, None)
+    assert cancelled.is_set()

--- a/backend/tests/unit/test_main_and_market_routes.py
+++ b/backend/tests/unit/test_main_and_market_routes.py
@@ -289,6 +289,14 @@ async def test_start_noncritical_services_logs_timeout_and_failures(monkeypatch)
     assert any("Failed to start OHLCV ingestion service" in item for item in exceptions)
     assert any("Failed to start OHLCV backfill scheduler" in item for item in exceptions)
 
+    async def fake_wait_for_error(coro, timeout):
+        coro.close()
+        raise RuntimeError("connector")
+
+    monkeypatch.setattr(main.asyncio, "wait_for", fake_wait_for_error)
+    await main._start_noncritical_services()
+    assert any("Failed to start Binance realtime connector" in item for item in exceptions)
+
 
 @pytest.mark.asyncio
 async def test_lifespan_cancels_pending_noncritical_startup(monkeypatch):

--- a/install-systemd-user-service.sh
+++ b/install-systemd-user-service.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_PATH="$ROOT_DIR/ops/systemd/crypto-stack.service"
+USER_SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+TARGET_PATH="$USER_SYSTEMD_DIR/crypto-stack.service"
+SERVICE_NAME="crypto-stack.service"
+CURRENT_USER="$(id -un)"
+
+if [[ ! -f "$TEMPLATE_PATH" ]]; then
+  echo "Missing service template: $TEMPLATE_PATH" >&2
+  exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "systemctl is not available on this host." >&2
+  exit 1
+fi
+
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  echo "systemd user session is unavailable for $CURRENT_USER." >&2
+  exit 1
+fi
+
+mkdir -p "$USER_SYSTEMD_DIR"
+sed "s|__ROOT_DIR__|$ROOT_DIR|g" "$TEMPLATE_PATH" >"$TARGET_PATH"
+
+if command -v loginctl >/dev/null 2>&1; then
+  loginctl enable-linger "$CURRENT_USER" >/dev/null 2>&1 || true
+fi
+
+systemctl --user daemon-reload
+"$ROOT_DIR/stop.sh" >/dev/null 2>&1 || true
+systemctl --user enable --now "$SERVICE_NAME"
+systemctl --user status "$SERVICE_NAME" --no-pager

--- a/ops/systemd/crypto-stack.service
+++ b/ops/systemd/crypto-stack.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Crypto stack bootstrap
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=__ROOT_DIR__
+ExecStart=__ROOT_DIR__/start.sh
+ExecStop=__ROOT_DIR__/stop.sh
+TimeoutStartSec=300
+TimeoutStopSec=120
+
+[Install]
+WantedBy=default.target

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,7 @@ BACKEND_UNIT="crypto-backend"
 FRONTEND_UNIT="crypto-frontend"
 RUNTIME_WORKER_UNIT="crypto-runtime-worker"
 CELERY_WORKER_UNIT="crypto-celery-worker"
+BINANCE_WORKER_UNIT="crypto-binance-realtime-worker"
 BACKEND_PORT="${CRYPTO_BACKEND_PORT:-8003}"
 FRONTEND_PORT="${CRYPTO_FRONTEND_PORT:-5173}"
 REDIS_HOST="${CRYPTO_REDIS_HOST:-127.0.0.1}"
@@ -16,10 +17,12 @@ BACKEND_LOG="/tmp/crypto-uvicorn-${BACKEND_PORT}.log"
 FRONTEND_LOG="/tmp/crypto-vite-${FRONTEND_PORT}.log"
 RUNTIME_WORKER_LOG="/tmp/crypto-runtime-worker.log"
 CELERY_WORKER_LOG="/tmp/crypto-celery-worker.log"
+BINANCE_WORKER_LOG="/tmp/crypto-binance-realtime-worker.log"
 BACKEND_PID_FILE="/tmp/crypto-backend.pid"
 FRONTEND_PID_FILE="/tmp/crypto-frontend.pid"
 RUNTIME_WORKER_PID_FILE="/tmp/crypto-runtime-worker.pid"
 CELERY_WORKER_PID_FILE="/tmp/crypto-celery-worker.pid"
+BINANCE_WORKER_PID_FILE="/tmp/crypto-binance-realtime-worker.pid"
 HEALTH_URL="http://127.0.0.1:${BACKEND_PORT}/api/health"
 FRONTEND_URL="http://127.0.0.1:${FRONTEND_PORT}"
 VENV_PYTHON="$BACKEND_DIR/.venv/bin/python"
@@ -48,6 +51,7 @@ export CELERY_RESULT_BACKEND="${CELERY_RESULT_BACKEND:-redis://${REDIS_HOST}:${R
 export CELERY_WORKER_CONCURRENCY="${CELERY_WORKER_CONCURRENCY:-1}"
 export CELERY_WORKER_PREFETCH_MULTIPLIER="${CELERY_WORKER_PREFETCH_MULTIPLIER:-1}"
 export CELERY_LOG_LEVEL="${CELERY_LOG_LEVEL:-INFO}"
+export BINANCE_REALTIME_WORKER_ENABLED="${BINANCE_REALTIME_WORKER_ENABLED:-1}"
 
 require_env_var() {
   local var_name="$1"
@@ -131,6 +135,12 @@ wait_for_tcp_open() {
     sleep "$sleep_s"
   done
   return 1
+}
+
+flag_enabled() {
+  local raw="${1:-}"
+  raw="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  [[ "$raw" != "0" && "$raw" != "false" && "$raw" != "no" && "$raw" != "off" ]]
 }
 
 store_runtime_pid() {
@@ -268,6 +278,7 @@ remove_stale_pid_file "$BACKEND_PID_FILE"
 remove_stale_pid_file "$FRONTEND_PID_FILE"
 remove_stale_pid_file "$RUNTIME_WORKER_PID_FILE"
 remove_stale_pid_file "$CELERY_WORKER_PID_FILE"
+remove_stale_pid_file "$BINANCE_WORKER_PID_FILE"
 
 if ! wait_for_http_ok "$HEALTH_URL" 2 1; then
   if user_systemd_available; then
@@ -275,11 +286,13 @@ if ! wait_for_http_ok "$HEALTH_URL" 2 1; then
       "$BACKEND_UNIT" \
       "$BACKEND_DIR" \
       "$BACKEND_LOG" \
-      "for env_file in $(shell_escape "$ROOT_DIR/backend/.env") $(shell_escape "$ROOT_DIR/.env"); do [ -f \"\$env_file\" ] && source \"\$env_file\"; done; exec $(shell_escape "$VENV_PYTHON") -m uvicorn app.main:app --host 0.0.0.0 --port $(shell_escape "$BACKEND_PORT")"
+      "for env_file in $(shell_escape "$ROOT_DIR/backend/.env") $(shell_escape "$ROOT_DIR/.env"); do [ -f \"\$env_file\" ] && source \"\$env_file\"; done; export BINANCE_REALTIME_ENABLED=0; exec $(shell_escape "$VENV_PYTHON") -m uvicorn app.main:app --host 0.0.0.0 --port $(shell_escape "$BACKEND_PORT")"
   else
     (
       cd "$BACKEND_DIR"
-      nohup "$VENV_PYTHON" -m uvicorn app.main:app --host 0.0.0.0 --port "$BACKEND_PORT" >"$BACKEND_LOG" 2>&1 < /dev/null &
+      nohup env \
+        BINANCE_REALTIME_ENABLED=0 \
+        "$VENV_PYTHON" -m uvicorn app.main:app --host 0.0.0.0 --port "$BACKEND_PORT" >"$BACKEND_LOG" 2>&1 < /dev/null &
     )
   fi
   store_runtime_pid "$BACKEND_PID_FILE" "uvicorn app.main:app.*--port ${BACKEND_PORT}" || true
@@ -337,6 +350,30 @@ ensure_process_running \
   "celery .*app.celery_app:celery_app worker" \
   "crypto celery worker"
 
+if flag_enabled "$BINANCE_REALTIME_WORKER_ENABLED"; then
+  if ! pgrep -f "python -m app.binance_realtime_worker" >/dev/null 2>&1; then
+    if user_systemd_available; then
+      start_transient_unit \
+        "$BINANCE_WORKER_UNIT" \
+        "$BACKEND_DIR" \
+        "$BINANCE_WORKER_LOG" \
+        "for env_file in $(shell_escape "$ROOT_DIR/backend/.env") $(shell_escape "$ROOT_DIR/.env"); do [ -f \"\$env_file\" ] && source \"\$env_file\"; done; export BINANCE_REALTIME_ENABLED=1; exec $(shell_escape "$VENV_PYTHON") -m app.binance_realtime_worker"
+    else
+      (
+        cd "$BACKEND_DIR"
+        nohup env \
+          BINANCE_REALTIME_ENABLED=1 \
+          "$VENV_PYTHON" -m app.binance_realtime_worker >"$BINANCE_WORKER_LOG" 2>&1 < /dev/null &
+        echo "$!" >"$BINANCE_WORKER_PID_FILE"
+      )
+    fi
+  fi
+  ensure_process_running \
+    "$BINANCE_WORKER_PID_FILE" \
+    "python -m app.binance_realtime_worker" \
+    "crypto binance realtime worker"
+fi
+
 if ! wait_for_http_ok "$FRONTEND_URL" 2 1; then
   if user_systemd_available; then
     start_transient_unit \
@@ -366,6 +403,12 @@ ensure_process_running \
   "$CELERY_WORKER_PID_FILE" \
   "celery .*app.celery_app:celery_app worker" \
   "crypto celery worker"
+if flag_enabled "$BINANCE_REALTIME_WORKER_ENABLED"; then
+  ensure_process_running \
+    "$BINANCE_WORKER_PID_FILE" \
+    "python -m app.binance_realtime_worker" \
+    "crypto binance realtime worker"
+fi
 
 echo "crypto backend:  ${CRYPTO_BACKEND_URL:-http://127.0.0.1:${BACKEND_PORT}}"
 echo "crypto frontend: ${CRYPTO_FRONTEND_URL:-http://127.0.0.1:${FRONTEND_PORT}}"

--- a/stop.sh
+++ b/stop.sh
@@ -5,6 +5,7 @@ BACKEND_UNIT="crypto-backend"
 FRONTEND_UNIT="crypto-frontend"
 RUNTIME_WORKER_UNIT="crypto-runtime-worker"
 CELERY_WORKER_UNIT="crypto-celery-worker"
+BINANCE_WORKER_UNIT="crypto-binance-realtime-worker"
 BACKEND_PORT="${CRYPTO_BACKEND_PORT:-8003}"
 FRONTEND_PORT="${CRYPTO_FRONTEND_PORT:-5173}"
 REDIS_CONTAINER_NAME="crypto-runtime-redis"
@@ -12,6 +13,7 @@ BACKEND_PID_FILE="/tmp/crypto-backend.pid"
 FRONTEND_PID_FILE="/tmp/crypto-frontend.pid"
 RUNTIME_WORKER_PID_FILE="/tmp/crypto-runtime-worker.pid"
 CELERY_WORKER_PID_FILE="/tmp/crypto-celery-worker.pid"
+BINANCE_WORKER_PID_FILE="/tmp/crypto-binance-realtime-worker.pid"
 
 user_systemd_available() {
   command -v systemctl >/dev/null 2>&1 || return 1
@@ -93,17 +95,20 @@ stop_user_unit "$BACKEND_UNIT"
 stop_user_unit "$FRONTEND_UNIT"
 stop_user_unit "$RUNTIME_WORKER_UNIT"
 stop_user_unit "$CELERY_WORKER_UNIT"
+stop_user_unit "$BINANCE_WORKER_UNIT"
 
 kill_pid_file "$BACKEND_PID_FILE"
 kill_pid_file "$FRONTEND_PID_FILE"
 kill_pid_file "$RUNTIME_WORKER_PID_FILE"
 kill_pid_file "$CELERY_WORKER_PID_FILE"
+kill_pid_file "$BINANCE_WORKER_PID_FILE"
 kill_by_port "$BACKEND_PORT"
 kill_by_port "$FRONTEND_PORT"
 kill_by_pattern "uvicorn app.main:app.*--port ${BACKEND_PORT}"
 kill_by_pattern "vite.*--port ${FRONTEND_PORT}"
 kill_by_pattern "python -m app.workers.runtime_worker"
 kill_by_pattern "celery .*app.celery_app:celery_app worker"
+kill_by_pattern "python -m app.binance_realtime_worker"
 
 if command -v docker >/dev/null 2>&1 && docker inspect "$REDIS_CONTAINER_NAME" >/dev/null 2>&1; then
   docker rm -f "$REDIS_CONTAINER_NAME" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- move Binance market refresh into a dedicated worker and shared snapshot store
- keep the FastAPI process isolated from the market worker so login and health endpoints stay responsive
- wire the worker into start/stop scripts and add a persistent systemd user service installer

## Validation
- installed and enabled `crypto-stack.service` via `./install-systemd-user-service.sh`
- confirmed `/api/health`, `/api/auth/login`, and `/api/market/binance/status` respond with the stack running under systemd
