### PR TITLE
fix: corrigir migration de chart patterns

### DIFF
--- a/backend/alembic/versions/20260424_0001_add_chart_patterns_to_market_indicator.py
+++ b/backend/alembic/versions/20260424_0001_add_chart_patterns_to_market_indicator.py
@@ -21,7 +21,8 @@ def upgrade() -> None:
         BEGIN
             IF to_regclass('public.market_indicator') IS NOT NULL THEN
                 ALTER TABLE market_indicator ADD COLUMN IF NOT EXISTS chart_patterns JSONB;
-            END $$;
+            END IF;
+        END $$;
         """)
 
 
@@ -31,5 +32,6 @@ def downgrade() -> None:
         BEGIN
             IF to_regclass('public.market_indicator') IS NOT NULL THEN
                 ALTER TABLE market_indicator DROP COLUMN IF EXISTS chart_patterns;
-            END $$;
+            END IF;
+        END $$;
         """)


### PR DESCRIPTION
## Resumo

- Corrige a migration `20260424_0001_add_chart_patterns_to_market_indicator.py`.
- Adiciona `END IF;` nos blocos `DO $$` de upgrade/downgrade.
- Resolve o erro de startup: `psycopg2.errors.SyntaxError: syntax error at end of input`.

## Evidências

- `./backend/.venv/bin/python -m py_compile backend/alembic/versions/20260424_0001_add_chart_patterns_to_market_indicator.py backend/alembic/versions/20260424_0002_add_pivot_levels_to_market_indicator.py`
- `./backend/.venv/bin/python -m black --check backend/alembic/versions/20260424_0001_add_chart_patterns_to_market_indicator.py backend/alembic/versions/20260424_0002_add_pivot_levels_to_market_indicator.py`
- `cd backend && ../backend/.venv/bin/alembic upgrade head`

## Impacto

- Corrige migração bloqueante antes da aplicação subir.
- Não altera modelos ou lógica de runtime.