### PR TITLE
feat: add Glassnode on-chain connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ backend/data/jobs/*.json
 backend/data/jobs/results.db
 backend/full_execution_log.txt.1
 .env
+.env.glassnode
 .env.docker.local
 backend/.env
 frontend/test-results/

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,6 +22,13 @@ class Settings(BaseSettings):
     # Market data providers (optional)
     alphavantage_api_key: str | None = None
 
+    # Glassnode on-chain metrics connector
+    glassnode_api_key: str | None = None
+    glassnode_base_url: str = "https://api.glassnode.com"
+    glassnode_cache_ttl_seconds: int = 900
+    glassnode_rate_limit_per_minute: int = 60
+    glassnode_request_timeout_seconds: float = 10.0
+
     # Main application DB. If omitted, runtime can fall back to workflow DB.
     database_url: str | None = None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.routes.coordination import router as coordination_router
 from app.routes.workflow import router as workflow_router
 from app.routes.workflow_validation import router as workflow_validation_router
 from app.routes.market import router as market_router
+from app.routes.onchain_metrics import router as onchain_metrics_router
 from app.routes.portfolio import router as portfolio_router
 from app.routes.signals import router as signals_router
 from app.routes.ai_dashboard import router as ai_dashboard_router
@@ -292,6 +293,7 @@ app.include_router(coordination_router)
 app.include_router(workflow_router)
 app.include_router(workflow_validation_router)
 app.include_router(market_router)
+app.include_router(onchain_metrics_router)
 app.include_router(portfolio_router)
 app.include_router(signals_router)
 app.include_router(ai_dashboard_router)

--- a/backend/app/routes/onchain_metrics.py
+++ b/backend/app/routes/onchain_metrics.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel
+
+from app.services.glassnode_service import (
+    DEFAULT_GLASSNODE_INTERVAL,
+    GlassnodeConfigError,
+    GlassnodeRateLimitError,
+    get_glassnode_service,
+)
+
+router = APIRouter(prefix="/api/onchain", tags=["onchain"])
+
+
+class GlassnodeMetricPayload(BaseModel):
+    metric: str
+    asset: str
+    interval: str
+    endpoint: str
+    points: list[dict[str, Any]]
+    latest: dict[str, Any] | None
+    fetched_at: datetime
+    cached_until: datetime
+    cached: bool
+
+
+class GlassnodeMetricsResponse(BaseModel):
+    asset: str
+    interval: str
+    cached: bool
+    metrics: list[GlassnodeMetricPayload]
+
+
+@router.get("/glassnode/{asset}", response_model=GlassnodeMetricsResponse)
+async def get_glassnode_onchain_metrics(
+    asset: str,
+    interval: str = Query(default=DEFAULT_GLASSNODE_INTERVAL, min_length=1),
+    since: int | None = Query(default=None, ge=0),
+    until: int | None = Query(default=None, ge=0),
+):
+    try:
+        payload = await get_glassnode_service().fetch_metrics(
+            asset,
+            interval=interval,
+            since=since,
+            until=until,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except GlassnodeConfigError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))
+    except GlassnodeRateLimitError as exc:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc))
+    return payload

--- a/backend/app/services/glassnode_service.py
+++ b/backend/app/services/glassnode_service.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from app.config import get_settings
+
+SUPPORTED_GLASSNODE_ASSETS = {"BTC", "ETH"}
+DEFAULT_GLASSNODE_INTERVAL = "24h"
+GLASSNODE_METRICS: dict[str, str] = {
+    "mvrv": "/v1/metrics/market/mvrv",
+    "nvt": "/v1/metrics/indicators/nvt",
+    "realized_cap": "/v1/metrics/market/marketcap_realized_usd",
+    "sopr": "/v1/metrics/indicators/sopr",
+}
+
+
+class GlassnodeConfigError(RuntimeError):
+    pass
+
+
+class GlassnodeRateLimitError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class GlassnodeMetricSeries:
+    metric: str
+    asset: str
+    interval: str
+    endpoint: str
+    points: list[dict[str, Any]]
+    fetched_at: datetime
+    cached_until: datetime
+    cached: bool
+
+    @property
+    def latest(self) -> dict[str, Any] | None:
+        return self.points[-1] if self.points else None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "metric": self.metric,
+            "asset": self.asset,
+            "interval": self.interval,
+            "endpoint": self.endpoint,
+            "points": list(self.points),
+            "latest": self.latest,
+            "fetched_at": self.fetched_at,
+            "cached_until": self.cached_until,
+            "cached": self.cached,
+        }
+
+
+class GlassnodeService:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        cache_ttl_seconds: int | None = None,
+        rate_limit_per_minute: int | None = None,
+        client: httpx.AsyncClient | None = None,
+        sleep=asyncio.sleep,
+        monotonic=time.monotonic,
+        now=None,
+    ) -> None:
+        settings = get_settings()
+        self.api_key = (api_key if api_key is not None else settings.glassnode_api_key) or ""
+        self.base_url = (base_url if base_url is not None else settings.glassnode_base_url).rstrip(
+            "/"
+        )
+        self.cache_ttl_seconds = int(
+            cache_ttl_seconds
+            if cache_ttl_seconds is not None
+            else settings.glassnode_cache_ttl_seconds
+        )
+        self.rate_limit_per_minute = int(
+            rate_limit_per_minute
+            if rate_limit_per_minute is not None
+            else settings.glassnode_rate_limit_per_minute
+        )
+        self._client = client
+        self._owns_client = client is None
+        self._sleep = sleep
+        self._monotonic = monotonic
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self._cache: dict[tuple[str, str, str, int | None, int | None], GlassnodeMetricSeries] = {}
+        self._cache_expires_at: dict[tuple[str, str, str, int | None, int | None], float] = {}
+        self._rate_lock = asyncio.Lock()
+        self._last_request_at: float | None = None
+
+    async def close(self) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def fetch_metrics(
+        self,
+        asset: str,
+        *,
+        interval: str = DEFAULT_GLASSNODE_INTERVAL,
+        since: int | None = None,
+        until: int | None = None,
+    ) -> dict[str, Any]:
+        normalized_asset = self._normalize_asset(asset)
+        metric_rows = []
+        for metric in GLASSNODE_METRICS:
+            row = await self.fetch_metric(
+                metric,
+                normalized_asset,
+                interval=interval,
+                since=since,
+                until=until,
+            )
+            metric_rows.append(row.as_dict())
+        return {
+            "asset": normalized_asset,
+            "interval": interval,
+            "cached": all(row["cached"] for row in metric_rows),
+            "metrics": metric_rows,
+        }
+
+    async def fetch_metric(
+        self,
+        metric: str,
+        asset: str,
+        *,
+        interval: str = DEFAULT_GLASSNODE_INTERVAL,
+        since: int | None = None,
+        until: int | None = None,
+    ) -> GlassnodeMetricSeries:
+        normalized_metric = self._normalize_metric(metric)
+        normalized_asset = self._normalize_asset(asset)
+        cache_key = (normalized_metric, normalized_asset, interval, since, until)
+        cached = self._read_cache(cache_key)
+        if cached is not None:
+            return GlassnodeMetricSeries(
+                metric=cached.metric,
+                asset=cached.asset,
+                interval=cached.interval,
+                endpoint=cached.endpoint,
+                points=cached.points,
+                fetched_at=cached.fetched_at,
+                cached_until=cached.cached_until,
+                cached=True,
+            )
+
+        if not self.api_key.strip():
+            raise GlassnodeConfigError("GLASSNODE_API_KEY is required to fetch Glassnode metrics")
+
+        await self._respect_rate_limit()
+        endpoint = GLASSNODE_METRICS[normalized_metric]
+        client = self._get_client()
+        params: dict[str, Any] = {
+            "a": normalized_asset,
+            "i": interval,
+            "f": "json",
+        }
+        if since is not None:
+            params["s"] = int(since)
+        if until is not None:
+            params["u"] = int(until)
+
+        response = await client.get(
+            f"{self.base_url}{endpoint}",
+            params=params,
+            headers={"X-Api-Key": self.api_key},
+        )
+        if response.status_code == 429:
+            raise GlassnodeRateLimitError("Glassnode API rate limit exceeded")
+        response.raise_for_status()
+
+        fetched_at = self._now()
+        cached_until = datetime.fromtimestamp(
+            fetched_at.timestamp() + self.cache_ttl_seconds,
+            tz=timezone.utc,
+        )
+        series = GlassnodeMetricSeries(
+            metric=normalized_metric,
+            asset=normalized_asset,
+            interval=interval,
+            endpoint=endpoint,
+            points=self._normalize_points(response.json()),
+            fetched_at=fetched_at,
+            cached_until=cached_until,
+            cached=False,
+        )
+        self._write_cache(cache_key, series)
+        return series
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=float(get_settings().glassnode_request_timeout_seconds)
+            )
+        return self._client
+
+    async def _respect_rate_limit(self) -> None:
+        if self.rate_limit_per_minute <= 0:
+            return
+        min_interval = 60.0 / float(self.rate_limit_per_minute)
+        async with self._rate_lock:
+            now = self._monotonic()
+            if self._last_request_at is not None:
+                wait_seconds = min_interval - (now - self._last_request_at)
+                if wait_seconds > 0:
+                    await self._sleep(wait_seconds)
+                    now = self._monotonic()
+            self._last_request_at = now
+
+    def _read_cache(
+        self, key: tuple[str, str, str, int | None, int | None]
+    ) -> GlassnodeMetricSeries | None:
+        expires_at = self._cache_expires_at.get(key)
+        if expires_at is None:
+            return None
+        if self._monotonic() >= expires_at:
+            self._cache.pop(key, None)
+            self._cache_expires_at.pop(key, None)
+            return None
+        return self._cache.get(key)
+
+    def _write_cache(
+        self,
+        key: tuple[str, str, str, int | None, int | None],
+        value: GlassnodeMetricSeries,
+    ) -> None:
+        self._cache[key] = value
+        self._cache_expires_at[key] = self._monotonic() + self.cache_ttl_seconds
+
+    @staticmethod
+    def _normalize_metric(metric: str) -> str:
+        normalized = str(metric or "").strip().lower()
+        if normalized not in GLASSNODE_METRICS:
+            supported = ", ".join(sorted(GLASSNODE_METRICS))
+            raise ValueError(f"Unsupported Glassnode metric '{metric}'. Supported: {supported}")
+        return normalized
+
+    @staticmethod
+    def _normalize_asset(asset: str) -> str:
+        normalized = str(asset or "").strip().upper()
+        if normalized not in SUPPORTED_GLASSNODE_ASSETS:
+            supported = ", ".join(sorted(SUPPORTED_GLASSNODE_ASSETS))
+            raise ValueError(f"Unsupported Glassnode asset '{asset}'. Supported: {supported}")
+        return normalized
+
+    @staticmethod
+    def _normalize_points(payload: Any) -> list[dict[str, Any]]:
+        if not isinstance(payload, list):
+            return []
+        points: list[dict[str, Any]] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            point = dict(item)
+            value = point.get("v")
+            if isinstance(value, float) and not math.isfinite(value):
+                point["v"] = None
+            points.append(point)
+        return points
+
+
+_SERVICE: GlassnodeService | None = None
+
+
+def get_glassnode_service() -> GlassnodeService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = GlassnodeService()
+    return _SERVICE

--- a/backend/tests/unit/test_glassnode_service.py
+++ b/backend/tests/unit/test_glassnode_service.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from app.services.glassnode_service import (
+    GLASSNODE_METRICS,
+    GlassnodeConfigError,
+    GlassnodeRateLimitError,
+    GlassnodeService,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 1000.0
+
+    def monotonic(self) -> float:
+        return self.value
+
+    async def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class FakeGlassnodeClient:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self.calls: list[dict] = []
+
+    async def get(self, url: str, params=None, headers=None):
+        self.calls.append({"url": url, "params": params, "headers": headers})
+        return httpx.Response(
+            self.status_code,
+            json=[{"t": 1726790400, "v": 1.23}],
+            request=httpx.Request("GET", url),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_requires_configured_api_key_before_network_call() -> None:
+    client = FakeGlassnodeClient()
+    service = GlassnodeService(api_key="", client=client, rate_limit_per_minute=0)
+
+    with pytest.raises(GlassnodeConfigError):
+        await service.fetch_metric("mvrv", "BTC")
+
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_uses_api_key_header_and_glassnode_params() -> None:
+    client = FakeGlassnodeClient()
+    service = GlassnodeService(api_key="secret", client=client, rate_limit_per_minute=0)
+
+    result = await service.fetch_metric("mvrv", "BTC", since=1, until=2)
+
+    assert result.asset == "BTC"
+    assert result.metric == "mvrv"
+    assert result.latest == {"t": 1726790400, "v": 1.23}
+    assert client.calls == [
+        {
+            "url": "https://api.glassnode.com/v1/metrics/market/mvrv",
+            "params": {"a": "BTC", "i": "24h", "f": "json", "s": 1, "u": 2},
+            "headers": {"X-Api-Key": "secret"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_caches_identical_query_for_15_minutes() -> None:
+    clock = FakeClock()
+    client = FakeGlassnodeClient()
+    service = GlassnodeService(
+        api_key="secret",
+        client=client,
+        cache_ttl_seconds=900,
+        rate_limit_per_minute=0,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    first = await service.fetch_metric("nvt", "ETH")
+    second = await service.fetch_metric("nvt", "ETH")
+    clock.value += 901
+    third = await service.fetch_metric("nvt", "ETH")
+
+    assert first.cached is False
+    assert second.cached is True
+    assert third.cached is False
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_spaces_uncached_requests() -> None:
+    clock = FakeClock()
+    client = FakeGlassnodeClient()
+    service = GlassnodeService(
+        api_key="secret",
+        client=client,
+        cache_ttl_seconds=900,
+        rate_limit_per_minute=30,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    await service.fetch_metric("mvrv", "BTC", since=1)
+    await service.fetch_metric("nvt", "BTC", since=1)
+
+    assert len(client.calls) == 2
+    assert clock.value == pytest.approx(1002.0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_metrics_covers_btc_and_eth_required_metrics() -> None:
+    for asset in ("BTC", "ETH"):
+        client = FakeGlassnodeClient()
+        service = GlassnodeService(api_key="secret", client=client, rate_limit_per_minute=0)
+
+        payload = await service.fetch_metrics(asset)
+
+        assert payload["asset"] == asset
+        assert [item["metric"] for item in payload["metrics"]] == list(GLASSNODE_METRICS)
+        assert len(client.calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_glassnode_429_raises_rate_limit_error() -> None:
+    service = GlassnodeService(
+        api_key="secret",
+        client=FakeGlassnodeClient(status_code=429),
+        rate_limit_per_minute=0,
+    )
+
+    with pytest.raises(GlassnodeRateLimitError):
+        await service.fetch_metric("sopr", "BTC")
+
+
+def test_unsupported_asset_and_metric_are_rejected() -> None:
+    service = GlassnodeService(api_key="secret", client=FakeGlassnodeClient())
+
+    with pytest.raises(ValueError, match="Unsupported Glassnode asset"):
+        service._normalize_asset("SOL")
+
+    with pytest.raises(ValueError, match="Unsupported Glassnode metric"):
+        service._normalize_metric("foo")
+
+
+def test_normalize_points_preserves_glassnode_value_shapes() -> None:
+    payload = [
+        {"t": 1, "v": 1.2},
+        {"t": 2, "v": {"short_term": 0.9, "long_term": 1.1}, "o": {"quality": "ok"}},
+        {"t": 3, "v": [1, 2, 3]},
+        {"t": 4, "v": float("nan")},
+    ]
+
+    points = GlassnodeService._normalize_points(payload)
+
+    assert points[:3] == payload[:3]
+    assert points[3] == {"t": 4, "v": None}

--- a/backend/tests/unit/test_onchain_metrics_route.py
+++ b/backend/tests/unit/test_onchain_metrics_route.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from app.routes import onchain_metrics
+from app.services.glassnode_service import GlassnodeConfigError, GlassnodeRateLimitError
+
+
+class FakeGlassnodeService:
+    async def fetch_metrics(self, asset: str, interval: str, since: int | None, until: int | None):
+        assert asset == "BTC"
+        assert interval == "24h"
+        assert since == 1
+        assert until == 2
+        now = datetime(2026, 4, 24, tzinfo=timezone.utc)
+        return {
+            "asset": "BTC",
+            "interval": "24h",
+            "cached": False,
+            "metrics": [
+                {
+                    "metric": "mvrv",
+                    "asset": "BTC",
+                    "interval": "24h",
+                    "endpoint": "/v1/metrics/market/mvrv",
+                    "points": [{"t": 1, "v": 2.0}],
+                    "latest": {"t": 1, "v": 2.0},
+                    "fetched_at": now,
+                    "cached_until": now,
+                    "cached": False,
+                }
+            ],
+        }
+
+
+@pytest.mark.asyncio
+async def test_glassnode_onchain_route_returns_service_payload(monkeypatch) -> None:
+    monkeypatch.setattr(onchain_metrics, "get_glassnode_service", lambda: FakeGlassnodeService())
+
+    payload = await onchain_metrics.get_glassnode_onchain_metrics(
+        asset="BTC",
+        interval="24h",
+        since=1,
+        until=2,
+    )
+
+    assert payload["asset"] == "BTC"
+    assert payload["metrics"][0]["metric"] == "mvrv"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "status_code"),
+    [
+        (ValueError("bad asset"), 400),
+        (GlassnodeConfigError("missing key"), 503),
+        (GlassnodeRateLimitError("rate limited"), 429),
+    ],
+)
+async def test_glassnode_onchain_route_maps_service_errors(
+    monkeypatch, exc: Exception, status_code: int
+) -> None:
+    class FailingGlassnodeService:
+        async def fetch_metrics(self, *_args, **_kwargs):
+            raise exc
+
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_glassnode_service",
+        lambda: FailingGlassnodeService(),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await onchain_metrics.get_glassnode_onchain_metrics(asset="BTC")
+
+    assert raised.value.status_code == status_code

--- a/openspec/changes/add-glassnode-onchain-connector/.openspec.yaml
+++ b/openspec/changes/add-glassnode-onchain-connector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/add-glassnode-onchain-connector/design.md
+++ b/openspec/changes/add-glassnode-onchain-connector/design.md
@@ -1,0 +1,54 @@
+## Context
+
+O serviço on-chain atual usa DeFiLlama/GitHub para sinais por cadeia. A feature Glassnode tem natureza diferente: métricas de asset (`BTC`, `ETH`) com API key, créditos e rate limit. Por isso o conector fica isolado em um service próprio, evitando acoplamento ao fluxo atual de snapshot/sinal.
+
+## Decisions
+
+### Configuração
+
+O conector lê `Settings`:
+
+- `glassnode_api_key`
+- `glassnode_base_url`
+- `glassnode_rate_limit_per_minute`
+- `glassnode_cache_ttl_seconds`
+
+Sem API key configurada, o conector falha cedo com erro explícito e não tenta chamar rede.
+
+### Endpoints
+
+Ruleset inicial de métricas:
+
+- `mvrv`: `/v1/metrics/market/mvrv`
+- `nvt`: `/v1/metrics/indicators/nvt`
+- `realized_cap`: `/v1/metrics/market/marketcap_realized_usd`
+- `sopr`: `/v1/metrics/indicators/sopr`
+
+Cada chamada usa `a`, `i`, `s`, `u`, `f=json` e autenticação por header `X-Api-Key`, conforme a documentação oficial da Glassnode.
+
+### Cache
+
+Cache em memória keyed por:
+
+- metric
+- asset
+- interval
+- since
+- until
+
+TTL padrão: `900` segundos, ou 15 minutos.
+
+### Rate limit
+
+Um limiter assíncrono serializa chamadas e garante espaçamento mínimo entre requests calculado a partir de `glassnode_rate_limit_per_minute`. O cache é checado antes do limiter para não consumir orçamento em hits locais.
+
+### Contrato de rota
+
+`GET /api/onchain/glassnode/{asset}` retorna:
+
+- `asset`
+- `interval`
+- `cached`
+- `metrics`: lista com `metric`, `endpoint`, `points`, `latest`, `fetched_at`, `cached_until`
+
+`asset` aceita apenas `BTC` e `ETH`.

--- a/openspec/changes/add-glassnode-onchain-connector/proposal.md
+++ b/openspec/changes/add-glassnode-onchain-connector/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+O sistema precisa enriquecer o engine on-chain com métricas de ciclo e valuation vindas da Glassnode. MVRV, NVT, realized cap e SOPR são fontes externas pagas/rate-limited, então o conector precisa centralizar autenticação, cache e controle de chamadas para evitar consumo excessivo de créditos.
+
+## What Changes
+
+- Adicionar conector backend para Glassnode API.
+- Coletar MVRV, NVT, realized cap e SOPR para BTC e ETH.
+- Tornar API key, base URL, rate limit e TTL de cache configuráveis.
+- Aplicar cache em memória de 15 minutos por asset/métrica/janela.
+- Respeitar rate limit antes de chamadas externas e expor erro claro em HTTP 429.
+- Expor rota backend para consulta das métricas agregadas por asset.
+
+## Capabilities
+
+### New Capabilities
+- `glassnode-onchain-connector`: Coleta métricas Glassnode versionadas por endpoint para BTC e ETH.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Backend: novo service `glassnode_service` e rota `onchain_metrics`.
+- Configuração: novas opções `GLASSNODE_API_KEY`, `GLASSNODE_BASE_URL`, `GLASSNODE_RATE_LIMIT_PER_MINUTE`, `GLASSNODE_CACHE_TTL_SECONDS`.
+- Testes: cobertura unitária para API key, cache 15min, rate limit, 429 e BTC/ETH.
+- Sem migração de banco nesta entrega.

--- a/openspec/changes/add-glassnode-onchain-connector/specs/glassnode-onchain-connector/spec.md
+++ b/openspec/changes/add-glassnode-onchain-connector/specs/glassnode-onchain-connector/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Glassnode API key is configurable
+The system SHALL load the Glassnode API key from runtime configuration.
+
+#### Scenario: Missing API key fails before network call
+- **GIVEN** no Glassnode API key is configured
+- **WHEN** a Glassnode metric fetch is requested
+- **THEN** the connector SHALL fail with a configuration error
+- **AND** SHALL NOT call the external Glassnode API.
+
+### Requirement: Connector fetches required Glassnode metrics
+The system SHALL collect MVRV, NVT, realized cap, and SOPR from Glassnode for supported assets.
+
+#### Scenario: BTC metrics collected
+- **WHEN** metrics are requested for `BTC`
+- **THEN** the connector SHALL request MVRV, NVT, realized cap, and SOPR from Glassnode.
+
+#### Scenario: ETH metrics collected
+- **WHEN** metrics are requested for `ETH`
+- **THEN** the connector SHALL request MVRV, NVT, realized cap, and SOPR from Glassnode.
+
+### Requirement: Connector caches responses for 15 minutes
+The connector SHALL cache Glassnode metric responses for 15 minutes by metric, asset, interval, since, and until.
+
+#### Scenario: Cache hit avoids external call
+- **GIVEN** a metric was fetched less than 15 minutes ago for the same query parameters
+- **WHEN** the same metric is requested again
+- **THEN** the connector SHALL return the cached response
+- **AND** SHALL NOT call Glassnode again.
+
+### Requirement: Connector respects rate limits
+The connector SHALL throttle outbound Glassnode requests according to configured rate limit.
+
+#### Scenario: Consecutive calls are spaced
+- **GIVEN** the configured Glassnode rate limit requires spacing between calls
+- **WHEN** two uncached Glassnode requests are issued consecutively
+- **THEN** the connector SHALL wait before the second outbound request.
+
+### Requirement: Upstream rate-limit errors are explicit
+The connector SHALL surface Glassnode HTTP 429 responses as rate-limit errors.
+
+#### Scenario: Glassnode returns 429
+- **WHEN** Glassnode returns HTTP 429
+- **THEN** the connector SHALL raise a rate-limit error that can be returned as HTTP 429 by the API route.

--- a/openspec/changes/add-glassnode-onchain-connector/tasks.md
+++ b/openspec/changes/add-glassnode-onchain-connector/tasks.md
@@ -1,0 +1,24 @@
+## 1. OpenSpec And Contract
+
+- [x] 1.1 Create proposal, design, spec delta, and tasks for the Glassnode connector.
+- [x] 1.2 Define supported metrics, supported assets, cache TTL, and rate-limit behavior.
+
+## 2. Backend Connector
+
+- [x] 2.1 Add configurable Glassnode settings.
+- [x] 2.2 Implement Glassnode service for MVRV, NVT, realized cap, and SOPR.
+- [x] 2.3 Enforce supported assets BTC and ETH.
+- [x] 2.4 Add 15-minute in-memory cache before external requests.
+- [x] 2.5 Respect configured rate limit before external requests.
+- [x] 2.6 Surface missing API key and upstream 429 errors clearly.
+
+## 3. API Surface
+
+- [x] 3.1 Add backend route to fetch Glassnode metrics by asset.
+- [x] 3.2 Register route in the FastAPI app.
+
+## 4. Validation
+
+- [x] 4.1 Add unit tests for cache, rate limit, API key, BTC/ETH support, and 429 handling.
+- [x] 4.2 Validate OpenSpec change.
+- [x] 4.3 Run backend targeted tests and frontend build.


### PR DESCRIPTION
## Summary
- Add a Glassnode connector for MVRV, NVT, realized cap, and SOPR.
- Support BTC and ETH with API key/base URL/rate limit/cache TTL settings.
- Use X-Api-Key header only, 15-minute cache, configured outbound request pacing, and explicit 429/config errors.
- Add /api/onchain/glassnode/{asset} route and OpenSpec artifacts.

## Validation
- openspec validate add-glassnode-onchain-connector --strict
- ./backend/.venv/bin/python -m pytest backend/tests/unit/test_glassnode_service.py backend/tests/unit/test_onchain_metrics_route.py -q
- ./backend/.venv/bin/python -m pytest backend/tests/unit/test_glassnode_service.py backend/tests/unit/test_onchain_metrics_route.py backend/tests/unit/test_main_and_market_routes.py -q
- ./backend/.venv/bin/python -m pytest -q
- ./backend/.venv/bin/python -m black --check backend
- npm --prefix frontend run build

## Notes
- No database migration: connector is cache-only for this delivery.
- GLASSNODE_API_KEY is required at runtime; missing key fails before network calls.