### PR TITLE
feat: collect exchange netflows

### DIFF
--- a/backend/app/routes/onchain_metrics.py
+++ b/backend/app/routes/onchain_metrics.py
@@ -12,6 +12,7 @@ from app.services.glassnode_service import (
     GlassnodeRateLimitError,
     get_glassnode_service,
 )
+from app.services.onchain_exchange_flow_service import get_exchange_flow_service
 
 router = APIRouter(prefix="/api/onchain", tags=["onchain"])
 
@@ -35,6 +36,33 @@ class GlassnodeMetricsResponse(BaseModel):
     metrics: list[GlassnodeMetricPayload]
 
 
+class ExchangeFlowExchangePayload(BaseModel):
+    exchange: str
+    inflow: float
+    outflow: float
+    netflow: float
+
+
+class ExchangeFlowSourcePayload(BaseModel):
+    endpoint: str
+    points: int
+    cached: bool
+    fetched_at: datetime
+    cached_until: datetime
+
+
+class ExchangeFlowsResponse(BaseModel):
+    asset: str
+    window: str
+    interval: str
+    since: int
+    until: int
+    cached: bool
+    total: dict[str, float]
+    exchanges: list[ExchangeFlowExchangePayload]
+    sources: dict[str, ExchangeFlowSourcePayload]
+
+
 @router.get("/glassnode/{asset}", response_model=GlassnodeMetricsResponse)
 async def get_glassnode_onchain_metrics(
     asset: str,
@@ -49,6 +77,22 @@ async def get_glassnode_onchain_metrics(
             since=since,
             until=until,
         )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except GlassnodeConfigError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))
+    except GlassnodeRateLimitError as exc:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc))
+    return payload
+
+
+@router.get("/glassnode/{asset}/exchange-flows", response_model=ExchangeFlowsResponse)
+async def get_glassnode_exchange_flows(
+    asset: str,
+    window: str = Query(default="24h", pattern="^(24h|7d|30d)$"),
+):
+    try:
+        payload = await get_exchange_flow_service().fetch_exchange_flows(asset, window=window)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     except GlassnodeConfigError as exc:

--- a/backend/app/services/glassnode_service.py
+++ b/backend/app/services/glassnode_service.py
@@ -19,6 +19,11 @@ GLASSNODE_METRICS: dict[str, str] = {
     "realized_cap": "/v1/metrics/market/marketcap_realized_usd",
     "sopr": "/v1/metrics/indicators/sopr",
 }
+GLASSNODE_EXCHANGE_FLOW_METRICS: dict[str, str] = {
+    "inflow": "/v1/metrics/transactions/transfers_volume_to_exchanges_sum",
+    "outflow": "/v1/metrics/transactions/transfers_volume_from_exchanges_sum",
+    "netflow": "/v1/metrics/transactions/transfers_volume_exchanges_net",
+}
 
 
 class GlassnodeConfigError(RuntimeError):
@@ -156,7 +161,7 @@ class GlassnodeService:
             raise GlassnodeConfigError("GLASSNODE_API_KEY is required to fetch Glassnode metrics")
 
         await self._respect_rate_limit()
-        endpoint = GLASSNODE_METRICS[normalized_metric]
+        endpoint = self._metric_endpoint(normalized_metric)
         client = self._get_client()
         params: dict[str, Any] = {
             "a": normalized_asset,
@@ -238,10 +243,19 @@ class GlassnodeService:
     @staticmethod
     def _normalize_metric(metric: str) -> str:
         normalized = str(metric or "").strip().lower()
-        if normalized not in GLASSNODE_METRICS:
-            supported = ", ".join(sorted(GLASSNODE_METRICS))
+        if (
+            normalized not in GLASSNODE_METRICS
+            and normalized not in GLASSNODE_EXCHANGE_FLOW_METRICS
+        ):
+            supported = ", ".join(
+                sorted((*GLASSNODE_METRICS.keys(), *GLASSNODE_EXCHANGE_FLOW_METRICS.keys()))
+            )
             raise ValueError(f"Unsupported Glassnode metric '{metric}'. Supported: {supported}")
         return normalized
+
+    @staticmethod
+    def _metric_endpoint(metric: str) -> str:
+        return GLASSNODE_METRICS.get(metric) or GLASSNODE_EXCHANGE_FLOW_METRICS[metric]
 
     @staticmethod
     def _normalize_asset(asset: str) -> str:

--- a/backend/app/services/onchain_exchange_flow_service.py
+++ b/backend/app/services/onchain_exchange_flow_service.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.services.glassnode_service import (
+    DEFAULT_GLASSNODE_INTERVAL,
+    GLASSNODE_EXCHANGE_FLOW_METRICS,
+    GlassnodeMetricSeries,
+    get_glassnode_service,
+)
+
+SUPPORTED_EXCHANGE_FLOW_WINDOWS: dict[str, timedelta] = {
+    "24h": timedelta(days=1),
+    "7d": timedelta(days=7),
+    "30d": timedelta(days=30),
+}
+
+
+class ExchangeFlowService:
+    def __init__(self, *, glassnode_service=None, now=None) -> None:
+        self._glassnode_service = glassnode_service or get_glassnode_service()
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    async def fetch_exchange_flows(
+        self,
+        asset: str,
+        *,
+        window: str,
+        interval: str = DEFAULT_GLASSNODE_INTERVAL,
+    ) -> dict[str, Any]:
+        normalized_window = normalize_exchange_flow_window(window)
+        until_dt = self._now()
+        since_dt = until_dt - SUPPORTED_EXCHANGE_FLOW_WINDOWS[normalized_window]
+        since = int(since_dt.timestamp())
+        until = int(until_dt.timestamp())
+
+        metric_rows: dict[str, GlassnodeMetricSeries] = {}
+        for metric in GLASSNODE_EXCHANGE_FLOW_METRICS:
+            metric_rows[metric] = await self._glassnode_service.fetch_metric(
+                metric,
+                asset,
+                interval=interval,
+                since=since,
+                until=until,
+            )
+
+        aggregation = aggregate_exchange_flow_series(metric_rows)
+        sources = {
+            metric: {
+                "endpoint": series.endpoint,
+                "points": len(series.points),
+                "cached": series.cached,
+                "fetched_at": series.fetched_at,
+                "cached_until": series.cached_until,
+            }
+            for metric, series in metric_rows.items()
+        }
+        normalized_asset = self._glassnode_service._normalize_asset(asset)
+        return {
+            "asset": normalized_asset,
+            "window": normalized_window,
+            "interval": interval,
+            "since": since,
+            "until": until,
+            "cached": all(series.cached for series in metric_rows.values()),
+            "total": aggregation["total"],
+            "exchanges": aggregation["exchanges"],
+            "sources": sources,
+        }
+
+
+def normalize_exchange_flow_window(window: str) -> str:
+    normalized = str(window or "").strip().lower()
+    if normalized not in SUPPORTED_EXCHANGE_FLOW_WINDOWS:
+        supported = ", ".join(SUPPORTED_EXCHANGE_FLOW_WINDOWS)
+        raise ValueError(f"Unsupported exchange flow window '{window}'. Supported: {supported}")
+    return normalized
+
+
+def aggregate_exchange_flow_series(
+    series_by_metric: dict[str, GlassnodeMetricSeries],
+) -> dict[str, Any]:
+    buckets: dict[str, dict[str, float]] = {}
+
+    for metric, series in series_by_metric.items():
+        for point in series.points:
+            _add_exchange_flow_value(buckets, metric, point.get("v"))
+
+    total = {
+        "inflow": 0.0,
+        "outflow": 0.0,
+        "netflow": 0.0,
+    }
+    exchanges: list[dict[str, Any]] = []
+    for exchange, values in sorted(buckets.items()):
+        inflow = values.get("inflow", 0.0)
+        outflow = values.get("outflow", 0.0)
+        netflow = values.get("netflow", inflow - outflow)
+
+        if exchange == "total":
+            total["inflow"] += inflow
+            total["outflow"] += outflow
+            total["netflow"] += netflow
+            continue
+
+        exchanges.append(
+            {
+                "exchange": exchange,
+                "inflow": inflow,
+                "outflow": outflow,
+                "netflow": netflow,
+            }
+        )
+        total["inflow"] += inflow
+        total["outflow"] += outflow
+        total["netflow"] += netflow
+
+    return {
+        "total": total,
+        "exchanges": exchanges,
+    }
+
+
+def _add_exchange_flow_value(
+    buckets: dict[str, dict[str, float]],
+    metric: str,
+    raw_value: Any,
+) -> None:
+    numeric = _numeric_or_none(raw_value)
+    if numeric is not None:
+        bucket = buckets.setdefault("total", {})
+        bucket[metric] = bucket.get(metric, 0.0) + numeric
+        return
+
+    if not isinstance(raw_value, dict):
+        return
+
+    for exchange, value in raw_value.items():
+        parsed = _numeric_or_none(value)
+        if parsed is None:
+            continue
+        bucket = buckets.setdefault(_normalize_exchange_name(exchange), {})
+        bucket[metric] = bucket.get(metric, 0.0) + parsed
+
+
+def _numeric_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _normalize_exchange_name(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    return normalized or "unknown"
+
+
+_SERVICE: ExchangeFlowService | None = None
+
+
+def get_exchange_flow_service() -> ExchangeFlowService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = ExchangeFlowService()
+    return _SERVICE

--- a/backend/tests/unit/test_onchain_exchange_flow_service.py
+++ b/backend/tests/unit/test_onchain_exchange_flow_service.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services.glassnode_service import GlassnodeMetricSeries
+from app.services.onchain_exchange_flow_service import (
+    ExchangeFlowService,
+    aggregate_exchange_flow_series,
+    normalize_exchange_flow_window,
+)
+
+
+def _series(metric: str, values: list[object], *, cached: bool = False) -> GlassnodeMetricSeries:
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    return GlassnodeMetricSeries(
+        metric=metric,
+        asset="BTC",
+        interval="24h",
+        endpoint=f"/v1/metrics/transactions/{metric}",
+        points=[{"t": 1 + index, "v": value} for index, value in enumerate(values)],
+        fetched_at=now,
+        cached_until=now,
+        cached=cached,
+    )
+
+
+def test_exchange_flow_aggregation_groups_object_payload_by_exchange() -> None:
+    result = aggregate_exchange_flow_series(
+        {
+            "inflow": _series(
+                "inflow",
+                [
+                    {"Binance": 100.0, "Coinbase": 50.0},
+                    {"Binance": 25.0, "Coinbase": 10.0},
+                ],
+            ),
+            "outflow": _series(
+                "outflow",
+                [
+                    {"Binance": 40.0, "Coinbase": 20.0},
+                    {"Binance": 5.0, "Coinbase": 15.0},
+                ],
+            ),
+            "netflow": _series(
+                "netflow",
+                [
+                    {"Binance": 60.0, "Coinbase": 30.0},
+                    {"Binance": 20.0, "Coinbase": -5.0},
+                ],
+            ),
+        }
+    )
+
+    assert result["exchanges"] == [
+        {"exchange": "binance", "inflow": 125.0, "outflow": 45.0, "netflow": 80.0},
+        {"exchange": "coinbase", "inflow": 60.0, "outflow": 35.0, "netflow": 25.0},
+    ]
+    assert result["total"] == {"inflow": 185.0, "outflow": 80.0, "netflow": 105.0}
+
+
+def test_exchange_flow_aggregation_derives_missing_exchange_netflow() -> None:
+    result = aggregate_exchange_flow_series(
+        {
+            "inflow": _series("inflow", [{"Binance": 100.0}]),
+            "outflow": _series("outflow", [{"Binance": 40.0}]),
+            "netflow": _series("netflow", []),
+        }
+    )
+
+    assert result["exchanges"] == [
+        {"exchange": "binance", "inflow": 100.0, "outflow": 40.0, "netflow": 60.0}
+    ]
+    assert result["total"] == {"inflow": 100.0, "outflow": 40.0, "netflow": 60.0}
+
+
+def test_exchange_flow_aggregation_uses_scalar_payload_as_total() -> None:
+    result = aggregate_exchange_flow_series(
+        {
+            "inflow": _series("inflow", [100.0, 50.0]),
+            "outflow": _series("outflow", [20.0, 10.0]),
+            "netflow": _series("netflow", [80.0, 40.0]),
+        }
+    )
+
+    assert result["exchanges"] == []
+    assert result["total"] == {"inflow": 150.0, "outflow": 30.0, "netflow": 120.0}
+
+
+def test_exchange_flow_window_validation() -> None:
+    assert normalize_exchange_flow_window("24H") == "24h"
+    assert normalize_exchange_flow_window("7d") == "7d"
+    assert normalize_exchange_flow_window("30d") == "30d"
+    with pytest.raises(ValueError, match="Unsupported exchange flow window"):
+        normalize_exchange_flow_window("90d")
+
+
+class FakeGlassnodeService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def fetch_metric(self, metric: str, asset: str, interval: str, since: int, until: int):
+        self.calls.append(
+            {
+                "metric": metric,
+                "asset": asset,
+                "interval": interval,
+                "since": since,
+                "until": until,
+            }
+        )
+        return _series(metric, [{"Binance": 1.0}], cached=True)
+
+    def _normalize_asset(self, asset: str) -> str:
+        return asset.upper()
+
+
+@pytest.mark.asyncio
+async def test_exchange_flow_service_fetches_required_metrics_for_7d_window() -> None:
+    fake_glassnode = FakeGlassnodeService()
+    service = ExchangeFlowService(
+        glassnode_service=fake_glassnode,
+        now=lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc),
+    )
+
+    payload = await service.fetch_exchange_flows("btc", window="7d")
+
+    assert payload["asset"] == "BTC"
+    assert payload["window"] == "7d"
+    assert payload["interval"] == "24h"
+    assert payload["until"] == 1777032000
+    assert payload["since"] == 1776427200
+    assert payload["cached"] is True
+    assert [call["metric"] for call in fake_glassnode.calls] == [
+        "inflow",
+        "outflow",
+        "netflow",
+    ]
+    assert {call["asset"] for call in fake_glassnode.calls} == {"btc"}

--- a/backend/tests/unit/test_onchain_metrics_route.py
+++ b/backend/tests/unit/test_onchain_metrics_route.py
@@ -36,6 +36,34 @@ class FakeGlassnodeService:
         }
 
 
+class FakeExchangeFlowService:
+    async def fetch_exchange_flows(self, asset: str, window: str):
+        assert asset == "BTC"
+        assert window == "7d"
+        now = datetime(2026, 4, 24, tzinfo=timezone.utc)
+        return {
+            "asset": "BTC",
+            "window": "7d",
+            "interval": "24h",
+            "since": 1,
+            "until": 2,
+            "cached": True,
+            "total": {"inflow": 100.0, "outflow": 40.0, "netflow": 60.0},
+            "exchanges": [
+                {"exchange": "binance", "inflow": 100.0, "outflow": 40.0, "netflow": 60.0}
+            ],
+            "sources": {
+                "inflow": {
+                    "endpoint": "/v1/metrics/transactions/transfers_volume_to_exchanges_sum",
+                    "points": 1,
+                    "cached": True,
+                    "fetched_at": now,
+                    "cached_until": now,
+                }
+            },
+        }
+
+
 @pytest.mark.asyncio
 async def test_glassnode_onchain_route_returns_service_payload(monkeypatch) -> None:
     monkeypatch.setattr(onchain_metrics, "get_glassnode_service", lambda: FakeGlassnodeService())
@@ -49,6 +77,22 @@ async def test_glassnode_onchain_route_returns_service_payload(monkeypatch) -> N
 
     assert payload["asset"] == "BTC"
     assert payload["metrics"][0]["metric"] == "mvrv"
+
+
+@pytest.mark.asyncio
+async def test_glassnode_exchange_flows_route_returns_service_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_exchange_flow_service",
+        lambda: FakeExchangeFlowService(),
+    )
+
+    payload = await onchain_metrics.get_glassnode_exchange_flows(asset="BTC", window="7d")
+
+    assert payload["asset"] == "BTC"
+    assert payload["window"] == "7d"
+    assert payload["total"]["netflow"] == 60.0
+    assert payload["exchanges"][0]["exchange"] == "binance"
 
 
 @pytest.mark.asyncio
@@ -75,5 +119,33 @@ async def test_glassnode_onchain_route_maps_service_errors(
 
     with pytest.raises(HTTPException) as raised:
         await onchain_metrics.get_glassnode_onchain_metrics(asset="BTC")
+
+    assert raised.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "status_code"),
+    [
+        (ValueError("bad window"), 400),
+        (GlassnodeConfigError("missing key"), 503),
+        (GlassnodeRateLimitError("rate limited"), 429),
+    ],
+)
+async def test_glassnode_exchange_flows_route_maps_service_errors(
+    monkeypatch, exc: Exception, status_code: int
+) -> None:
+    class FailingExchangeFlowService:
+        async def fetch_exchange_flows(self, *_args, **_kwargs):
+            raise exc
+
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_exchange_flow_service",
+        lambda: FailingExchangeFlowService(),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await onchain_metrics.get_glassnode_exchange_flows(asset="BTC")
 
     assert raised.value.status_code == status_code

--- a/openspec/changes/collect-exchange-netflows/.openspec.yaml
+++ b/openspec/changes/collect-exchange-netflows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/collect-exchange-netflows/design.md
+++ b/openspec/changes/collect-exchange-netflows/design.md
@@ -1,0 +1,58 @@
+## Context
+
+O conector Glassnode atual já centraliza API key, cache e rate limit. A nova feature deve reaproveitar esse conector, evitando outro cliente HTTP e preservando o uso de `X-Api-Key`.
+
+## Decisions
+
+### Endpoints
+
+- `inflow`: `/v1/metrics/transactions/transfers_volume_to_exchanges_sum`
+- `outflow`: `/v1/metrics/transactions/transfers_volume_from_exchanges_sum`
+- `netflow`: `/v1/metrics/transactions/transfers_volume_exchanges_net`
+
+### Windows
+
+Janelas suportadas:
+
+- `24h`: 1 dia
+- `7d`: 7 dias
+- `30d`: 30 dias
+
+O serviço calcula `since`/`until` em Unix seconds a partir do relógio injetável do service. A chamada usa `i=24h` para manter granularidade diária e reduzir custo de API.
+
+### Agregação
+
+Cada endpoint retorna uma série temporal Glassnode. O valor `v` pode ser:
+
+- número: agregado total do provider;
+- objeto: quebra por exchange;
+- array: preservado pelo parser, mas ignorado para agregação numérica se não houver pares nomeados.
+
+A regra:
+
+- se `v` é objeto, somar cada chave como exchange ao longo da janela;
+- se `v` é número, somar no bucket `total`;
+- o total de cada métrica é a soma de todos os buckets de exchange quando existem exchanges, ou o bucket `total` quando o provider retorna escalar.
+
+Para cada exchange:
+
+- `inflow` vem do endpoint de entradas;
+- `outflow` vem do endpoint de saídas;
+- `netflow` usa endpoint de netflow quando disponível para a exchange;
+- se netflow por exchange não existir, é calculado como `inflow - outflow`.
+
+### API
+
+`GET /api/onchain/glassnode/{asset}/exchange-flows?window=24h|7d|30d`
+
+Retorna:
+
+- `asset`
+- `window`
+- `interval`
+- `since`
+- `until`
+- `cached`
+- `total`
+- `exchanges`
+- `sources`

--- a/openspec/changes/collect-exchange-netflows/proposal.md
+++ b/openspec/changes/collect-exchange-netflows/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+O sistema já consegue consultar métricas on-chain da Glassnode, mas ainda não entrega exchange flows em uma forma pronta para decisão: inflow, outflow e netflow precisam ser agregados por exchange e também em total para janelas operacionais padronizadas.
+
+## What Changes
+
+- Coletar exchange inflow, outflow e netflow via Glassnode.
+- Agregar valores por exchange quando o payload do provider vier quebrado por exchange.
+- Agregar total da janela para inflow, outflow e netflow.
+- Suportar janelas `24h`, `7d` e `30d`.
+- Expor endpoint backend para consulta dos flows por asset e janela.
+
+## Capabilities
+
+### New Capabilities
+- `exchange-netflows`: Normaliza e agrega exchange flows por exchange e total.
+
+### Modified Capabilities
+- `glassnode-onchain-connector`: Expande o conector Glassnode para coletar flows de exchanges.
+
+## Impact
+
+- Backend: extensão do `GlassnodeService` e da rota `/api/onchain`.
+- Testes: cobertura unitária para janelas, inflow/outflow/netflow, agregação por exchange, fallback total e rota.
+- Sem migração de banco; entrega cache-only usando o conector Glassnode existente.

--- a/openspec/changes/collect-exchange-netflows/specs/exchange-netflows/spec.md
+++ b/openspec/changes/collect-exchange-netflows/specs/exchange-netflows/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Exchange flows include inflow and outflow
+The system SHALL collect exchange inflow and outflow volumes for supported assets.
+
+#### Scenario: Inflow and outflow collected
+- **WHEN** exchange flows are requested for an asset
+- **THEN** the system SHALL fetch inflow from `transfers_volume_to_exchanges_sum`
+- **AND** outflow from `transfers_volume_from_exchanges_sum`.
+
+### Requirement: Exchange flows include netflow
+The system SHALL collect or derive netflow for exchange flows.
+
+#### Scenario: Netflow collected
+- **WHEN** exchange flows are requested for an asset
+- **THEN** the system SHALL fetch netflow from `transfers_volume_exchanges_net`.
+
+#### Scenario: Per-exchange netflow fallback
+- **GIVEN** per-exchange inflow and outflow exist
+- **AND** per-exchange netflow is missing for an exchange
+- **WHEN** exchange flows are aggregated
+- **THEN** netflow for that exchange SHALL equal `inflow - outflow`.
+
+### Requirement: Exchange flows aggregate by exchange and total
+The system SHALL return exchange flow aggregation by exchange and total.
+
+#### Scenario: Object payload aggregates exchanges
+- **GIVEN** Glassnode returns object values keyed by exchange
+- **WHEN** the system aggregates the window
+- **THEN** each exchange SHALL have inflow, outflow, and netflow totals
+- **AND** the response SHALL include overall totals.
+
+#### Scenario: Scalar payload aggregates total
+- **GIVEN** Glassnode returns scalar values
+- **WHEN** the system aggregates the window
+- **THEN** the scalar values SHALL be aggregated into the overall total.
+
+### Requirement: Exchange flows support operational windows
+The system SHALL support `24h`, `7d`, and `30d` windows.
+
+#### Scenario: Supported window requested
+- **WHEN** `window=7d` is requested
+- **THEN** the service SHALL request data from the last seven days.
+
+#### Scenario: Unsupported window rejected
+- **WHEN** an unsupported window is requested
+- **THEN** the API SHALL return a validation error.

--- a/openspec/changes/collect-exchange-netflows/tasks.md
+++ b/openspec/changes/collect-exchange-netflows/tasks.md
@@ -1,0 +1,24 @@
+## 1. OpenSpec And Contract
+
+- [x] 1.1 Create proposal, design, spec delta, and tasks.
+- [x] 1.2 Define supported windows, endpoints, and aggregation rules.
+
+## 2. Backend Service
+
+- [x] 2.1 Add Glassnode exchange flow endpoint mapping.
+- [x] 2.2 Implement `24h`, `7d`, and `30d` window resolution.
+- [x] 2.3 Aggregate inflow, outflow, and netflow by exchange.
+- [x] 2.4 Aggregate inflow, outflow, and netflow totals.
+- [x] 2.5 Preserve API key, rate-limit, and cache behavior from the existing connector.
+
+## 3. API Surface
+
+- [x] 3.1 Add endpoint to fetch exchange flows by asset/window.
+- [x] 3.2 Map provider/config/rate-limit errors to existing HTTP statuses.
+
+## 4. Validation
+
+- [x] 4.1 Add unit tests for object payload aggregation by exchange.
+- [x] 4.2 Add unit tests for scalar total fallback.
+- [x] 4.3 Add route tests for supported windows and error mapping.
+- [x] 4.4 Run OpenSpec validation and backend/frontend checks.


### PR DESCRIPTION
## Summary
- Add Glassnode exchange flow endpoint mappings for inflow, outflow, and netflow.
- Add ExchangeFlowService to aggregate by exchange and total for 24h, 7d, and 30d windows.
- Add /api/onchain/glassnode/{asset}/exchange-flows route.
- Add OpenSpec artifacts and unit tests for object exchange payloads, scalar total fallback, window validation, and route error mapping.

## Validation
- openspec validate collect-exchange-netflows --strict
- ./backend/.venv/bin/python -m pytest backend/tests/unit/test_glassnode_service.py backend/tests/unit/test_onchain_exchange_flow_service.py backend/tests/unit/test_onchain_metrics_route.py -q
- ./backend/.venv/bin/python -m black --check backend
- ./backend/.venv/bin/python -m pytest -q
- npm --prefix frontend run build

## Notes
- Uses existing Glassnode API key/header, cache, and rate limiter.
- No database migration; this delivery remains cache-only.