### PR TITLE
feat: normalize indicator scores

### DIFF
--- a/backend/app/routes/admin_market_indicators.py
+++ b/backend/app/routes/admin_market_indicators.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from app.middleware.authMiddleware import get_current_admin
+from app.services.indicator_score_service import get_indicator_score_service
 from app.services.market_indicator_service import get_market_indicator_service
 
 router = APIRouter(prefix="/api/admin/indicators", tags=["admin-indicators"])
@@ -39,6 +40,26 @@ class IndicatorRecomputeJobResponse(BaseModel):
     finished_at: str | None
     current_timeframe: str | None
     error: str | None = None
+
+
+class IndicatorScoreItem(BaseModel):
+    name: str
+    score: float = Field(ge=0, le=10)
+    rule_version: str
+    rule_type: str
+    inputs: dict[str, float]
+
+
+class IndicatorScoreRow(BaseModel):
+    symbol: str | None
+    timeframe: str | None
+    ts: Any | None
+    rule_version: str
+    scores: list[IndicatorScoreItem]
+
+
+class IndicatorScoresResponse(BaseModel):
+    items: list[IndicatorScoreRow]
 
 
 def _serialize_job(job: dict[str, Any]) -> IndicatorRecomputeJobResponse:
@@ -125,3 +146,23 @@ def get_latest_indicators(
             detail="No indicators found for symbol/timeframe",
         )
     return {"items": rows}
+
+
+@router.get("/latest/scores", response_model=IndicatorScoresResponse)
+def get_latest_indicator_scores(
+    symbol: str = Query(..., min_length=1),
+    timeframe: str = Query(..., min_length=1),
+    limit: int = Query(default=1, ge=1, le=200),
+    _admin_user_id: str = Depends(get_current_admin),
+):
+    _ = _admin_user_id
+    rows = get_market_indicator_service().get_latest(
+        symbol=symbol, timeframe=timeframe, limit=limit
+    )
+    if not rows:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No indicators found for symbol/timeframe",
+        )
+
+    return IndicatorScoresResponse(items=get_indicator_score_service().score_rows(rows))

--- a/backend/app/services/indicator_score_service.py
+++ b/backend/app/services/indicator_score_service.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RULESET_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "indicator_score_rules.v1.json"
+)
+
+
+@dataclass(frozen=True)
+class IndicatorScore:
+    name: str
+    score: float
+    rule_version: str
+    rule_type: str
+    inputs: dict[str, float]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "score": self.score,
+            "rule_version": self.rule_version,
+            "rule_type": self.rule_type,
+            "inputs": dict(self.inputs),
+        }
+
+
+def _clamp_score(value: float) -> float:
+    return round(max(0.0, min(10.0, float(value))), 4)
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _polarity(rule: dict[str, Any]) -> float:
+    return -1.0 if str(rule.get("polarity") or "normal").lower() == "inverse" else 1.0
+
+
+def _linear_score(value: float, low: float, high: float, polarity: float) -> float | None:
+    if high == low:
+        return None
+    normalized = (value - low) / (high - low)
+    if polarity < 0:
+        normalized = 1.0 - normalized
+    return _clamp_score(normalized * 10.0)
+
+
+def _required_inputs(row: dict[str, Any], rule: dict[str, Any]) -> dict[str, float] | None:
+    raw_inputs = rule.get("inputs")
+    if not isinstance(raw_inputs, dict) or not raw_inputs:
+        return None
+
+    values: dict[str, float] = {}
+    for input_name, column in raw_inputs.items():
+        parsed = _float_or_none(row.get(str(column)))
+        if parsed is None:
+            return None
+        values[str(input_name)] = parsed
+    return values
+
+
+def load_indicator_score_rules(path: str | Path | None = None) -> dict[str, Any]:
+    configured_path = path or os.getenv("INDICATOR_SCORE_RULES_PATH") or DEFAULT_RULESET_PATH
+    ruleset_path = Path(configured_path)
+    with ruleset_path.open("r", encoding="utf-8") as fh:
+        ruleset = json.load(fh)
+
+    version = str(ruleset.get("version") or "").strip()
+    rules = ruleset.get("indicators")
+    if not version:
+        raise ValueError("indicator score ruleset must define a non-empty version")
+    if not isinstance(rules, list) or not rules:
+        raise ValueError("indicator score ruleset must define a non-empty indicators list")
+
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            raise ValueError(f"indicator score rule #{index} must be an object")
+        if not str(rule.get("name") or "").strip():
+            raise ValueError(f"indicator score rule #{index} must define name")
+        if not str(rule.get("type") or "").strip():
+            raise ValueError(f"indicator score rule {rule.get('name')} must define type")
+        if not isinstance(rule.get("inputs"), dict) or not rule["inputs"]:
+            raise ValueError(f"indicator score rule {rule.get('name')} must define inputs")
+
+    return ruleset
+
+
+class IndicatorScoreService:
+    def __init__(self, ruleset: dict[str, Any] | None = None) -> None:
+        self.ruleset = ruleset or load_indicator_score_rules()
+        self.version = str(self.ruleset["version"])
+        self.rules = list(self.ruleset["indicators"])
+
+    def score_row(self, row: dict[str, Any]) -> list[IndicatorScore]:
+        scores: list[IndicatorScore] = []
+        for rule in self.rules:
+            inputs = _required_inputs(row, rule)
+            if inputs is None:
+                continue
+
+            value = self._score_rule(rule, inputs)
+            if value is None:
+                continue
+
+            scores.append(
+                IndicatorScore(
+                    name=str(rule["name"]),
+                    score=value,
+                    rule_version=self.version,
+                    rule_type=str(rule["type"]),
+                    inputs=inputs,
+                )
+            )
+        return scores
+
+    def score_row_as_dicts(self, row: dict[str, Any]) -> list[dict[str, Any]]:
+        return [score.as_dict() for score in self.score_row(row)]
+
+    def score_rows(self, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        scored_rows: list[dict[str, Any]] = []
+        for row in rows:
+            scored_rows.append(
+                {
+                    "symbol": row.get("symbol"),
+                    "timeframe": row.get("timeframe"),
+                    "ts": row.get("ts"),
+                    "rule_version": self.version,
+                    "scores": self.score_row_as_dicts(row),
+                }
+            )
+        return scored_rows
+
+    def _score_rule(self, rule: dict[str, Any], inputs: dict[str, float]) -> float | None:
+        rule_type = str(rule.get("type") or "").lower()
+        polarity = _polarity(rule)
+
+        if rule_type == "linear":
+            low = _float_or_none(rule.get("min"))
+            high = _float_or_none(rule.get("max"))
+            if low is None or high is None:
+                return None
+            return _linear_score(inputs["value"], low, high, polarity)
+
+        if rule_type == "centered_tanh":
+            center = _float_or_none(rule.get("center")) or 0.0
+            scale = _float_or_none(rule.get("scale"))
+            if scale is None or scale <= 0:
+                return None
+            distance = (inputs["value"] - center) / scale
+            return _clamp_score(5.0 + (math.tanh(distance) * 5.0 * polarity))
+
+        if rule_type == "crossover":
+            slow = inputs["slow"]
+            if slow == 0:
+                return None
+            percent_scale = _float_or_none(rule.get("percent_scale")) or 1.0
+            if percent_scale <= 0:
+                return None
+            delta_percent = ((inputs["fast"] - slow) / abs(slow)) * 100.0
+            return _clamp_score(5.0 + (math.tanh(delta_percent / percent_scale) * 5.0))
+
+        if rule_type == "band_width":
+            middle = inputs["middle"]
+            if middle == 0:
+                return None
+            width_percent = ((inputs["upper"] - inputs["lower"]) / abs(middle)) * 100.0
+            low = _float_or_none(rule.get("min_percent"))
+            high = _float_or_none(rule.get("max_percent"))
+            if low is None or high is None:
+                return None
+            return _linear_score(width_percent, low, high, polarity)
+
+        if rule_type == "ratio_linear":
+            denominator = inputs["denominator"]
+            if denominator == 0:
+                return None
+            ratio_percent = (inputs["numerator"] / abs(denominator)) * 100.0
+            low = _float_or_none(rule.get("min_percent"))
+            high = _float_or_none(rule.get("max_percent"))
+            if low is None or high is None:
+                return None
+            return _linear_score(ratio_percent, low, high, polarity)
+
+        if rule_type == "range_width":
+            center = inputs["center"]
+            if center == 0:
+                return None
+            width_percent = ((inputs["upper"] - inputs["lower"]) / abs(center)) * 100.0
+            low = _float_or_none(rule.get("min_percent"))
+            high = _float_or_none(rule.get("max_percent"))
+            if low is None or high is None:
+                return None
+            return _linear_score(width_percent, low, high, polarity)
+
+        return None
+
+
+@lru_cache()
+def get_indicator_score_service() -> IndicatorScoreService:
+    return IndicatorScoreService()

--- a/backend/config/indicator_score_rules.v1.json
+++ b/backend/config/indicator_score_rules.v1.json
@@ -1,0 +1,80 @@
+{
+  "version": "technical-normalization/v1",
+  "description": "Default normalized 0-10 technical indicator scores for the composite engine.",
+  "indicators": [
+    {
+      "name": "ema_trend",
+      "type": "crossover",
+      "inputs": {"fast": "ema_9", "slow": "ema_21"},
+      "percent_scale": 2.0
+    },
+    {
+      "name": "sma_trend",
+      "type": "crossover",
+      "inputs": {"fast": "sma_20", "slow": "sma_50"},
+      "percent_scale": 3.0
+    },
+    {
+      "name": "rsi_14",
+      "type": "linear",
+      "inputs": {"value": "rsi_14"},
+      "min": 30.0,
+      "max": 70.0,
+      "polarity": "inverse"
+    },
+    {
+      "name": "macd_histogram",
+      "type": "centered_tanh",
+      "inputs": {"value": "macd_histogram"},
+      "center": 0.0,
+      "scale": 1.0,
+      "polarity": "normal"
+    },
+    {
+      "name": "bollinger_width",
+      "type": "band_width",
+      "inputs": {
+        "upper": "bb_upper_20_2",
+        "middle": "bb_middle_20_2",
+        "lower": "bb_lower_20_2"
+      },
+      "min_percent": 2.0,
+      "max_percent": 12.0,
+      "polarity": "inverse"
+    },
+    {
+      "name": "atr_14",
+      "type": "ratio_linear",
+      "inputs": {"numerator": "atr_14", "denominator": "bb_middle_20_2"},
+      "min_percent": 0.5,
+      "max_percent": 6.0,
+      "polarity": "inverse"
+    },
+    {
+      "name": "stochastic",
+      "type": "linear",
+      "inputs": {"value": "stoch_k_14_3_3"},
+      "min": 20.0,
+      "max": 80.0,
+      "polarity": "inverse"
+    },
+    {
+      "name": "ichimoku_trend",
+      "type": "crossover",
+      "inputs": {"fast": "ichimoku_tenkan_9", "slow": "ichimoku_kijun_26"},
+      "percent_scale": 2.0
+    },
+    {
+      "name": "pivot_range",
+      "type": "range_width",
+      "inputs": {
+        "upper": "resistance_1",
+        "center": "pivot_point",
+        "lower": "support_1"
+      },
+      "min_percent": 0.5,
+      "max_percent": 8.0,
+      "polarity": "inverse"
+    }
+  ]
+}

--- a/backend/scripts/benchmark_indicator_score_service.py
+++ b/backend/scripts/benchmark_indicator_score_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app.services.indicator_score_service import IndicatorScoreService
+
+
+def _sample_row(index: int) -> dict[str, float | str]:
+    close = 100.0 + (index % 17)
+    return {
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "ema_9": close * 1.01,
+        "ema_21": close,
+        "sma_20": close * 1.005,
+        "sma_50": close,
+        "rsi_14": 35.0 + (index % 30),
+        "macd_histogram": -1.0 + ((index % 200) / 100.0),
+        "bb_upper_20_2": close * 1.04,
+        "bb_middle_20_2": close,
+        "bb_lower_20_2": close * 0.96,
+        "atr_14": close * 0.018,
+        "stoch_k_14_3_3": 25.0 + (index % 55),
+        "ichimoku_tenkan_9": close * 1.006,
+        "ichimoku_kijun_26": close,
+        "pivot_point": close,
+        "support_1": close * 0.98,
+        "resistance_1": close * 1.02,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark indicator score normalization.")
+    parser.add_argument("--rows", type=int, default=10000)
+    args = parser.parse_args()
+
+    rows = [_sample_row(index) for index in range(args.rows)]
+    service = IndicatorScoreService()
+
+    started = time.perf_counter()
+    scored = service.score_rows(rows)
+    elapsed = time.perf_counter() - started
+    score_count = sum(len(row["scores"]) for row in scored)
+    rows_per_second = args.rows / elapsed if elapsed else float("inf")
+
+    print(f"ruleset_version={service.version}")
+    print(f"rows={args.rows}")
+    print(f"scores={score_count}")
+    print(f"elapsed_ms={elapsed * 1000:.3f}")
+    print(f"rows_per_second={rows_per_second:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_indicator_score_service.py
+++ b/backend/tests/unit/test_indicator_score_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+
+from app.services.indicator_score_service import (
+    IndicatorScoreService,
+    load_indicator_score_rules,
+)
+
+
+def _complete_indicator_row() -> dict[str, float | str]:
+    return {
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "ts": "2026-04-24T00:00:00Z",
+        "ema_9": 102.0,
+        "ema_21": 100.0,
+        "sma_20": 101.0,
+        "sma_50": 100.0,
+        "rsi_14": 45.0,
+        "macd_histogram": 0.5,
+        "bb_upper_20_2": 106.0,
+        "bb_middle_20_2": 100.0,
+        "bb_lower_20_2": 94.0,
+        "atr_14": 2.0,
+        "stoch_k_14_3_3": 40.0,
+        "ichimoku_tenkan_9": 101.5,
+        "ichimoku_kijun_26": 100.0,
+        "pivot_point": 100.0,
+        "support_1": 98.0,
+        "resistance_1": 102.0,
+    }
+
+
+def test_default_indicator_scores_are_bounded_and_versioned() -> None:
+    service = IndicatorScoreService()
+
+    scores = service.score_row_as_dicts(_complete_indicator_row())
+
+    assert len(scores) == 9
+    assert {score["rule_version"] for score in scores} == {"technical-normalization/v1"}
+    assert all(0.0 <= score["score"] <= 10.0 for score in scores)
+    assert {score["name"] for score in scores} >= {
+        "ema_trend",
+        "rsi_14",
+        "macd_histogram",
+        "pivot_range",
+    }
+
+
+def test_missing_or_null_inputs_skip_only_the_affected_score() -> None:
+    service = IndicatorScoreService()
+    row = _complete_indicator_row()
+    row["rsi_14"] = None
+
+    scores = service.score_row_as_dicts(row)
+
+    assert "rsi_14" not in {score["name"] for score in scores}
+    assert "ema_trend" in {score["name"] for score in scores}
+    assert all(0.0 <= score["score"] <= 10.0 for score in scores)
+
+
+def test_override_ruleset_preserves_configured_version(tmp_path) -> None:
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text(
+        json.dumps(
+            {
+                "version": "test-rules/v2",
+                "indicators": [
+                    {
+                        "name": "custom_rsi",
+                        "type": "linear",
+                        "inputs": {"value": "rsi_14"},
+                        "min": 0,
+                        "max": 100,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    ruleset = load_indicator_score_rules(rules_path)
+    service = IndicatorScoreService(ruleset=ruleset)
+
+    scores = service.score_row_as_dicts(_complete_indicator_row())
+
+    assert scores == [
+        {
+            "name": "custom_rsi",
+            "score": 4.5,
+            "rule_version": "test-rules/v2",
+            "rule_type": "linear",
+            "inputs": {"value": 45.0},
+        }
+    ]
+
+
+def test_admin_latest_scores_endpoint_uses_persisted_indicator_rows(monkeypatch) -> None:
+    from app.routes import admin_market_indicators as route
+
+    class FakeMarketIndicatorService:
+        def get_latest(self, symbol: str, timeframe: str, limit: int):
+            assert symbol == "BTCUSDT"
+            assert timeframe == "1h"
+            assert limit == 1
+            return [_complete_indicator_row()]
+
+    monkeypatch.setattr(route, "get_market_indicator_service", lambda: FakeMarketIndicatorService())
+    monkeypatch.setattr(route, "get_indicator_score_service", lambda: IndicatorScoreService())
+
+    response = route.get_latest_indicator_scores(
+        symbol="BTCUSDT",
+        timeframe="1h",
+        limit=1,
+        _admin_user_id="admin",
+    )
+
+    assert response.items[0].rule_version == "technical-normalization/v1"
+    assert len(response.items[0].scores) == 9
+    assert all(0.0 <= score.score <= 10.0 for score in response.items[0].scores)

--- a/openspec/changes/normalize-indicator-scores/.openspec.yaml
+++ b/openspec/changes/normalize-indicator-scores/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/normalize-indicator-scores/benchmark.md
+++ b/openspec/changes/normalize-indicator-scores/benchmark.md
@@ -1,0 +1,35 @@
+## Indicator Score Normalization Benchmark
+
+### Goal
+
+Measure the overhead of converting persisted `market_indicator` rows into normalized `0-10` scores for the composite engine.
+
+### Command
+
+```bash
+cd backend
+../backend/.venv/bin/python scripts/benchmark_indicator_score_service.py --rows 10000
+```
+
+### Method
+
+- Builds synthetic rows containing all fields used by the default ruleset.
+- Loads `backend/config/indicator_score_rules.v1.json`.
+- Runs `IndicatorScoreService.score_rows`.
+- Reports elapsed milliseconds, rows per second, generated score count, and ruleset version.
+
+### Current Result
+
+On the VPS/dev runtime, the default service produced this result for 10,000 rows:
+
+```text
+ruleset_version=technical-normalization/v1
+rows=10000
+scores=90000
+elapsed_ms=897.310
+rows_per_second=11144.42
+```
+
+### Acceptance Benchmark
+
+The normalizer is an in-memory transformation with no database or network calls. For 10,000 rows on the VPS/dev runtime, expected throughput is at least 10,000 rows/second. This threshold is intentionally documented instead of enforced in CI to avoid noisy timing failures on shared runners.

--- a/openspec/changes/normalize-indicator-scores/design.md
+++ b/openspec/changes/normalize-indicator-scores/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`market_indicator` já é a fonte dedicada de indicadores técnicos. A nova camada não deve recalcular EMA, SMA, RSI, MACD ou indicadores avançados; ela apenas interpreta os valores persistidos com regras declarativas.
+
+## Decisions
+
+### Ruleset JSON versionado
+
+As regras ficam em `backend/config/indicator_score_rules.v1.json` e possuem:
+
+- `version`: identificador estável do ruleset.
+- `indicators`: lista de regras nomeadas.
+- `type`: algoritmo de normalização.
+- `inputs`: colunas de `market_indicator` consumidas.
+
+O caminho pode ser sobrescrito com `INDICATOR_SCORE_RULES_PATH`, permitindo benchmark, QA ou rollout controlado sem alterar código.
+
+### Score contract
+
+Cada score retornado inclui:
+
+- `name`
+- `score` entre `0.0` e `10.0`
+- `rule_version`
+- `rule_type`
+- `inputs`
+
+Campos ausentes, nulos ou inválidos não geram score, preservando warmup dos indicadores.
+
+### Rule types
+
+- `linear`: normaliza um valor entre `min` e `max`.
+- `centered_tanh`: normaliza distância de um centro com `tanh`, útil para histogramas.
+- `crossover`: compara indicador rápido/lento em diferença percentual.
+- `band_width`: pontua largura relativa de bandas.
+- `ratio_linear`: pontua razão entre dois campos.
+- `range_width`: pontua largura relativa entre suporte/resistência e pivô.
+
+## Benchmark
+
+O benchmark é scriptado em `backend/scripts/benchmark_indicator_score_service.py` e documentado em `benchmark.md`. Ele mede normalização em memória sobre linhas sintéticas com todos os campos usados pelo ruleset padrão.

--- a/openspec/changes/normalize-indicator-scores/proposal.md
+++ b/openspec/changes/normalize-indicator-scores/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+O engine composto precisa consumir indicadores técnicos em uma escala comum. Hoje cada indicador possui unidade, direção e faixa própria, o que dificulta composição, peso e comparação entre sinais.
+
+## What Changes
+
+- Adicionar um serviço backend que converte indicadores persistidos em `market_indicator` para scores normalizados `0-10`.
+- Carregar regras configuráveis por indicador a partir de arquivo JSON versionado.
+- Propagar a versão do ruleset em cada score calculado.
+- Documentar o benchmark e fornecer script reproduzível para medir throughput do normalizador.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `market-indicators`: Expande a interface de scoring para oferecer scores técnicos normalizados e versionados a partir dos indicadores persistidos.
+
+## Impact
+
+- Backend: novo serviço de scoring técnico normalizado.
+- Configuração: ruleset JSON versionado com override por variável de ambiente.
+- Testes: cobertura unitária para limites `0-10`, regras configuráveis, campos ausentes e versionamento.
+- Operação: benchmark documentado em `openspec/changes/normalize-indicator-scores/benchmark.md`.

--- a/openspec/changes/normalize-indicator-scores/score-rules.md
+++ b/openspec/changes/normalize-indicator-scores/score-rules.md
@@ -1,0 +1,29 @@
+## Indicator Score Rules v1
+
+Ruleset: `technical-normalization/v1`
+
+Location: `backend/config/indicator_score_rules.v1.json`
+
+Override: `INDICATOR_SCORE_RULES_PATH=/path/to/rules.json`
+
+## Contract
+
+- Scores are floating point values clamped to `0-10`.
+- Each emitted score includes `rule_version`.
+- Missing, null, `NaN`, or non-finite inputs are skipped instead of converted to `0`.
+- The scoring layer consumes persisted `market_indicator` rows and does not recalculate raw indicators.
+- Scores are calculated on demand in this change; if scores are persisted later, storage must include `rule_version` in the key or metadata so historical meaning is not overwritten.
+
+## Default Rules
+
+| Score | Inputs | Rule | Direction |
+| --- | --- | --- | --- |
+| `ema_trend` | `ema_9`, `ema_21` | Fast/slow crossover, percent delta through `tanh` | Fast above slow increases score |
+| `sma_trend` | `sma_20`, `sma_50` | Fast/slow crossover, percent delta through `tanh` | Fast above slow increases score |
+| `rsi_14` | `rsi_14` | Linear 30-70, inverse | Lower RSI increases score |
+| `macd_histogram` | `macd_histogram` | Centered `tanh` around zero | Positive histogram increases score |
+| `bollinger_width` | `bb_upper_20_2`, `bb_middle_20_2`, `bb_lower_20_2` | Relative band width, inverse | Narrower bands increase score |
+| `atr_14` | `atr_14`, `bb_middle_20_2` | ATR as percent of middle band, inverse | Lower volatility increases score |
+| `stochastic` | `stoch_k_14_3_3` | Linear 20-80, inverse | Lower stochastic increases score |
+| `ichimoku_trend` | `ichimoku_tenkan_9`, `ichimoku_kijun_26` | Tenkan/kijun crossover | Tenkan above kijun increases score |
+| `pivot_range` | `resistance_1`, `pivot_point`, `support_1` | Relative S1/R1 width, inverse | Tighter range increases score |

--- a/openspec/changes/normalize-indicator-scores/specs/market-indicators/spec.md
+++ b/openspec/changes/normalize-indicator-scores/specs/market-indicators/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Indicadores possuem score normalizado para engine composto
+The scoring subsystem SHALL convert persisted technical indicator values into normalized scores from `0` to `10`.
+
+#### Scenario: Score tecnico dentro da faixa contratada
+- **GIVEN** a persisted `market_indicator` row with all inputs required by the active ruleset
+- **WHEN** the indicator scoring service scores the row
+- **THEN** every emitted indicator score SHALL be greater than or equal to `0`
+- **AND** less than or equal to `10`.
+
+### Requirement: Regras de score sao configuraveis por indicador
+The indicator scoring subsystem SHALL load per-indicator scoring rules from configuration.
+
+#### Scenario: Ruleset padrao carregado
+- **WHEN** the scoring service starts without an override path
+- **THEN** it SHALL load the default versioned JSON ruleset from backend configuration.
+
+#### Scenario: Ruleset alternativo carregado
+- **GIVEN** `INDICATOR_SCORE_RULES_PATH` points to a valid ruleset JSON file
+- **WHEN** the scoring service loads rules
+- **THEN** it SHALL use that file instead of the default ruleset.
+
+### Requirement: Scores carregam versao das regras
+The indicator scoring subsystem SHALL include the active scoring ruleset version in each emitted score.
+
+#### Scenario: Versao propagada no resultado
+- **GIVEN** an active ruleset with version `technical-normalization/v1`
+- **WHEN** the scoring service emits indicator scores
+- **THEN** each score SHALL include `rule_version` equal to `technical-normalization/v1`.
+
+### Requirement: Benchmark de normalizacao documentado
+The system SHALL document how to benchmark indicator score normalization.
+
+#### Scenario: Benchmark reproduzivel
+- **WHEN** an engineer needs to measure normalization throughput
+- **THEN** the OpenSpec change SHALL document the benchmark command, method, and acceptance target.

--- a/openspec/changes/normalize-indicator-scores/tasks.md
+++ b/openspec/changes/normalize-indicator-scores/tasks.md
@@ -1,0 +1,22 @@
+## 1. OpenSpec And Contract
+
+- [x] 1.1 Create proposal, design, spec delta, tasks, and benchmark documentation.
+- [x] 1.2 Define score output contract with `0-10` bounds and rule version.
+
+## 2. Configurable Versioned Rules
+
+- [x] 2.1 Add default JSON ruleset for technical indicator scores.
+- [x] 2.2 Support runtime override via `INDICATOR_SCORE_RULES_PATH`.
+- [x] 2.3 Validate required ruleset fields and input definitions.
+
+## 3. Backend Scoring Service
+
+- [x] 3.1 Implement normalized indicator scoring service consuming persisted indicator rows.
+- [x] 3.2 Preserve null/warmup behavior by skipping scores with missing inputs.
+- [x] 3.3 Return version metadata with every score.
+
+## 4. Validation
+
+- [x] 4.1 Add unit tests for score bounds and default rules.
+- [x] 4.2 Add unit tests for configurable override rules and versioning.
+- [x] 4.3 Add reproducible benchmark script and document expected use.


### PR DESCRIPTION
## Summary
- Add versioned configurable indicator score rules for normalized 0-10 technical scores.
- Add backend score service and admin latest scores endpoint consuming persisted market_indicator rows.
- Add OpenSpec artifacts, score-rules documentation, and benchmark script/result.

## Validation
- openspec validate normalize-indicator-scores --strict
- ./backend/.venv/bin/python -m pytest backend/tests/unit/test_indicator_score_service.py backend/tests/unit/test_market_indicator_advanced_consumption.py backend/tests/unit/test_market_indicator_pivot_levels.py -q
- ./backend/.venv/bin/python -m pytest backend/tests/unit/test_api_coverage.py -q
- ./backend/.venv/bin/python -m pytest -q
- npm --prefix frontend run build

## Benchmark
- cd backend && ../backend/.venv/bin/python scripts/benchmark_indicator_score_service.py --rows 10000
- Result: 10,000 rows, 90,000 scores, 897.310 ms, 11,144.42 rows/sec, ruleset technical-normalization/v1