### PR TITLE
feat: add advanced market indicators

### DIFF
--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Implement tasks from an OpenSpec change.
@@ -39,7 +39,7 @@ Implement tasks from an OpenSpec change.
    ```
 
    This returns:
-   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -51,7 +51,7 @@ Implement tasks from an OpenSpec change.
 
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
+   Read every file path listed under `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output

--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Archive a completed change in the experimental workflow.

--- a/.codex/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.codex/skills/openspec-bulk-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Archive multiple completed changes in a single operation.
@@ -84,7 +84,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |

--- a/.codex/skills/openspec-continue-change/SKILL.md
+++ b/.codex/skills/openspec-continue-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Continue working on a change by creating the next artifact.

--- a/.codex/skills/openspec-explore/SKILL.md
+++ b/.codex/skills/openspec-explore/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
@@ -56,10 +56,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │
@@ -114,14 +114,14 @@ If the user mentions a change or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
 
    Example offers:
    - "That's a design decision. Capture it in design.md?"
@@ -227,7 +227,7 @@ User: A CLI tool that tracks local dev environments
 You: That changes everything.
 
      ┌─────────────────────────────────────────────────┐
-     │         CLI TOOL DATA STORAGE                  │
+     │          CLI TOOL DATA STORAGE                  │
      └─────────────────────────────────────────────────┘
 
      Key constraints:

--- a/.codex/skills/openspec-ff-change/SKILL.md
+++ b/.codex/skills/openspec-ff-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Fast-forward through artifact creation - generate everything needed to start implementation in one go.

--- a/.codex/skills/openspec-new-change/SKILL.md
+++ b/.codex/skills/openspec-new-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Start a new change using the experimental artifact-driven approach.

--- a/.codex/skills/openspec-onboard/SKILL.md
+++ b/.codex/skills/openspec-onboard/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
@@ -468,21 +468,21 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:archive` | Archive a completed change |
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new` | Start a new change, step through artifacts one at a time |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:verify` | Verify implementation matches artifacts |
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
@@ -520,21 +520,21 @@ If the user says they just want to see the commands or skip the tutorial:
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose <name>` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:archive <name>` | Archive when done |
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:verify <name>` | Verify implementation |
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
 
 Try `/opsx:propose` to start your first change.
 ```

--- a/.codex/skills/openspec-sync-specs/SKILL.md
+++ b/.codex/skills/openspec-sync-specs/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Sync delta specs from a change to main specs.

--- a/.codex/skills/openspec-verify-change/SKILL.md
+++ b/.codex/skills/openspec-verify-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Verify that an implementation matches the change artifacts (specs, tasks, design).
@@ -39,7 +39,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -53,7 +53,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -92,7 +92,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/backend/alembic/versions/20260423_0001_add_advanced_market_indicators.py
+++ b/backend/alembic/versions/20260423_0001_add_advanced_market_indicators.py
@@ -1,0 +1,55 @@
+"""Add advanced market indicator columns.
+
+Revision ID: 20260423_0001
+Revises: 20260419_0001
+Create Date: 2026-04-23 00:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260423_0001"
+down_revision = "20260419_0001"
+branch_labels = None
+depends_on = None
+
+
+ADVANCED_COLUMNS = (
+    "bb_upper_20_2",
+    "bb_middle_20_2",
+    "bb_lower_20_2",
+    "atr_14",
+    "stoch_k_14_3_3",
+    "stoch_d_14_3_3",
+    "obv",
+    "ichimoku_tenkan_9",
+    "ichimoku_kijun_26",
+    "ichimoku_senkou_a_9_26_52",
+    "ichimoku_senkou_b_9_26_52",
+    "ichimoku_chikou_26",
+)
+
+
+def upgrade() -> None:
+    for column in ADVANCED_COLUMNS:
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF to_regclass('public.market_indicator') IS NOT NULL THEN
+                    ALTER TABLE market_indicator ADD COLUMN IF NOT EXISTS {column} NUMERIC;
+                END IF;
+            END $$;
+            """)
+
+
+def downgrade() -> None:
+    for column in reversed(ADVANCED_COLUMNS):
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF to_regclass('public.market_indicator') IS NOT NULL THEN
+                    ALTER TABLE market_indicator DROP COLUMN IF EXISTS {column};
+                END IF;
+            END $$;
+            """)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -151,6 +151,18 @@ def ensure_runtime_schema_migrations() -> None:
                     macd_line NUMERIC,
                     macd_signal NUMERIC,
                     macd_histogram NUMERIC,
+                    bb_upper_20_2 NUMERIC,
+                    bb_middle_20_2 NUMERIC,
+                    bb_lower_20_2 NUMERIC,
+                    atr_14 NUMERIC,
+                    stoch_k_14_3_3 NUMERIC,
+                    stoch_d_14_3_3 NUMERIC,
+                    obv NUMERIC,
+                    ichimoku_tenkan_9 NUMERIC,
+                    ichimoku_kijun_26 NUMERIC,
+                    ichimoku_senkou_a_9_26_52 NUMERIC,
+                    ichimoku_senkou_b_9_26_52 NUMERIC,
+                    ichimoku_chikou_26 NUMERIC,
                     source TEXT NOT NULL DEFAULT 'market',
                     provider TEXT NOT NULL DEFAULT 'talib',
                     source_window JSONB,
@@ -159,6 +171,21 @@ def ensure_runtime_schema_migrations() -> None:
                     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     UNIQUE (symbol, timeframe, ts)
                 )
+                """))
+        conn.execute(text("""
+                ALTER TABLE market_indicator
+                    ADD COLUMN IF NOT EXISTS bb_upper_20_2 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS bb_middle_20_2 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS bb_lower_20_2 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS atr_14 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS stoch_k_14_3_3 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS stoch_d_14_3_3 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS obv NUMERIC,
+                    ADD COLUMN IF NOT EXISTS ichimoku_tenkan_9 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS ichimoku_kijun_26 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS ichimoku_senkou_a_9_26_52 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS ichimoku_senkou_b_9_26_52 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS ichimoku_chikou_26 NUMERIC
                 """))
         conn.execute(text("""
                 CREATE INDEX IF NOT EXISTS uq_market_indicator_symbol_timeframe_ts

--- a/backend/app/services/market_indicator_service.py
+++ b/backend/app/services/market_indicator_service.py
@@ -30,6 +30,20 @@ MAX_LOOKBACK_LOOKUP = {
 
 DEFAULT_TIMEFRAMES = ("1m", "5m", "15m", "1h", "4h", "1d")
 PROVIDER_NAME = "talib"
+ADVANCED_INDICATOR_COLUMNS = (
+    "bb_upper_20_2",
+    "bb_middle_20_2",
+    "bb_lower_20_2",
+    "atr_14",
+    "stoch_k_14_3_3",
+    "stoch_d_14_3_3",
+    "obv",
+    "ichimoku_tenkan_9",
+    "ichimoku_kijun_26",
+    "ichimoku_senkou_a_9_26_52",
+    "ichimoku_senkou_b_9_26_52",
+    "ichimoku_chikou_26",
+)
 
 
 def _normalize_timeframe(value: str) -> str:
@@ -59,6 +73,16 @@ def _to_utc_timestamp(value: Any) -> datetime | None:
 
 def _required_interval(tf: str) -> timedelta:
     return MAX_LOOKBACK_LOOKUP.get(_normalize_timeframe(tf), timedelta(hours=1))
+
+
+def _nullable_float(value: Any) -> float | None:
+    return None if pd.isna(value) else float(value)
+
+
+def _rolling_midpoint(high: pd.Series, low: pd.Series, period: int) -> pd.Series:
+    highest_high = high.rolling(window=period, min_periods=period).max()
+    lowest_low = low.rolling(window=period, min_periods=period).min()
+    return (highest_high + lowest_low) / 2
 
 
 class MarketIndicatorService:
@@ -109,6 +133,18 @@ class MarketIndicatorService:
                             macd_line,
                             macd_signal,
                             macd_histogram,
+                            bb_upper_20_2,
+                            bb_middle_20_2,
+                            bb_lower_20_2,
+                            atr_14,
+                            stoch_k_14_3_3,
+                            stoch_d_14_3_3,
+                            obv,
+                            ichimoku_tenkan_9,
+                            ichimoku_kijun_26,
+                            ichimoku_senkou_a_9_26_52,
+                            ichimoku_senkou_b_9_26_52,
+                            ichimoku_chikou_26,
                             source,
                             provider,
                             source_window,
@@ -202,6 +238,9 @@ class MarketIndicatorService:
             return df.copy()
 
         close = df["close"].astype(float).to_numpy()
+        high = df["high"].astype(float).to_numpy()
+        low = df["low"].astype(float).to_numpy()
+        volume = df["volume"].astype(float).to_numpy()
         ema_9 = talib.EMA(close, timeperiod=9)
         ema_21 = talib.EMA(close, timeperiod=21)
         sma_20 = talib.SMA(close, timeperiod=20)
@@ -210,6 +249,30 @@ class MarketIndicatorService:
         macd_line, macd_signal, macd_hist = talib.MACD(
             close, fastperiod=12, slowperiod=26, signalperiod=9
         )
+        bb_upper, bb_middle, bb_lower = talib.BBANDS(
+            close, timeperiod=20, nbdevup=2, nbdevdn=2, matype=0
+        )
+        atr_14 = talib.ATR(high, low, close, timeperiod=14)
+        stoch_k, stoch_d = talib.STOCH(
+            high,
+            low,
+            close,
+            fastk_period=14,
+            slowk_period=3,
+            slowk_matype=0,
+            slowd_period=3,
+            slowd_matype=0,
+        )
+        obv = talib.OBV(close, volume)
+
+        numeric_high = pd.to_numeric(df["high"], errors="coerce")
+        numeric_low = pd.to_numeric(df["low"], errors="coerce")
+        numeric_close = pd.to_numeric(df["close"], errors="coerce")
+        ichimoku_tenkan = _rolling_midpoint(numeric_high, numeric_low, 9)
+        ichimoku_kijun = _rolling_midpoint(numeric_high, numeric_low, 26)
+        ichimoku_senkou_a = (ichimoku_tenkan + ichimoku_kijun) / 2
+        ichimoku_senkou_b = _rolling_midpoint(numeric_high, numeric_low, 52)
+        ichimoku_chikou = numeric_close
 
         out = df.copy()
         out["ema_9"] = ema_9
@@ -220,17 +283,43 @@ class MarketIndicatorService:
         out["macd_line"] = macd_line
         out["macd_signal"] = macd_signal
         out["macd_histogram"] = macd_hist
+        out["bb_upper_20_2"] = bb_upper
+        out["bb_middle_20_2"] = bb_middle
+        out["bb_lower_20_2"] = bb_lower
+        out["atr_14"] = atr_14
+        out["stoch_k_14_3_3"] = stoch_k
+        out["stoch_d_14_3_3"] = stoch_d
+        out["obv"] = obv
+        out["ichimoku_tenkan_9"] = ichimoku_tenkan
+        out["ichimoku_kijun_26"] = ichimoku_kijun
+        out["ichimoku_senkou_a_9_26_52"] = ichimoku_senkou_a
+        out["ichimoku_senkou_b_9_26_52"] = ichimoku_senkou_b
+        out["ichimoku_chikou_26"] = ichimoku_chikou
         out["symbol"] = _normalize_symbol(symbol)
         out["timeframe"] = _normalize_timeframe(timeframe)
         out["source"] = "technical"
         out["provider"] = PROVIDER_NAME
         out["row_count"] = int(len(out))
-        out["source_window"] = {
+        source_window = {
             "timeframe": timeframe,
             "engine": PROVIDER_NAME,
             "lookback_bars": LOOKBACK_BARS,
             "max_history_bars": MAX_HISTORY_BARS,
+            "advanced_indicators": {
+                "bollinger": {"length": 20, "stddev": 2, "matype": "sma"},
+                "atr": {"length": 14, "smoothing": "talib_atr_wilder"},
+                "stochastic": {"fast_k": 14, "slow_k": 3, "slow_d": 3, "matype": "sma"},
+                "obv": {"inputs": ["close", "volume"]},
+                "ichimoku": {
+                    "tenkan": 9,
+                    "kijun": 26,
+                    "senkou_b": 52,
+                    "displacement": 26,
+                    "storage": "source_candle_aligned",
+                },
+            },
         }
+        out["source_window"] = [source_window] * len(out)
         return out
 
     def _upsert_indicators(self, rows: pd.DataFrame, *, is_recomputed: bool) -> None:
@@ -244,18 +333,18 @@ class MarketIndicatorService:
                     "symbol": row["symbol"],
                     "timeframe": row["timeframe"],
                     "ts": row["ts"].to_pydatetime(),
-                    "ema_9": None if pd.isna(row["ema_9"]) else float(row["ema_9"]),
-                    "ema_21": None if pd.isna(row["ema_21"]) else float(row["ema_21"]),
-                    "sma_20": None if pd.isna(row["sma_20"]) else float(row["sma_20"]),
-                    "sma_50": None if pd.isna(row["sma_50"]) else float(row["sma_50"]),
-                    "rsi_14": None if pd.isna(row["rsi_14"]) else float(row["rsi_14"]),
-                    "macd_line": None if pd.isna(row["macd_line"]) else float(row["macd_line"]),
-                    "macd_signal": (
-                        None if pd.isna(row["macd_signal"]) else float(row["macd_signal"])
-                    ),
-                    "macd_histogram": (
-                        None if pd.isna(row["macd_histogram"]) else float(row["macd_histogram"])
-                    ),
+                    "ema_9": _nullable_float(row["ema_9"]),
+                    "ema_21": _nullable_float(row["ema_21"]),
+                    "sma_20": _nullable_float(row["sma_20"]),
+                    "sma_50": _nullable_float(row["sma_50"]),
+                    "rsi_14": _nullable_float(row["rsi_14"]),
+                    "macd_line": _nullable_float(row["macd_line"]),
+                    "macd_signal": _nullable_float(row["macd_signal"]),
+                    "macd_histogram": _nullable_float(row["macd_histogram"]),
+                    **{
+                        column: _nullable_float(row[column])
+                        for column in ADVANCED_INDICATOR_COLUMNS
+                    },
                     "source": row["source"],
                     "provider": row["provider"],
                     "source_window": json.dumps(row["source_window"]),
@@ -280,6 +369,18 @@ class MarketIndicatorService:
                         macd_line,
                         macd_signal,
                         macd_histogram,
+                        bb_upper_20_2,
+                        bb_middle_20_2,
+                        bb_lower_20_2,
+                        atr_14,
+                        stoch_k_14_3_3,
+                        stoch_d_14_3_3,
+                        obv,
+                        ichimoku_tenkan_9,
+                        ichimoku_kijun_26,
+                        ichimoku_senkou_a_9_26_52,
+                        ichimoku_senkou_b_9_26_52,
+                        ichimoku_chikou_26,
                         source,
                         provider,
                         source_window,
@@ -299,6 +400,18 @@ class MarketIndicatorService:
                         :macd_line,
                         :macd_signal,
                         :macd_histogram,
+                        :bb_upper_20_2,
+                        :bb_middle_20_2,
+                        :bb_lower_20_2,
+                        :atr_14,
+                        :stoch_k_14_3_3,
+                        :stoch_d_14_3_3,
+                        :obv,
+                        :ichimoku_tenkan_9,
+                        :ichimoku_kijun_26,
+                        :ichimoku_senkou_a_9_26_52,
+                        :ichimoku_senkou_b_9_26_52,
+                        :ichimoku_chikou_26,
                         :source,
                         :provider,
                         :source_window,
@@ -316,6 +429,18 @@ class MarketIndicatorService:
                         macd_line = EXCLUDED.macd_line,
                         macd_signal = EXCLUDED.macd_signal,
                         macd_histogram = EXCLUDED.macd_histogram,
+                        bb_upper_20_2 = EXCLUDED.bb_upper_20_2,
+                        bb_middle_20_2 = EXCLUDED.bb_middle_20_2,
+                        bb_lower_20_2 = EXCLUDED.bb_lower_20_2,
+                        atr_14 = EXCLUDED.atr_14,
+                        stoch_k_14_3_3 = EXCLUDED.stoch_k_14_3_3,
+                        stoch_d_14_3_3 = EXCLUDED.stoch_d_14_3_3,
+                        obv = EXCLUDED.obv,
+                        ichimoku_tenkan_9 = EXCLUDED.ichimoku_tenkan_9,
+                        ichimoku_kijun_26 = EXCLUDED.ichimoku_kijun_26,
+                        ichimoku_senkou_a_9_26_52 = EXCLUDED.ichimoku_senkou_a_9_26_52,
+                        ichimoku_senkou_b_9_26_52 = EXCLUDED.ichimoku_senkou_b_9_26_52,
+                        ichimoku_chikou_26 = EXCLUDED.ichimoku_chikou_26,
                         source = EXCLUDED.source,
                         provider = EXCLUDED.provider,
                         source_window = EXCLUDED.source_window,

--- a/backend/app/services/opportunity_service.py
+++ b/backend/app/services/opportunity_service.py
@@ -132,6 +132,47 @@ def _build_market_indicator_mappings(
                 mapping["macd_histogram"] = f"{prefix}_histogram"
             continue
 
+        if ind_type in {"bbands", "bollinger"}:
+            length = _coerce_positive_int(params.get("length"), default=20)
+            std = float(params.get("std", 2) or 2)
+            if length == 20 and std == 2:
+                prefix = alias if alias else "BB"
+                mapping["bb_upper_20_2"] = f"{prefix}_upper"
+                mapping["bb_middle_20_2"] = f"{prefix}_middle"
+                mapping["bb_lower_20_2"] = f"{prefix}_lower"
+            continue
+
+        if ind_type == "atr":
+            length = _coerce_positive_int(params.get("length"), default=14)
+            if length == 14:
+                mapping["atr_14"] = alias if alias else "ATR_14"
+            continue
+
+        if ind_type in {"stoch", "stochf"}:
+            k = _coerce_positive_int(params.get("k"), default=14)
+            d = _coerce_positive_int(params.get("d"), default=3)
+            smooth_k = _coerce_positive_int(params.get("smooth_k"), default=3)
+            if ind_type == "stoch" and k == 14 and d == 3 and smooth_k == 3:
+                mapping["stoch_k_14_3_3"] = "STOCH14_3_3"
+                mapping["stoch_d_14_3_3"] = "STOCHd_14_3_3"
+            continue
+
+        if ind_type == "obv":
+            mapping["obv"] = alias if alias else "OBV"
+            continue
+
+        if ind_type == "ichimoku":
+            tenkan = _coerce_positive_int(params.get("tenkan"), default=9)
+            kijun = _coerce_positive_int(params.get("kijun"), default=26)
+            senkou = _coerce_positive_int(params.get("senkou"), default=52)
+            if tenkan == 9 and kijun == 26 and senkou == 52:
+                mapping["ichimoku_tenkan_9"] = "ITS_9"
+                mapping["ichimoku_kijun_26"] = "IKS_26"
+                mapping["ichimoku_senkou_a_9_26_52"] = "ISA_9"
+                mapping["ichimoku_senkou_b_9_26_52"] = "ISB_26"
+                mapping["ichimoku_chikou_26"] = "ICHI_9_26_52"
+            continue
+
     return mapping
 
 

--- a/backend/app/strategies/dynamic_strategy.py
+++ b/backend/app/strategies/dynamic_strategy.py
@@ -118,16 +118,16 @@ class DynamicStrategy:
         high = pd.to_numeric(df["high"], errors="coerce")
         low = pd.to_numeric(df["low"], errors="coerce")
 
-        def _rolling_mid(series, period):
+        def _rolling_mid(period):
             return (
-                series.rolling(window=period, min_periods=period).max()
-                + series.rolling(window=period, min_periods=period).min()
+                high.rolling(window=period, min_periods=period).max()
+                + low.rolling(window=period, min_periods=period).min()
             ) / 2
 
-        its = _rolling_mid(high, tenkan)
-        iks = _rolling_mid(low, kijun)
+        its = _rolling_mid(tenkan)
+        iks = _rolling_mid(kijun)
         span_a = ((its + iks) / 2).shift(kijun)
-        span_b = _rolling_mid(high, senkou).shift(kijun)
+        span_b = _rolling_mid(senkou).shift(kijun)
         chikou = close.shift(-kijun)
 
         return {

--- a/backend/tests/unit/test_market_indicator_advanced_consumption.py
+++ b/backend/tests/unit/test_market_indicator_advanced_consumption.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from app.services.opportunity_service import (
+    _build_market_indicator_mappings,
+    _hydrate_with_stored_indicators,
+)
+
+
+def test_advanced_indicator_mappings_are_available_for_stored_indicator_hydration() -> None:
+    mappings = _build_market_indicator_mappings(
+        [
+            {"type": "bbands", "alias": "bb", "params": {"length": 20, "std": 2}},
+            {"type": "atr", "params": {"length": 14}},
+            {"type": "stoch", "params": {"k": 14, "d": 3, "smooth_k": 3}},
+            {"type": "obv", "params": {}},
+            {"type": "ichimoku", "params": {"tenkan": 9, "kijun": 26, "senkou": 52}},
+        ]
+    )
+
+    assert mappings == {
+        "bb_upper_20_2": "bb_upper",
+        "bb_middle_20_2": "bb_middle",
+        "bb_lower_20_2": "bb_lower",
+        "atr_14": "ATR_14",
+        "stoch_k_14_3_3": "STOCH14_3_3",
+        "stoch_d_14_3_3": "STOCHd_14_3_3",
+        "obv": "OBV",
+        "ichimoku_tenkan_9": "ITS_9",
+        "ichimoku_kijun_26": "IKS_26",
+        "ichimoku_senkou_a_9_26_52": "ISA_9",
+        "ichimoku_senkou_b_9_26_52": "ISB_26",
+        "ichimoku_chikou_26": "ICHI_9_26_52",
+    }
+
+
+def test_advanced_stored_indicators_hydrate_without_inline_recalculation() -> None:
+    ts = pd.Timestamp("2026-04-23T00:00:00Z")
+    df = pd.DataFrame({"close": [100.0]}, index=[ts])
+    rows = [
+        {
+            "ts": ts,
+            "bb_upper_20_2": 110.0,
+            "bb_middle_20_2": 100.0,
+            "bb_lower_20_2": 90.0,
+            "atr_14": 5.0,
+            "stoch_k_14_3_3": 70.0,
+            "stoch_d_14_3_3": 65.0,
+            "obv": 12345.0,
+            "ichimoku_tenkan_9": 99.0,
+            "ichimoku_kijun_26": 98.0,
+            "ichimoku_senkou_a_9_26_52": 98.5,
+            "ichimoku_senkou_b_9_26_52": 97.0,
+            "ichimoku_chikou_26": 100.0,
+        }
+    ]
+    mappings = {
+        "bb_upper_20_2": "bb_upper",
+        "atr_14": "ATR_14",
+        "stoch_k_14_3_3": "STOCH14_3_3",
+        "obv": "OBV",
+        "ichimoku_tenkan_9": "ITS_9",
+    }
+
+    hydrated, used_stored = _hydrate_with_stored_indicators(df, rows, mappings)
+
+    assert used_stored is True
+    assert hydrated.loc[ts, "bb_upper"] == 110.0
+    assert hydrated.loc[ts, "ATR_14"] == 5.0
+    assert hydrated.loc[ts, "STOCH14_3_3"] == 70.0
+    assert hydrated.loc[ts, "OBV"] == 12345.0
+    assert hydrated.loc[ts, "ITS_9"] == 99.0

--- a/backend/tests/unit/test_market_indicator_tradingview_fixtures.py
+++ b/backend/tests/unit/test_market_indicator_tradingview_fixtures.py
@@ -83,6 +83,76 @@ def _assert_matching(
     )
 
 
+def _independent_bbands(close: pd.Series) -> tuple[pd.Series, pd.Series, pd.Series]:
+    middle = close.rolling(window=20, min_periods=20).mean()
+    stddev = close.rolling(window=20, min_periods=20).std(ddof=0)
+    return middle + (stddev * 2), middle, middle - (stddev * 2)
+
+
+def _independent_atr(high: pd.Series, low: pd.Series, close: pd.Series) -> pd.Series:
+    true_range = pd.concat(
+        [
+            high - low,
+            (high - close.shift(1)).abs(),
+            (low - close.shift(1)).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+
+    period = 14
+    values = [np.nan] * len(true_range)
+    if len(true_range) > period:
+        values[period] = true_range.iloc[1 : period + 1].mean()
+        for idx in range(period + 1, len(true_range)):
+            values[idx] = ((values[idx - 1] * (period - 1)) + true_range.iloc[idx]) / period
+    return pd.Series(values, index=true_range.index, name="atr_14")
+
+
+def _independent_stoch(
+    high: pd.Series, low: pd.Series, close: pd.Series
+) -> tuple[pd.Series, pd.Series]:
+    lowest_low = low.rolling(window=14, min_periods=14).min()
+    highest_high = high.rolling(window=14, min_periods=14).max()
+    fast_k = ((close - lowest_low) / (highest_high - lowest_low)) * 100
+    slow_k = fast_k.rolling(window=3, min_periods=3).mean()
+    slow_d = slow_k.rolling(window=3, min_periods=3).mean()
+    return slow_k.where(slow_d.notna()), slow_d
+
+
+def _independent_obv(close: pd.Series, volume: pd.Series) -> pd.Series:
+    if close.empty:
+        return pd.Series(dtype=float, name="obv")
+
+    values = [float(volume.iloc[0])]
+    for idx in range(1, len(close)):
+        if close.iloc[idx] > close.iloc[idx - 1]:
+            values.append(values[-1] + float(volume.iloc[idx]))
+        elif close.iloc[idx] < close.iloc[idx - 1]:
+            values.append(values[-1] - float(volume.iloc[idx]))
+        else:
+            values.append(values[-1])
+    return pd.Series(values, index=close.index, name="obv")
+
+
+def _independent_ichimoku(
+    high: pd.Series, low: pd.Series, close: pd.Series
+) -> dict[str, pd.Series]:
+    def midpoint(period: int) -> pd.Series:
+        highest_high = high.rolling(window=period, min_periods=period).max()
+        lowest_low = low.rolling(window=period, min_periods=period).min()
+        return (highest_high + lowest_low) / 2
+
+    tenkan = midpoint(9)
+    kijun = midpoint(26)
+    return {
+        "ichimoku_tenkan_9": tenkan,
+        "ichimoku_kijun_26": kijun,
+        "ichimoku_senkou_a_9_26_52": (tenkan + kijun) / 2,
+        "ichimoku_senkou_b_9_26_52": midpoint(52),
+        "ichimoku_chikou_26": close,
+    }
+
+
 @pytest.mark.parametrize(
     "fixture",
     [
@@ -144,3 +214,145 @@ def test_market_indicator_tradingview_fixture_parity_with_tolerance(
 
     warmup_mask = df["ema_9"].isna() & df["sma_20"].isna() & df["rsi_14"].isna()
     assert warmup_mask.any()
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        TradingViewFixture("BTCUSDT", "1d", "btcusdt_1d_tradingview_reference.csv"),
+        TradingViewFixture("BTCUSDT", "1h", "btcusdt_1h_tradingview_reference.csv"),
+        TradingViewFixture("NVDA", "1d", "nvda_1d_tradingview_reference.csv"),
+        TradingViewFixture("NVDA", "1h", "nvda_1h_tradingview_reference.csv"),
+    ],
+)
+def test_advanced_market_indicators_cross_validate_with_talib_and_formulas(
+    fixture: TradingViewFixture,
+) -> None:
+    talib = pytest.importorskip("talib", reason="TA-Lib required for indicator parity tests")
+    pandas_ta = pytest.importorskip("pandas_ta", reason="pandas-ta required for cross-source tests")
+
+    from app.services.market_indicator_service import MarketIndicatorService
+
+    service = MarketIndicatorService()
+    df = _load_reference_df(fixture.filename)
+    _assert_timeframe_regular_and_utc(df, fixture.timeframe)
+    computed = _compute_fixture(service, df, fixture.symbol, fixture.timeframe)
+
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    close = df["close"].astype(float)
+    volume = df["volume"].astype(float)
+
+    talib_upper, talib_middle, talib_lower = talib.BBANDS(
+        close.to_numpy(), timeperiod=20, nbdevup=2, nbdevdn=2, matype=0
+    )
+    talib_stoch_k, talib_stoch_d = talib.STOCH(
+        high.to_numpy(),
+        low.to_numpy(),
+        close.to_numpy(),
+        fastk_period=14,
+        slowk_period=3,
+        slowk_matype=0,
+        slowd_period=3,
+        slowd_matype=0,
+    )
+    talib_expected = {
+        "bb_upper_20_2": pd.Series(talib_upper),
+        "bb_middle_20_2": pd.Series(talib_middle),
+        "bb_lower_20_2": pd.Series(talib_lower),
+        "atr_14": pd.Series(talib.ATR(high, low, close, timeperiod=14)),
+        "stoch_k_14_3_3": pd.Series(talib_stoch_k),
+        "stoch_d_14_3_3": pd.Series(talib_stoch_d),
+        "obv": pd.Series(talib.OBV(close, volume)),
+    }
+    for column, expected in talib_expected.items():
+        _assert_matching(computed[column], expected, f"{column} TA-Lib", rtol=1e-10, atol=1e-6)
+
+    pandas_ta_bbands = pandas_ta.bbands(close, length=20, std=2)
+    pandas_ta_stoch = pandas_ta.stoch(high, low, close, k=14, d=3, smooth_k=3)
+    pandas_ta_expected = {
+        "bb_upper_20_2": pandas_ta_bbands["BBU_20_2.0_2.0"],
+        "bb_middle_20_2": pandas_ta_bbands["BBM_20_2.0_2.0"],
+        "bb_lower_20_2": pandas_ta_bbands["BBL_20_2.0_2.0"],
+        "atr_14": pandas_ta.atr(high, low, close, length=14),
+        "stoch_k_14_3_3": pandas_ta_stoch["STOCHk_14_3_3"],
+        "stoch_d_14_3_3": pandas_ta_stoch["STOCHd_14_3_3"],
+        "obv": pandas_ta.obv(close, volume),
+    }
+    for column, expected in pandas_ta_expected.items():
+        _assert_matching(computed[column], expected, f"{column} pandas-ta", rtol=1e-10, atol=1e-6)
+
+    formula_upper, formula_middle, formula_lower = _independent_bbands(close)
+    formula_stoch_k, formula_stoch_d = _independent_stoch(high, low, close)
+    formula_expected = {
+        "bb_upper_20_2": formula_upper,
+        "bb_middle_20_2": formula_middle,
+        "bb_lower_20_2": formula_lower,
+        "atr_14": _independent_atr(high, low, close),
+        "stoch_k_14_3_3": formula_stoch_k,
+        "stoch_d_14_3_3": formula_stoch_d,
+        "obv": _independent_obv(close, volume),
+        **_independent_ichimoku(high, low, close),
+    }
+    for column, expected in formula_expected.items():
+        _assert_matching(computed[column], expected, f"{column} formula", rtol=1e-10, atol=1e-6)
+
+    assert computed["source_window"].iloc[-1]["advanced_indicators"]["ichimoku"] == {
+        "tenkan": 9,
+        "kijun": 26,
+        "senkou_b": 52,
+        "displacement": 26,
+        "storage": "source_candle_aligned",
+    }
+
+
+def test_advanced_market_indicator_upsert_serializes_nullable_values_and_conflict_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("talib", reason="TA-Lib required for indicator parity tests")
+
+    from app.services import market_indicator_service as target
+    from app.services.market_indicator_service import MarketIndicatorService
+
+    df = _load_reference_df("btcusdt_1d_tradingview_reference.csv")
+    computed = _compute_fixture(MarketIndicatorService(), df, "BTCUSDT", "1d").head(1)
+
+    class FakeConn:
+        def __init__(self) -> None:
+            self.statement = None
+            self.params = None
+
+        def execute(self, statement, params=None):
+            self.statement = str(statement)
+            self.params = params
+
+    class FakeBegin:
+        def __init__(self, conn: FakeConn) -> None:
+            self.conn = conn
+
+        def __enter__(self) -> FakeConn:
+            return self.conn
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.conn = FakeConn()
+
+        def begin(self) -> FakeBegin:
+            return FakeBegin(self.conn)
+
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(target, "engine", fake_engine)
+
+    MarketIndicatorService()._upsert_indicators(computed, is_recomputed=True)
+
+    assert "ON CONFLICT (symbol, timeframe, ts)" in fake_engine.conn.statement
+    assert "bb_upper_20_2 = EXCLUDED.bb_upper_20_2" in fake_engine.conn.statement
+    assert "ichimoku_chikou_26 = EXCLUDED.ichimoku_chikou_26" in fake_engine.conn.statement
+    assert fake_engine.conn.params[0]["bb_upper_20_2"] is None
+    assert fake_engine.conn.params[0]["atr_14"] is None
+    assert fake_engine.conn.params[0]["ichimoku_tenkan_9"] is None
+    assert fake_engine.conn.params[0]["obv"] == 42000.0
+    assert fake_engine.conn.params[0]["is_recomputed"] is True

--- a/openspec/changes/calculate-advanced-market-indicators/.openspec.yaml
+++ b/openspec/changes/calculate-advanced-market-indicators/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/calculate-advanced-market-indicators/design.md
+++ b/openspec/changes/calculate-advanced-market-indicators/design.md
@@ -1,0 +1,108 @@
+## Context
+
+The existing `market-indicators` capability persists EMA/SMA/RSI/MACD in `market_indicator` and validates them against TradingView fixtures. Advanced indicators already exist partially in strategy engines, but those values are calculated inline for strategy execution and are not available as persisted, audit-ready scoring features.
+
+This change extends the dedicated market indicator pipeline to cover Bollinger Bands, ATR, Stochastic, OBV, and Ichimoku across active timeframes. The implementation must preserve the current incremental recompute behavior, PostgreSQL runtime requirement, and `market_indicator` uniqueness model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add persisted advanced indicator vectors for every processed `symbol`/`timeframe` candle.
+- Keep runtime calculation deterministic and aligned with documented formulas.
+- Preserve incremental/idempotent recompute semantics.
+- Document formulas, default parameters, displacement rules, and validation tolerances.
+- Validate advanced indicators against three reference sources where practical:
+  - TradingView exported fixtures.
+  - TA-Lib output for indicators supported by TA-Lib.
+  - Independent formula implementation documented in tests/specs.
+
+**Non-Goals:**
+
+- Redesign the strategy engine or combo strategy authoring model.
+- Add UI controls for advanced indicators.
+- Add new trading signals or change scoring weights.
+- Support arbitrary user-defined indicator formulas.
+- Replace the existing basic indicator fields.
+
+## Decisions
+
+### Decision: Extend the dedicated market indicator pipeline
+
+Advanced indicators should be calculated in `MarketIndicatorService` rather than only in strategy classes. This keeps scoring consumers on the same persistent source as basic indicators and avoids recalculating features inline.
+
+Alternative considered: reuse `DynamicStrategy` calculations directly. Rejected because strategy calculations are parameterized for strategy execution, have different column naming, and are not persisted with recompute metadata.
+
+### Decision: Prefer explicit columns unless schema pressure requires JSONB
+
+The default implementation path is to add explicit numeric columns for stable default indicators:
+
+- `bb_upper_20_2`, `bb_middle_20_2`, `bb_lower_20_2`
+- `atr_14`
+- `stoch_k_14_3_3`, `stoch_d_14_3_3`
+- `obv`
+- `ichimoku_tenkan_9`, `ichimoku_kijun_26`, `ichimoku_senkou_a_9_26_52`, `ichimoku_senkou_b_9_26_52`, `ichimoku_chikou_26`
+
+Alternative considered: store all advanced values in a generic JSONB payload. Rejected as the default because scoring queries and parity tests benefit from typed, directly selectable columns. JSONB remains acceptable only if implementation proves the explicit column set causes migration or compatibility issues.
+
+### Decision: Use TA-Lib where it matches the documented formula
+
+Use TA-Lib for:
+
+- Bollinger Bands: `BBANDS(close, timeperiod=20, nbdevup=2, nbdevdn=2, matype=0)`.
+- ATR: `ATR(high, low, close, timeperiod=14)`.
+- Stochastic: `STOCH(high, low, close, fastk_period=14, slowk_period=3, slowk_matype=0, slowd_period=3, slowd_matype=0)`.
+- OBV: `OBV(close, volume)`.
+
+Ichimoku is implemented directly because TA-Lib does not provide an Ichimoku function in the Python supported function list.
+
+Alternative considered: implement every formula manually. Rejected because TA-Lib is already the runtime engine for basic indicators and reduces divergence for supported indicators.
+
+### Decision: Implement Ichimoku from documented high/low midpoints
+
+Ichimoku must use highest-high and lowest-low windows:
+
+- Tenkan: `(highest_high(9) + lowest_low(9)) / 2`
+- Kijun: `(highest_high(26) + lowest_low(26)) / 2`
+- Senkou A: `(Tenkan + Kijun) / 2`, plotted 26 periods forward
+- Senkou B: `(highest_high(52) + lowest_low(52)) / 2`, plotted 26 periods forward
+- Chikou: close plotted 26 periods backward
+
+The persisted row must document whether displaced spans are stored at their plotted timestamp or as raw values on the source candle timestamp. The preferred model is to store the values aligned to the source candle timestamp and document displacement metadata, because the table key represents candle close time.
+
+Alternative considered: physically shift Senkou/Chikou values into future/past table rows. Rejected because it can create values for timestamps without source candles and complicates idempotent upserts.
+
+### Decision: Cross-validation is evidence, not runtime dependency
+
+Runtime calculation should not call TradingView or external documentation sources. Cross-validation belongs in tests and QA artifacts:
+
+- TradingView fixture parity validates platform-visible values.
+- TA-Lib parity validates supported runtime engine outputs.
+- Independent formula parity validates formulas and catches implementation mistakes.
+
+Ichimoku uses TradingView fixture parity plus independent formula parity; TA-Lib is not applicable for that indicator.
+
+## Risks / Trade-offs
+
+- [Risk] TradingView defaults can differ from TA-Lib defaults, especially ATR smoothing and Stochastic variants. -> Mitigation: document exact parameters, export fixtures with matching defaults, and set indicator-specific tolerances.
+- [Risk] Ichimoku displacement semantics can be ambiguous in a row-oriented store. -> Mitigation: store source-aligned values and include displacement metadata in formula docs and tests.
+- [Risk] Adding many columns can make future indicator expansion cumbersome. -> Mitigation: keep this change scoped to named default indicators and revisit JSONB only when indicator count becomes dynamic.
+- [Risk] Existing strategy implementations may contain formula drift. -> Mitigation: do not treat strategy code as the source of truth; align shared helpers or tests to the documented formulas before reuse.
+- [Risk] Backfilling all active symbols/timeframes can be expensive. -> Mitigation: reuse incremental recompute windows and provide force-full recompute only for explicit operational backfill.
+
+## Migration Plan
+
+1. Add the advanced indicator storage fields through a PostgreSQL migration and startup schema guard.
+2. Extend `MarketIndicatorService._compute_indicators` to calculate the default advanced indicators.
+3. Extend read/upsert paths so latest and time-series APIs include advanced fields.
+4. Add formula documentation and fixture metadata.
+5. Add parity tests with TradingView fixtures, TA-Lib outputs, and independent formula calculations.
+6. Run a controlled recompute/backfill for target symbols/timeframes.
+
+Rollback strategy: keep new columns nullable, deploy code so old rows remain readable, and disable advanced consumers if parity tests fail. A rollback can leave nullable columns in place without breaking existing basic indicator reads.
+
+## Open Questions
+
+- Which symbols/timeframes are the minimum required TradingView fixture set for final QA: current BTCUSDT/NVDA `1d` and `1h`, or an added intraday crypto timeframe?
+- Should scoring consume every advanced field immediately, or should this change only make the fields available for future scoring rules?
+- Should advanced indicator columns be included in all existing indicator API responses by default, or gated behind a version/field selection parameter?

--- a/openspec/changes/calculate-advanced-market-indicators/formula-validation.md
+++ b/openspec/changes/calculate-advanced-market-indicators/formula-validation.md
@@ -1,0 +1,103 @@
+## Formula Documentation
+
+This change extends the dedicated `market_indicator` pipeline with source-candle-aligned
+advanced indicator fields. Warmup values remain null until each rolling window has enough
+history.
+
+### Bollinger Bands
+
+- Columns: `bb_upper_20_2`, `bb_middle_20_2`, `bb_lower_20_2`
+- Defaults: length 20, standard deviation multiplier 2, SMA middle band
+- Formula:
+  - `middle = SMA(close, 20)`
+  - `upper = middle + 2 * STDDEV(close, 20)`
+  - `lower = middle - 2 * STDDEV(close, 20)`
+- Validation sources:
+  - TradingView OHLCV fixture data used as the input candle source.
+  - TA-Lib `BBANDS`.
+  - pandas-ta `bbands`.
+  - Independent pandas rolling SMA/stddev formula in tests.
+
+### ATR
+
+- Column: `atr_14`
+- Defaults: length 14
+- Formula:
+  - `TR = max(high - low, abs(high - previous_close), abs(low - previous_close))`
+  - Runtime uses TA-Lib ATR/Wilder smoothing.
+- Validation sources:
+  - TradingView OHLCV fixture data used as the input candle source.
+  - TA-Lib `ATR`.
+  - pandas-ta `atr`.
+  - Independent True Range/Wilder smoothing formula in tests.
+
+### Stochastic
+
+- Columns: `stoch_k_14_3_3`, `stoch_d_14_3_3`
+- Defaults: fast `%K` length 14, `%K` smoothing 3, `%D` smoothing 3
+- Formula:
+  - `fast_k = (close - lowest_low_14) / (highest_high_14 - lowest_low_14) * 100`
+  - `stoch_k = SMA(fast_k, 3)`
+  - `stoch_d = SMA(stoch_k, 3)`
+- Validation sources:
+  - TradingView OHLCV fixture data used as the input candle source.
+  - TA-Lib `STOCH`.
+  - pandas-ta `stoch`.
+  - Independent rolling high/low and SMA formula in tests.
+
+### OBV
+
+- Column: `obv`
+- Defaults: close and volume input, no lookback period
+- Formula:
+  - If current close is above previous close, add current volume.
+  - If current close is below previous close, subtract current volume.
+  - If current close is equal to previous close, keep previous OBV.
+- Validation sources:
+  - TradingView OHLCV fixture data used as the input candle source.
+  - TA-Lib `OBV`.
+  - pandas-ta `obv`.
+  - Independent cumulative close-direction formula in tests.
+
+### Ichimoku
+
+- Columns:
+  - `ichimoku_tenkan_9`
+  - `ichimoku_kijun_26`
+  - `ichimoku_senkou_a_9_26_52`
+  - `ichimoku_senkou_b_9_26_52`
+  - `ichimoku_chikou_26`
+- Defaults: Tenkan 9, Kijun 26, Senkou Span B 52, displacement 26
+- Formula:
+  - `tenkan = (highest_high_9 + lowest_low_9) / 2`
+  - `kijun = (highest_high_26 + lowest_low_26) / 2`
+  - `senkou_a = (tenkan + kijun) / 2`
+  - `senkou_b = (highest_high_52 + lowest_low_52) / 2`
+  - `chikou = close`
+- Storage semantics:
+  - Values are stored aligned to the source candle timestamp.
+  - Displacement is recorded in `source_window.advanced_indicators.ichimoku.displacement`.
+  - The pipeline does not write projected future rows or past rows for shifted chart display.
+- Validation sources:
+  - TradingView OHLCV fixture data used as the input candle source.
+  - TA-Lib is not applicable because TA-Lib does not provide an Ichimoku function.
+  - pandas-ta is used only as a secondary review source for Tenkan/Kijun naming and
+    displacement behavior, not as strict parity for persisted source-aligned spans.
+  - Independent rolling highest-high/lowest-low formula in tests.
+
+## Backfill / Recompute Note
+
+Existing rows will have null advanced fields until recomputed. Use the existing admin
+indicator recompute endpoint with `forceFull=true` for a controlled full backfill by
+symbol/timeframe, or the default incremental recompute for routine updates:
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "timeframes": ["1h", "1d"],
+  "forceFull": true
+}
+```
+
+Backfill should be run in small batches per symbol to keep PostgreSQL write pressure
+predictable.

--- a/openspec/changes/calculate-advanced-market-indicators/proposal.md
+++ b/openspec/changes/calculate-advanced-market-indicators/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+O scoring e os fluxos de análise precisam de sinais técnicos mais ricos do que EMA/SMA/RSI/MACD para capturar volatilidade, momentum, volume e contexto de tendência. Hoje alguns desses cálculos existem apenas dentro de motores de estratégia, mas não como indicadores persistidos, auditáveis e validados no pipeline dedicado de indicadores.
+
+## What Changes
+
+- Calcular indicadores avançados para cada par `symbol`/`timeframe` ativo:
+  - Bollinger Bands: banda superior, média e inferior.
+  - ATR.
+  - Stochastic: linhas `%K` e `%D`.
+  - OBV.
+  - Ichimoku: Tenkan, Kijun, Senkou Span A, Senkou Span B e Chikou.
+- Persistir esses indicadores no armazenamento dedicado de indicadores de mercado, mantendo unicidade por `symbol`, `timeframe` e timestamp.
+- Manter recálculo incremental e idempotente, seguindo o mesmo padrão operacional dos indicadores básicos.
+- Documentar as fórmulas usadas para cada indicador, incluindo parâmetros padrão e deslocamentos quando aplicável.
+- Validar os resultados por indicador com comparação cruzada contra 3 fontes de referência.
+- Garantir que o scoring possa consumir os indicadores avançados persistidos sem recalcular em linha.
+- Corrigir divergências conhecidas entre cálculos atuais de estratégia e as fórmulas documentadas quando esses cálculos forem reaproveitados.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `market-indicators`: Expande o pipeline dedicado de indicadores para incluir Bollinger, ATR, Stochastic, OBV e Ichimoku, com documentação de fórmulas, persistência, recálculo incremental e validação cruzada.
+
+## Impact
+
+- Backend: serviço de cálculo de indicadores, rotinas de recompute, leitura de OHLCV, consumo pelo scoring e possível reaproveitamento/correção de lógica já existente em estratégias.
+- Banco de dados: expansão da tabela `market_indicator` ou definição de armazenamento equivalente para séries avançadas com metadados e integridade.
+- Testes: novos fixtures e testes de paridade para TradingView e validação cruzada com TA-Lib/fórmulas independentes onde aplicável.
+- Documentação/OpenSpec: fórmulas, parâmetros padrão, fontes de referência e tolerâncias aceitas por indicador.
+- Operação: recompute/backfill dos novos campos para ativos e timeframes já armazenados.

--- a/openspec/changes/calculate-advanced-market-indicators/specs/market-indicators/spec.md
+++ b/openspec/changes/calculate-advanced-market-indicators/specs/market-indicators/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: Sistema calcula indicadores avançados em todos os timeframes ativos
+
+The system SHALL compute Bollinger Bands, ATR, Stochastic, OBV, and Ichimoku values for each configured `symbol`/`timeframe` pair processed by the dedicated market indicator pipeline.
+
+#### Scenario: Indicadores avançados gerados por candle fechado
+
+- **GIVEN** candles OHLCV fechados para um `symbol`/`timeframe` ativo
+- **WHEN** o pipeline dedicado de indicadores roda
+- **THEN** o sistema SHALL calcular Bollinger Bands, ATR, Stochastic, OBV e Ichimoku para cada candle elegível
+- **AND** valores SHALL permanecer nulos durante a fase de aquecimento quando a janela mínima ainda não existir
+
+#### Scenario: Indicadores avançados disponíveis para scoring
+
+- **GIVEN** um run de scoring precisa de features técnicas avançadas
+- **WHEN** o scoring lê indicadores técnicos
+- **THEN** o sistema SHALL ler Bollinger Bands, ATR, Stochastic, OBV e Ichimoku do armazenamento dedicado de indicadores
+- **AND** o scoring MUST NOT recalcular esses indicadores em linha
+
+### Requirement: Sistema persiste indicadores avançados com integridade e metadados
+
+The system SHALL persist advanced indicator values in the dedicated market indicator storage while preserving uniqueness by `symbol`, `timeframe`, and candle timestamp.
+
+#### Scenario: Persistência idempotente de indicadores avançados
+
+- **GIVEN** um registro técnico para `symbol`, `timeframe` e `ts`
+- **WHEN** indicadores avançados são persistidos
+- **THEN** o sistema SHALL armazenar os valores avançados no mesmo registro lógico do candle
+- **AND** retries/replays MUST update the existing row instead of creating duplicates
+- **AND** metadata such as `provider`, `source_window`, `row_count`, `is_recomputed`, and `updated_at` MUST remain populated
+
+#### Scenario: Recompute incremental preserva consistência
+
+- **GIVEN** indicadores avançados já persistidos para um `symbol`/`timeframe`
+- **WHEN** um novo candle chega e o recompute incremental roda
+- **THEN** o sistema SHALL recalculate only the required lookback window for all basic and advanced indicators
+- **AND** rows outside the recompute window MUST remain unchanged
+
+### Requirement: Fórmulas de indicadores avançados são documentadas
+
+The system SHALL document the formulas, default parameters, and displacement semantics used for each advanced indicator.
+
+#### Scenario: Fórmulas disponíveis para revisão técnica
+
+- **WHEN** um reviewer consulta a documentação da change
+- **THEN** ela MUST define Bollinger Bands as SMA plus/minus standard-deviation bands
+- **AND** ATR as Wilder-style average true range over true range values
+- **AND** Stochastic as close position within the rolling high-low range plus `%K`/`%D` smoothing
+- **AND** OBV as cumulative volume adjusted by close direction
+- **AND** Ichimoku as Tenkan, Kijun, Senkou A, Senkou B, and Chikou using highest-high/lowest-low windows and documented displacement
+
+### Requirement: Indicadores avançados usam parâmetros padrão explícitos
+
+The system SHALL use explicit default parameters for advanced indicators unless a later capability introduces configurable indicator parameter sets.
+
+#### Scenario: Parâmetros padrão aplicados no runtime
+
+- **WHEN** o pipeline calcula indicadores avançados sem parâmetros customizados
+- **THEN** Bollinger Bands MUST use length 20 and standard deviation multiplier 2
+- **AND** ATR MUST use length 14
+- **AND** Stochastic MUST use fast `%K` length 14, `%K` smoothing 3, and `%D` smoothing 3
+- **AND** Ichimoku MUST use Tenkan 9, Kijun 26, Senkou Span B 52, and displacement 26
+- **AND** OBV MUST use close and volume without a lookback period
+
+### Requirement: Validação cruzada usa três fontes de referência
+
+The system SHALL include automated validation evidence for advanced indicator calculations using three independent reference sources where applicable.
+
+#### Scenario: Uso de fixtures TradingView como base de validação
+
+- **GIVEN** fixtures OHLCV exportados da TradingView
+- **WHEN** testes de paridade executam
+- **THEN** the system SHALL use those candles as reference market input for advanced indicator validation
+- **AND** existing TradingView basic indicator reference columns MUST continue to pass within indicator-specific tolerances
+
+#### Scenario: Paridade com TA-Lib para indicadores suportados
+
+- **GIVEN** the runtime has TA-Lib available
+- **WHEN** tests compare supported advanced indicators against TA-Lib calculations
+- **THEN** Bollinger Bands, ATR, Stochastic, and OBV SHALL match TA-Lib outputs within indicator-specific tolerances
+- **AND** Ichimoku MUST be excluded from TA-Lib parity because TA-Lib does not provide an Ichimoku function
+
+#### Scenario: Paridade com pandas-ta para indicadores suportados
+
+- **GIVEN** the runtime has pandas-ta available in the test environment
+- **WHEN** tests compare supported advanced indicators against pandas-ta calculations
+- **THEN** Bollinger Bands, ATR, Stochastic, and OBV SHALL match pandas-ta outputs within indicator-specific tolerances
+- **AND** Ichimoku MUST be treated separately because chart displacement conventions differ from source-candle-aligned storage
+
+#### Scenario: Paridade com implementação independente de fórmulas
+
+- **GIVEN** an independent formula implementation in tests
+- **WHEN** tests compare runtime output with documented formulas
+- **THEN** Bollinger Bands, ATR, Stochastic, OBV, and Ichimoku SHALL match the independent formula outputs within indicator-specific tolerances
+
+### Requirement: Ichimoku usa fórmulas corretas de midpoint
+
+The system SHALL calculate Ichimoku lines using rolling highest-high and lowest-low midpoints, not independent high-only or low-only rolling values.
+
+#### Scenario: Cálculo correto de Tenkan e Kijun
+
+- **WHEN** Ichimoku is calculated for a candle with enough history
+- **THEN** Tenkan MUST equal `(highest_high_9 + lowest_low_9) / 2`
+- **AND** Kijun MUST equal `(highest_high_26 + lowest_low_26) / 2`
+
+#### Scenario: Cálculo correto de spans e Chikou
+
+- **WHEN** Ichimoku spans are calculated for a candle with enough history
+- **THEN** Senkou Span A MUST equal `(Tenkan + Kijun) / 2`
+- **AND** Senkou Span B MUST equal `(highest_high_52 + lowest_low_52) / 2`
+- **AND** Chikou MUST represent the close series with the documented 26-period lagging displacement
+- **AND** persisted values MUST document whether displacement is represented as metadata or shifted timestamps

--- a/openspec/changes/calculate-advanced-market-indicators/tasks.md
+++ b/openspec/changes/calculate-advanced-market-indicators/tasks.md
@@ -1,0 +1,39 @@
+## 1. Schema And Storage
+
+- [x] 1.1 Add PostgreSQL migration fields or equivalent storage for Bollinger, ATR, Stochastic, OBV, and Ichimoku values.
+- [x] 1.2 Update startup schema guard for `market_indicator` so fresh environments include advanced indicator storage.
+- [x] 1.3 Preserve unique `(symbol, timeframe, ts)` writes and nullable warmup values for all advanced fields.
+- [x] 1.4 Update latest/time-series read queries to return advanced indicator fields with existing metadata.
+
+## 2. Calculation Pipeline
+
+- [x] 2.1 Extend `MarketIndicatorService._compute_indicators` to calculate Bollinger Bands with length 20 and 2 standard deviations.
+- [x] 2.2 Add ATR 14 calculation using the selected runtime engine and documented smoothing semantics.
+- [x] 2.3 Add Stochastic 14/3/3 calculation with `%K` and `%D` outputs.
+- [x] 2.4 Add OBV calculation from close and volume.
+- [x] 2.5 Add Ichimoku calculation using highest-high/lowest-low midpoint formulas and documented displacement metadata.
+- [x] 2.6 Update upsert serialization so all advanced values persist idempotently during full and incremental recompute.
+
+## 3. Documentation And Formula Evidence
+
+- [x] 3.1 Document formulas, defaults, warmup behavior, and displacement semantics in the change handoff or market-indicators docs.
+- [x] 3.2 Record the validation sources for each indicator: TradingView fixture input, TA-Lib where applicable, pandas-ta where applicable, and independent formula implementation.
+- [x] 3.3 Document why Ichimoku uses custom formula validation instead of TA-Lib parity.
+
+## 4. Validation Tests
+
+- [x] 4.1 Use existing TradingView fixture CSVs as reference OHLCV inputs and preserve existing TradingView basic-indicator parity.
+- [x] 4.2 Add TA-Lib and pandas-ta parity checks for Bollinger, ATR, Stochastic, and OBV with indicator-specific tolerances.
+- [x] 4.3 Add independent formula parity checks for all advanced indicators, including Ichimoku.
+- [x] 4.4 Add tests proving warmup nulls and incremental recompute remain idempotent for advanced fields.
+- [x] 4.5 Run targeted unit tests for market indicator fixtures and recompute behavior.
+
+## 5. Scoring And Operational Readiness
+
+- [x] 5.1 Confirm scoring reads advanced indicators from dedicated storage and does not recalculate them inline.
+- [x] 5.2 Add a controlled recompute/backfill note for existing symbols and timeframes.
+- [x] 5.3 Reconcile `tasks.md`, implementation evidence, and handoff before moving the change to QA.
+
+## 6. Project Skills Reminder
+
+- [x] 6.1 Use relevant project skills when applying this change, especially architecture review, db migration review, unit test planning, debugging checklist, and CI failure triage if needed.

--- a/openspec/changes/calculate-basic-market-indicators/.openspec.yaml
+++ b/openspec/changes/calculate-basic-market-indicators/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/calculate-basic-market-indicators/proposal.md
+++ b/openspec/changes/calculate-basic-market-indicators/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+O scoring precisa de indicadores técnicos básicos consistentes, auditáveis e disponíveis para todos os timeframes suportados sem recalcular valores em linha a cada uso. Formalizar este fluxo reduz divergência entre backtest, monitoramento e scoring, e cria uma base confiável para evoluções futuras de indicadores.
+
+## What Changes
+
+- Calcular EMA, SMA, RSI e MACD para cada par `symbol`/`timeframe` ativo a partir dos candles OHLCV fechados.
+- Usar uma engine técnica padronizada para runtime, com preferência por TA-Lib quando disponível no ambiente.
+- Persistir os vetores de indicadores em uma tabela dedicada com chave única por `symbol`, `timeframe` e timestamp.
+- Suportar recálculo incremental/idempotente, evitando recomputar a série inteira em rotinas regulares.
+- Expor ou manter um fluxo operacional de recompute para backfill, correção e atualização manual.
+- Validar os cálculos com testes automatizados contra valores de referência exportados da TradingView.
+- Garantir que o scoring leia os indicadores persistidos, sem recálculo inline.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `market-indicators`: Reforça os requisitos para cálculo, persistência, recálculo incremental, validação TradingView e consumo de EMA/SMA/RSI/MACD pelo scoring.
+
+## Impact
+
+- Backend: serviço de cálculo de indicadores, jobs/admin endpoints de recompute, leitura de candles OHLCV e camada de scoring.
+- Banco de dados: tabela dedicada `market_indicator`, campos técnicos, metadados e constraint de unicidade.
+- Testes: fixtures TradingView e testes de paridade por indicador/timeframe com tolerância explícita.
+- Dependências: TA-Lib ou biblioteca técnica equivalente aprovada para cálculo determinístico.
+- Operação: recompute/backfill de indicadores para ativos e timeframes já armazenados.


### PR DESCRIPTION
## Summary
- Add OpenSpec changes for basic and advanced market indicators
- Persist Bollinger, ATR, Stochastic, OBV, and Ichimoku values in market_indicator
- Add advanced indicator parity tests and stored-indicator hydration
- Update OpenSpec skills

## Validation
- PYTHONPATH=backend ./backend/.venv/bin/python -m pytest backend/tests/unit/test_market_indicator_tradingview_fixtures.py backend/tests/unit/test_market_indicator_advanced_consumption.py -q
- openspec validate calculate-advanced-market-indicators --type change --strict --json
- git diff --check