### PR TITLE
feat: calcular suporte e resistência por pivots

### DIFF
--- a/backend/alembic/versions/20260424_0002_add_pivot_levels_to_market_indicator.py
+++ b/backend/alembic/versions/20260424_0002_add_pivot_levels_to_market_indicator.py
@@ -1,0 +1,50 @@
+"""Add pivot support and resistance levels to market indicators.
+
+Revision ID: 20260424_0002
+Revises: 20260424_0001
+Create Date: 2026-04-24 00:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260424_0002"
+down_revision = "20260424_0001"
+branch_labels = None
+depends_on = None
+
+
+PIVOT_COLUMNS = (
+    "pivot_point",
+    "support_1",
+    "support_2",
+    "support_3",
+    "resistance_1",
+    "resistance_2",
+    "resistance_3",
+)
+
+
+def upgrade() -> None:
+    for column in PIVOT_COLUMNS:
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF to_regclass('public.market_indicator') IS NOT NULL THEN
+                    ALTER TABLE market_indicator ADD COLUMN IF NOT EXISTS {column} NUMERIC;
+                END IF;
+            END $$;
+            """)
+
+
+def downgrade() -> None:
+    for column in reversed(PIVOT_COLUMNS):
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF to_regclass('public.market_indicator') IS NOT NULL THEN
+                    ALTER TABLE market_indicator DROP COLUMN IF EXISTS {column};
+                END IF;
+            END $$;
+            """)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -164,6 +164,13 @@ def ensure_runtime_schema_migrations() -> None:
                     ichimoku_senkou_b_9_26_52 NUMERIC,
                     ichimoku_chikou_26 NUMERIC,
                     chart_patterns JSONB,
+                    pivot_point NUMERIC,
+                    support_1 NUMERIC,
+                    support_2 NUMERIC,
+                    support_3 NUMERIC,
+                    resistance_1 NUMERIC,
+                    resistance_2 NUMERIC,
+                    resistance_3 NUMERIC,
                     source TEXT NOT NULL DEFAULT 'market',
                     provider TEXT NOT NULL DEFAULT 'talib',
                     source_window JSONB,
@@ -187,7 +194,14 @@ def ensure_runtime_schema_migrations() -> None:
                     ADD COLUMN IF NOT EXISTS ichimoku_senkou_a_9_26_52 NUMERIC,
                     ADD COLUMN IF NOT EXISTS ichimoku_senkou_b_9_26_52 NUMERIC,
                     ADD COLUMN IF NOT EXISTS ichimoku_chikou_26 NUMERIC,
-                    ADD COLUMN IF NOT EXISTS chart_patterns JSONB
+                    ADD COLUMN IF NOT EXISTS chart_patterns JSONB,
+                    ADD COLUMN IF NOT EXISTS pivot_point NUMERIC,
+                    ADD COLUMN IF NOT EXISTS support_1 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS support_2 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS support_3 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS resistance_1 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS resistance_2 NUMERIC,
+                    ADD COLUMN IF NOT EXISTS resistance_3 NUMERIC
                 """))
         conn.execute(text("""
                 CREATE INDEX IF NOT EXISTS uq_market_indicator_symbol_timeframe_ts

--- a/backend/app/services/market_indicator_service.py
+++ b/backend/app/services/market_indicator_service.py
@@ -45,6 +45,15 @@ ADVANCED_INDICATOR_COLUMNS = (
     "ichimoku_senkou_b_9_26_52",
     "ichimoku_chikou_26",
 )
+PIVOT_LEVEL_COLUMNS = (
+    "pivot_point",
+    "support_1",
+    "support_2",
+    "support_3",
+    "resistance_1",
+    "resistance_2",
+    "resistance_3",
+)
 
 
 def _normalize_timeframe(value: str) -> str:
@@ -94,6 +103,25 @@ def _rolling_midpoint(high: pd.Series, low: pd.Series, period: int) -> pd.Series
     highest_high = high.rolling(window=period, min_periods=period).max()
     lowest_low = low.rolling(window=period, min_periods=period).min()
     return (highest_high + lowest_low) / 2
+
+
+def _classic_pivot_levels(
+    high: pd.Series, low: pd.Series, close: pd.Series
+) -> dict[str, pd.Series]:
+    previous_high = high.shift(1)
+    previous_low = low.shift(1)
+    previous_close = close.shift(1)
+    pivot = (previous_high + previous_low + previous_close) / 3
+    previous_range = previous_high - previous_low
+    return {
+        "pivot_point": pivot,
+        "support_1": (2 * pivot) - previous_high,
+        "support_2": pivot - previous_range,
+        "support_3": previous_low - (2 * (previous_high - pivot)),
+        "resistance_1": (2 * pivot) - previous_low,
+        "resistance_2": pivot + previous_range,
+        "resistance_3": previous_high + (2 * (pivot - previous_low)),
+    }
 
 
 class MarketIndicatorService:
@@ -157,6 +185,13 @@ class MarketIndicatorService:
                             ichimoku_senkou_b_9_26_52,
                             ichimoku_chikou_26,
                             chart_patterns,
+                            pivot_point,
+                            support_1,
+                            support_2,
+                            support_3,
+                            resistance_1,
+                            resistance_2,
+                            resistance_3,
                             source,
                             provider,
                             source_window,
@@ -201,11 +236,23 @@ class MarketIndicatorService:
                 rows = (
                     conn.execute(
                         text("""
+                            WITH previous_candle AS (
+                                SELECT candle_time
+                                FROM market_ohlcv
+                                WHERE symbol = :symbol
+                                  AND timeframe = :timeframe
+                                  AND candle_time < :since
+                                ORDER BY candle_time DESC
+                                LIMIT 1
+                            )
                             SELECT candle_time, open, high, low, close, volume
                             FROM market_ohlcv
                             WHERE symbol = :symbol
                               AND timeframe = :timeframe
-                              AND candle_time >= :since
+                              AND (
+                                  candle_time >= :since
+                                  OR candle_time = (SELECT candle_time FROM previous_candle)
+                              )
                             ORDER BY candle_time ASC
                             """),
                         {
@@ -285,6 +332,7 @@ class MarketIndicatorService:
         ichimoku_senkou_a = (ichimoku_tenkan + ichimoku_kijun) / 2
         ichimoku_senkou_b = _rolling_midpoint(numeric_high, numeric_low, 52)
         ichimoku_chikou = numeric_close
+        pivot_levels = _classic_pivot_levels(numeric_high, numeric_low, numeric_close)
 
         out = df.copy()
         out["ema_9"] = ema_9
@@ -307,6 +355,8 @@ class MarketIndicatorService:
         out["ichimoku_senkou_a_9_26_52"] = ichimoku_senkou_a
         out["ichimoku_senkou_b_9_26_52"] = ichimoku_senkou_b
         out["ichimoku_chikou_26"] = ichimoku_chikou
+        for column, values in pivot_levels.items():
+            out[column] = values
         out["chart_patterns"] = detect_chart_patterns(out)
         out["symbol"] = _normalize_symbol(symbol)
         out["timeframe"] = _normalize_timeframe(timeframe)
@@ -329,6 +379,21 @@ class MarketIndicatorService:
                     "senkou_b": 52,
                     "displacement": 26,
                     "storage": "source_candle_aligned",
+                },
+            },
+            "support_resistance": {
+                "pivot": {
+                    "method": "classic",
+                    "source": "previous_candle_ohlc",
+                    "levels": [
+                        "pivot_point",
+                        "support_1",
+                        "support_2",
+                        "support_3",
+                        "resistance_1",
+                        "resistance_2",
+                        "resistance_3",
+                    ],
                 },
             },
         }
@@ -358,6 +423,7 @@ class MarketIndicatorService:
                         column: _nullable_float(row[column])
                         for column in ADVANCED_INDICATOR_COLUMNS
                     },
+                    **{column: _nullable_float(row[column]) for column in PIVOT_LEVEL_COLUMNS},
                     "chart_patterns": _json_or_none(row.get("chart_patterns")),
                     "source": row["source"],
                     "provider": row["provider"],
@@ -396,6 +462,13 @@ class MarketIndicatorService:
                         ichimoku_senkou_b_9_26_52,
                         ichimoku_chikou_26,
                         chart_patterns,
+                        pivot_point,
+                        support_1,
+                        support_2,
+                        support_3,
+                        resistance_1,
+                        resistance_2,
+                        resistance_3,
                         source,
                         provider,
                         source_window,
@@ -428,6 +501,13 @@ class MarketIndicatorService:
                         :ichimoku_senkou_b_9_26_52,
                         :ichimoku_chikou_26,
                         :chart_patterns,
+                        :pivot_point,
+                        :support_1,
+                        :support_2,
+                        :support_3,
+                        :resistance_1,
+                        :resistance_2,
+                        :resistance_3,
                         :source,
                         :provider,
                         :source_window,
@@ -458,6 +538,13 @@ class MarketIndicatorService:
                         ichimoku_senkou_b_9_26_52 = EXCLUDED.ichimoku_senkou_b_9_26_52,
                         ichimoku_chikou_26 = EXCLUDED.ichimoku_chikou_26,
                         chart_patterns = EXCLUDED.chart_patterns,
+                        pivot_point = EXCLUDED.pivot_point,
+                        support_1 = EXCLUDED.support_1,
+                        support_2 = EXCLUDED.support_2,
+                        support_3 = EXCLUDED.support_3,
+                        resistance_1 = EXCLUDED.resistance_1,
+                        resistance_2 = EXCLUDED.resistance_2,
+                        resistance_3 = EXCLUDED.resistance_3,
                         source = EXCLUDED.source,
                         provider = EXCLUDED.provider,
                         source_window = EXCLUDED.source_window,

--- a/backend/tests/unit/test_market_indicator_pivot_levels.py
+++ b/backend/tests/unit/test_market_indicator_pivot_levels.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from app.services.market_indicator_service import MarketIndicatorService
+
+PIVOT_COLUMNS = (
+    "pivot_point",
+    "support_1",
+    "support_2",
+    "support_3",
+    "resistance_1",
+    "resistance_2",
+    "resistance_3",
+)
+
+
+def _ohlcv(rows: list[tuple[str, float, float, float]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": pd.date_range("2026-04-24T00:00:00Z", periods=len(rows), freq="h"),
+            "open": [close for _label, _high, _low, close in rows],
+            "high": [high for _label, high, _low, _close in rows],
+            "low": [low for _label, _high, low, _close in rows],
+            "close": [close for _label, _high, _low, close in rows],
+            "volume": [1000.0 + idx for idx in range(len(rows))],
+        }
+    )
+
+
+def _classic_pivots(high: float, low: float, close: float) -> dict[str, float]:
+    pivot = (high + low + close) / 3
+    return {
+        "pivot_point": pivot,
+        "support_1": (2 * pivot) - high,
+        "support_2": pivot - (high - low),
+        "support_3": low - (2 * (high - pivot)),
+        "resistance_1": (2 * pivot) - low,
+        "resistance_2": pivot + (high - low),
+        "resistance_3": high + (2 * (pivot - low)),
+    }
+
+
+def test_compute_indicators_calculates_classic_pivot_levels_from_previous_candle() -> None:
+    rows = _ohlcv(
+        [
+            ("previous", 110.0, 90.0, 100.0),
+            ("current", 115.0, 95.0, 105.0),
+            ("next", 120.0, 100.0, 110.0),
+        ]
+    )
+
+    output = MarketIndicatorService()._compute_indicators(rows, timeframe="1h", symbol="btcusdt")
+
+    expected = _classic_pivots(high=110.0, low=90.0, close=100.0)
+    for column, value in expected.items():
+        assert output.loc[1, column] == pytest.approx(value)
+
+
+def test_compute_indicators_keeps_first_row_pivot_levels_null() -> None:
+    rows = _ohlcv(
+        [
+            ("first", 110.0, 90.0, 100.0),
+            ("second", 115.0, 95.0, 105.0),
+        ]
+    )
+
+    output = MarketIndicatorService()._compute_indicators(rows, timeframe="1h", symbol="btcusdt")
+
+    for column in PIVOT_COLUMNS:
+        assert math.isnan(output.loc[0, column])
+
+
+@pytest.mark.parametrize("timeframe", ["1m", "5m", "15m", "1h", "4h", "1d"])
+def test_compute_indicators_includes_pivot_levels_for_each_timeframe(timeframe: str) -> None:
+    rows = _ohlcv(
+        [
+            ("first", 110.0, 90.0, 100.0),
+            ("second", 115.0, 95.0, 105.0),
+            ("third", 120.0, 100.0, 110.0),
+        ]
+    )
+
+    output = MarketIndicatorService()._compute_indicators(
+        rows, timeframe=timeframe, symbol="ethusdt"
+    )
+
+    assert len(output) == len(rows)
+    assert output["timeframe"].tolist() == [timeframe] * len(rows)
+    assert output["symbol"].tolist() == ["ETHUSDT"] * len(rows)
+    pivot_columns = list(PIVOT_COLUMNS)
+    assert list(output[pivot_columns].columns) == pivot_columns
+    assert output.loc[1:, pivot_columns].notna().all().all()
+
+
+def test_read_ohlcv_incremental_includes_previous_candle_for_pivot_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import market_indicator_service as target
+
+    class FakeConn:
+        def __init__(self) -> None:
+            self.statement = ""
+            self.params: dict[str, Any] | None = None
+
+        def execute(self, statement, params=None):
+            self.statement = str(statement)
+            self.params = params
+            return self
+
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [
+                {
+                    "candle_time": datetime(2026, 4, 24, 0, 0, tzinfo=timezone.utc),
+                    "open": 100,
+                    "high": 110,
+                    "low": 90,
+                    "close": 100,
+                    "volume": 1000,
+                },
+                {
+                    "candle_time": datetime(2026, 4, 24, 1, 0, tzinfo=timezone.utc),
+                    "open": 101,
+                    "high": 115,
+                    "low": 95,
+                    "close": 105,
+                    "volume": 1001,
+                },
+            ]
+
+    class FakeBegin:
+        def __init__(self, conn: FakeConn) -> None:
+            self.conn = conn
+
+        def __enter__(self) -> FakeConn:
+            return self.conn
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.conn = FakeConn()
+
+        def begin(self) -> FakeBegin:
+            return FakeBegin(self.conn)
+
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(target, "engine", fake_engine)
+
+    since = datetime(2026, 4, 24, 1, 0, tzinfo=timezone.utc)
+    output = MarketIndicatorService()._read_ohlcv("BTCUSDT", "1h", since)
+
+    assert "previous_candle" in fake_engine.conn.statement
+    assert "candle_time < :since" in fake_engine.conn.statement
+    assert fake_engine.conn.params == {
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "since": since,
+    }
+    assert output["ts"].dt.tz is not None
+    assert output.shape[0] == 2
+
+
+def test_get_time_series_returns_pivot_level_columns(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected_row = {
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "ts": datetime(2026, 4, 24, 1, 0, tzinfo=timezone.utc),
+        "pivot_point": 100.0,
+        "support_1": 90.0,
+        "support_2": 80.0,
+        "support_3": 70.0,
+        "resistance_1": 110.0,
+        "resistance_2": 120.0,
+        "resistance_3": 130.0,
+    }
+
+    monkeypatch.setattr(
+        MarketIndicatorService,
+        "_fetch_latest_rows",
+        lambda self, symbol, timeframe, limit: [expected_row],
+    )
+
+    rows = MarketIndicatorService().get_time_series("btcusdt", "1h", 1)
+
+    assert rows == [expected_row]
+    for column in PIVOT_COLUMNS:
+        assert column in rows[0]

--- a/backend/tests/unit/test_market_indicator_tradingview_fixtures.py
+++ b/backend/tests/unit/test_market_indicator_tradingview_fixtures.py
@@ -364,9 +364,15 @@ def test_advanced_market_indicator_upsert_serializes_nullable_values_and_conflic
     assert "bb_upper_20_2 = EXCLUDED.bb_upper_20_2" in fake_engine.conn.statement
     assert "ichimoku_chikou_26 = EXCLUDED.ichimoku_chikou_26" in fake_engine.conn.statement
     assert "chart_patterns = EXCLUDED.chart_patterns" in fake_engine.conn.statement
+    assert "pivot_point = EXCLUDED.pivot_point" in fake_engine.conn.statement
+    assert "support_3 = EXCLUDED.support_3" in fake_engine.conn.statement
+    assert "resistance_3 = EXCLUDED.resistance_3" in fake_engine.conn.statement
     assert fake_engine.conn.params[0]["bb_upper_20_2"] is None
     assert fake_engine.conn.params[0]["atr_14"] is None
     assert fake_engine.conn.params[0]["ichimoku_tenkan_9"] is None
     assert fake_engine.conn.params[0]["obv"] == 42000.0
+    assert fake_engine.conn.params[0]["pivot_point"] is None
+    assert fake_engine.conn.params[0]["support_1"] is None
+    assert fake_engine.conn.params[0]["resistance_1"] is None
     assert '"pattern": "golden_cross"' in fake_engine.conn.params[0]["chart_patterns"]
     assert fake_engine.conn.params[0]["is_recomputed"] is True

--- a/openspec/changes/calculate-pivot-support-resistance/.openspec.yaml
+++ b/openspec/changes/calculate-pivot-support-resistance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/calculate-pivot-support-resistance/design.md
+++ b/openspec/changes/calculate-pivot-support-resistance/design.md
@@ -1,0 +1,62 @@
+## Context
+
+O projeto já possui o pipeline `MarketIndicatorService`, que lê `market_ohlcv`, calcula indicadores por `symbol`/`timeframe` e persiste em `market_indicator` com unicidade `(symbol, timeframe, ts)`. Essa trilha já é incremental, idempotente e consumida por scoring/monitor.
+
+Suporte/resistência por pivot deve seguir a mesma trilha para evitar cálculo no frontend ou em consumidores de scoring. Como pivot clássico depende do OHLC do candle anterior do mesmo timeframe, os níveis são naturalmente atualizados a cada candle/timeframe processado.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Calcular pivot clássico, S1-S3 e R1-R3 por candle processado.
+- Usar exclusivamente OHLC do candle anterior do mesmo `symbol`/`timeframe`.
+- Persistir níveis como colunas numéricas nullable em `market_indicator`.
+- Manter primeiro candle como nulo por falta de candle anterior.
+- Incluir níveis nas leituras `get_latest` e `get_time_series`.
+
+**Non-Goals:**
+
+- Implementar variações Fibonacci, Camarilla, Woodie ou DeMark.
+- Criar UI nova para desenhar níveis no gráfico.
+- Alterar scoring ou lógica de entrada/saída.
+- Criar alertas quando preço toca suporte/resistência.
+
+## Decisions
+
+### Decision: Usar pivot clássico
+
+Fórmulas:
+
+- `P = (Hprev + Lprev + Cprev) / 3`
+- `R1 = (2 * P) - Lprev`
+- `S1 = (2 * P) - Hprev`
+- `R2 = P + (Hprev - Lprev)`
+- `S2 = P - (Hprev - Lprev)`
+- `R3 = Hprev + 2 * (P - Lprev)`
+- `S3 = Lprev - 2 * (Hprev - P)`
+
+Alternativa considerada: pivot Fibonacci. Rejeitada porque o DoD pede algoritmo de pivot points e níveis S1-S3/R1-R3 sem especificar variante; clássico é o padrão mais simples e auditável.
+
+### Decision: Persistir em colunas explícitas
+
+Os níveis são estáveis e usados em consultas/scoring, então colunas numéricas explícitas são melhores que JSONB para legibilidade, filtros e validação.
+
+### Decision: Integrar ao pipeline de indicadores
+
+O cálculo entra em `_compute_indicators` junto aos demais valores derivados de OHLCV. Isso preserva incrementalidade, idempotência e atualização por timeframe sem criar job novo.
+
+## Risks / Trade-offs
+
+- [Risk] O primeiro candle de cada janela incremental pode perder contexto do candle anterior se a janela começar depois do histórico real. -> Mitigation: a janela incremental já recua `LOOKBACK_BARS`, dando contexto suficiente para recalcular o trecho recente; primeiro registro da janela pode ficar nulo, mas registros seguintes usam o candle anterior da janela.
+- [Risk] Usuários podem esperar variações diferentes de pivot. -> Mitigation: documentar explicitamente que esta entrega usa pivot clássico.
+- [Risk] Adicionar colunas aumenta largura da tabela. -> Mitigation: o conjunto é fixo e pequeno.
+
+## Migration Plan
+
+1. Adicionar colunas nullable em `market_indicator` via Alembic e schema guard.
+2. Calcular pivot/S/R em `_compute_indicators` com `shift(1)`.
+3. Incluir colunas no select e upsert.
+4. Adicionar testes de fórmula, warmup e serialização.
+5. Recompute/backfill operacional para preencher históricos existentes.
+
+Rollback: as colunas são nullable; rollback pode removê-las via Alembic sem afetar indicadores existentes.

--- a/openspec/changes/calculate-pivot-support-resistance/proposal.md
+++ b/openspec/changes/calculate-pivot-support-resistance/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+O monitor/scoring precisa de níveis técnicos objetivos de suporte e resistência para cada timeframe, sem depender de cálculo manual ou lógica duplicada no frontend. Pivot points clássicos oferecem níveis S1-S3 e R1-R3 determinísticos a partir do candle anterior de cada timeframe.
+
+## What Changes
+
+- Calcular pivot point clássico por `symbol`/`timeframe` usando OHLC do candle anterior.
+- Persistir por candle os níveis:
+  - `pivot_point`
+  - `support_1`, `support_2`, `support_3`
+  - `resistance_1`, `resistance_2`, `resistance_3`
+- Atualizar os níveis sempre que o pipeline de indicadores processar candles do timeframe correspondente.
+- Manter warmup nulo para o primeiro candle sem candle anterior.
+- Expor os níveis nas leituras existentes de indicadores para scoring/monitor.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `market-indicators`: Expande o pipeline dedicado de indicadores para calcular, persistir e retornar níveis dinâmicos de suporte/resistência por pivot points em cada timeframe.
+
+## Impact
+
+- Backend: `MarketIndicatorService` passa a calcular e persistir níveis S1-S3/R1-R3.
+- Banco de dados: novos campos numéricos nullable em `market_indicator`.
+- API: leituras de indicadores retornam os níveis de suporte/resistência junto aos demais indicadores.
+- Testes: cobertura unitária para fórmula clássica, warmup nulo, upsert/read shape e atualização por timeframe.

--- a/openspec/changes/calculate-pivot-support-resistance/specs/market-indicators/spec.md
+++ b/openspec/changes/calculate-pivot-support-resistance/specs/market-indicators/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Sistema calcula suporte e resistência por pivot clássico
+The market indicator pipeline SHALL calculate classic pivot point support and resistance levels for each processed `symbol`/`timeframe` candle.
+
+#### Scenario: Níveis S1-S3 e R1-R3 calculados
+- **WHEN** the market indicator pipeline processes a candle with a previous candle in the same timeframe
+- **THEN** it SHALL calculate `pivot_point`, `support_1`, `support_2`, `support_3`, `resistance_1`, `resistance_2`, and `resistance_3` from the previous candle OHLC values.
+
+### Requirement: Primeiro candle sem contexto mantém níveis nulos
+The market indicator pipeline SHALL keep pivot support/resistance values null when no previous candle is available.
+
+#### Scenario: Warmup sem candle anterior
+- **WHEN** the first candle in a processed series has no previous candle
+- **THEN** all pivot support/resistance fields for that row SHALL be null.
+
+### Requirement: Níveis são persistidos e retornados por timeframe
+The system SHALL persist and return pivot support/resistance levels in the dedicated market indicator store.
+
+#### Scenario: Leitura de indicadores inclui suporte/resistência
+- **WHEN** `get_latest` or `get_time_series` reads market indicator rows for a symbol/timeframe
+- **THEN** the returned rows SHALL include `pivot_point`, `support_1`, `support_2`, `support_3`, `resistance_1`, `resistance_2`, and `resistance_3`.
+
+#### Scenario: Atualização por timeframe processado
+- **WHEN** indicator recompute runs for a specific timeframe
+- **THEN** pivot support/resistance levels SHALL be updated for candles in that timeframe without requiring other timeframes to run.

--- a/openspec/changes/calculate-pivot-support-resistance/tasks.md
+++ b/openspec/changes/calculate-pivot-support-resistance/tasks.md
@@ -1,0 +1,24 @@
+## 1. OpenSpec And Contract
+
+- [x] 1.1 Create proposal, design, and spec for dynamic support/resistance pivot levels.
+- [x] 1.2 Define classic pivot formulas and persisted field names.
+
+## 2. Storage And Read Path
+
+- [x] 2.1 Add nullable numeric storage for `pivot_point`, S1-S3, and R1-R3 in `market_indicator`.
+- [x] 2.2 Add Alembic migration and startup schema guard.
+- [x] 2.3 Include pivot support/resistance fields in latest/time-series read queries.
+- [x] 2.4 Serialize pivot support/resistance fields during indicator upsert.
+
+## 3. Calculation Pipeline
+
+- [x] 3.1 Implement classic pivot point calculation from previous candle OHLC.
+- [x] 3.2 Preserve null warmup values for rows without previous candle context.
+- [x] 3.3 Integrate calculation into `MarketIndicatorService._compute_indicators` for every processed timeframe.
+- [x] 3.4 Document pivot formula metadata in `source_window`.
+
+## 4. Validation
+
+- [x] 4.1 Add unit tests for classic pivot formulas and warmup nulls.
+- [x] 4.2 Add tests for market indicator upsert/read shape.
+- [x] 4.3 Run targeted backend tests for market indicators.


### PR DESCRIPTION
## Resumo

- Implementa níveis dinâmicos de suporte/resistência por pivot point clássico no pipeline de indicadores.
- Persiste pivot_point, support_1..3 e resistance_1..3 em market_indicator.
- Atualiza leitura latest/time-series e upsert para incluir os novos campos.
- Adiciona migration Alembic e schema guard de runtime.
- Registra change OpenSpec calculate-pivot-support-resistance com proposal/design/spec/tasks completos.

## Fórmula

- P = (Hprev + Lprev + Cprev) / 3
- R1 = 2P - Lprev; S1 = 2P - Hprev
- R2 = P + (Hprev - Lprev); S2 = P - (Hprev - Lprev)
- R3 = Hprev + 2(P - Lprev); S3 = Lprev - 2(Hprev - P)

## Evidências

- openspec validate calculate-pivot-support-resistance --strict
- ./backend/.venv/bin/python -m black --check backend/app/database.py backend/app/services/market_indicator_service.py backend/alembic/versions/20260424_0002_add_pivot_levels_to_market_indicator.py backend/tests/unit/test_market_indicator_pivot_levels.py backend/tests/unit/test_market_indicator_tradingview_fixtures.py
- ./backend/.venv/bin/python -m pytest backend/tests/unit/test_market_indicator_pivot_levels.py backend/tests/unit/test_market_indicator_tradingview_fixtures.py backend/tests/unit/test_market_indicator_advanced_consumption.py backend/tests/unit/test_main_and_market_routes.py backend/tests/unit/test_api_coverage.py -q

## OpenSpec

- Change: openspec/changes/calculate-pivot-support-resistance/
- Tasks: 13/13 concluídas

## Subagents

- explorer: mapeou integração no pipeline de indicadores.
- worker: criou testes focados.
- reviewer: encontrou problemas em migration/contexto incremental; ambos corrigidos antes do PR.