### PR TITLE
feat: collect mining network metrics

### DIFF
--- a/backend/app/routes/onchain_metrics.py
+++ b/backend/app/routes/onchain_metrics.py
@@ -13,6 +13,7 @@ from app.services.glassnode_service import (
     get_glassnode_service,
 )
 from app.services.onchain_exchange_flow_service import get_exchange_flow_service
+from app.services.onchain_mining_metric_service import get_mining_metric_service
 
 router = APIRouter(prefix="/api/onchain", tags=["onchain"])
 
@@ -63,6 +64,36 @@ class ExchangeFlowsResponse(BaseModel):
     sources: dict[str, ExchangeFlowSourcePayload]
 
 
+class MiningMetricAlertPayload(BaseModel):
+    type: str
+    threshold_pct: float
+    drop_pct_vs_ma_7d: float | None
+
+
+class MiningMetricPayload(BaseModel):
+    metric: str
+    asset: str
+    interval: str
+    endpoint: str
+    points: list[dict[str, Any]]
+    latest: dict[str, Any] | None
+    ath: dict[str, Any] | None
+    drop_pct_vs_ma_7d: float | None
+    alerts: list[MiningMetricAlertPayload]
+    fetched_at: datetime
+    cached_until: datetime
+    cached: bool
+
+
+class MiningMetricsResponse(BaseModel):
+    asset: str
+    interval: str
+    since: int | None
+    until: int | None
+    cached: bool
+    metrics: list[MiningMetricPayload]
+
+
 @router.get("/glassnode/{asset}", response_model=GlassnodeMetricsResponse)
 async def get_glassnode_onchain_metrics(
     asset: str,
@@ -72,6 +103,29 @@ async def get_glassnode_onchain_metrics(
 ):
     try:
         payload = await get_glassnode_service().fetch_metrics(
+            asset,
+            interval=interval,
+            since=since,
+            until=until,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except GlassnodeConfigError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))
+    except GlassnodeRateLimitError as exc:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc))
+    return payload
+
+
+@router.get("/glassnode/{asset}/mining-metrics", response_model=MiningMetricsResponse)
+async def get_glassnode_mining_metrics(
+    asset: str,
+    interval: str = Query(default=DEFAULT_GLASSNODE_INTERVAL, pattern="^24h$"),
+    since: int | None = Query(default=None, ge=0),
+    until: int | None = Query(default=None, ge=0),
+):
+    try:
+        payload = await get_mining_metric_service().fetch_mining_metrics(
             asset,
             interval=interval,
             since=since,

--- a/backend/app/services/glassnode_service.py
+++ b/backend/app/services/glassnode_service.py
@@ -24,6 +24,11 @@ GLASSNODE_EXCHANGE_FLOW_METRICS: dict[str, str] = {
     "outflow": "/v1/metrics/transactions/transfers_volume_from_exchanges_sum",
     "netflow": "/v1/metrics/transactions/transfers_volume_exchanges_net",
 }
+GLASSNODE_MINING_METRICS: dict[str, str] = {
+    "hash_rate": "/v1/metrics/mining/hash_rate_mean",
+    "difficulty": "/v1/metrics/mining/difficulty_latest",
+    "miner_revenue_total": "/v1/metrics/mining/revenue_sum",
+}
 
 
 class GlassnodeConfigError(RuntimeError):
@@ -246,16 +251,21 @@ class GlassnodeService:
         if (
             normalized not in GLASSNODE_METRICS
             and normalized not in GLASSNODE_EXCHANGE_FLOW_METRICS
+            and normalized not in GLASSNODE_MINING_METRICS
         ):
-            supported = ", ".join(
-                sorted((*GLASSNODE_METRICS.keys(), *GLASSNODE_EXCHANGE_FLOW_METRICS.keys()))
+            metric_names = (
+                *GLASSNODE_METRICS.keys(),
+                *GLASSNODE_EXCHANGE_FLOW_METRICS.keys(),
+                *GLASSNODE_MINING_METRICS.keys(),
             )
+            supported = ", ".join(sorted(metric_names))
             raise ValueError(f"Unsupported Glassnode metric '{metric}'. Supported: {supported}")
         return normalized
 
     @staticmethod
     def _metric_endpoint(metric: str) -> str:
-        return GLASSNODE_METRICS.get(metric) or GLASSNODE_EXCHANGE_FLOW_METRICS[metric]
+        endpoint = GLASSNODE_METRICS.get(metric) or GLASSNODE_EXCHANGE_FLOW_METRICS.get(metric)
+        return endpoint or GLASSNODE_MINING_METRICS[metric]
 
     @staticmethod
     def _normalize_asset(asset: str) -> str:

--- a/backend/app/services/onchain_mining_metric_service.py
+++ b/backend/app/services/onchain_mining_metric_service.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from app.services.glassnode_service import (
+    DEFAULT_GLASSNODE_INTERVAL,
+    GLASSNODE_MINING_METRICS,
+    GlassnodeMetricSeries,
+    get_glassnode_service,
+)
+
+SHARP_DROP_THRESHOLD_PCT = 10.0
+SHARP_DROP_RATIO = 1.0 - (SHARP_DROP_THRESHOLD_PCT / 100.0)
+MOVING_AVERAGE_WINDOWS = (7, 30)
+SUPPORTED_MINING_METRIC_INTERVAL = DEFAULT_GLASSNODE_INTERVAL
+
+
+class MiningMetricService:
+    def __init__(self, *, glassnode_service=None) -> None:
+        self._glassnode_service = glassnode_service or get_glassnode_service()
+
+    async def fetch_mining_metrics(
+        self,
+        asset: str,
+        *,
+        interval: str = DEFAULT_GLASSNODE_INTERVAL,
+        since: int | None = None,
+        until: int | None = None,
+    ) -> dict[str, Any]:
+        normalized_interval = normalize_mining_metric_interval(interval)
+        metric_rows: dict[str, GlassnodeMetricSeries] = {}
+        for metric in GLASSNODE_MINING_METRICS:
+            metric_rows[metric] = await self._glassnode_service.fetch_metric(
+                metric,
+                asset,
+                interval=normalized_interval,
+                since=since,
+                until=until,
+            )
+
+        normalized_asset = self._glassnode_service._normalize_asset(asset)
+        return {
+            "asset": normalized_asset,
+            "interval": normalized_interval,
+            "since": since,
+            "until": until,
+            "cached": all(series.cached for series in metric_rows.values()),
+            "metrics": [enrich_mining_metric_series(series) for series in metric_rows.values()],
+        }
+
+
+def normalize_mining_metric_interval(interval: str) -> str:
+    normalized = str(interval or "").strip().lower()
+    if normalized != SUPPORTED_MINING_METRIC_INTERVAL:
+        raise ValueError(
+            "Unsupported mining metric interval "
+            f"'{interval}'. Supported: {SUPPORTED_MINING_METRIC_INTERVAL}"
+        )
+    return normalized
+
+
+def enrich_mining_metric_series(series: GlassnodeMetricSeries) -> dict[str, Any]:
+    enriched_points = _enrich_points(series.points)
+    latest = enriched_points[-1] if enriched_points else None
+    ath = _ath_from_points(enriched_points)
+    drop_pct_vs_ma_7d = _drop_pct_vs_ma_7d(latest)
+    alerts = _alerts_for_latest(latest, drop_pct_vs_ma_7d)
+
+    return {
+        "metric": series.metric,
+        "asset": series.asset,
+        "interval": series.interval,
+        "endpoint": series.endpoint,
+        "points": enriched_points,
+        "latest": latest,
+        "ath": ath,
+        "drop_pct_vs_ma_7d": drop_pct_vs_ma_7d,
+        "alerts": alerts,
+        "fetched_at": series.fetched_at,
+        "cached_until": series.cached_until,
+        "cached": series.cached,
+    }
+
+
+def _enrich_points(points: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    numeric_values: list[float] = []
+    ath_value: float | None = None
+    enriched: list[dict[str, Any]] = []
+
+    for point in sorted(points, key=_point_sort_key):
+        row = dict(point)
+        value = _numeric_or_none(row.get("v"))
+        if value is not None:
+            numeric_values.append(value)
+            if ath_value is None or value > ath_value:
+                ath_value = value
+            row["distance_from_ath_pct"] = _distance_from_ath_pct(value, ath_value)
+            for window in MOVING_AVERAGE_WINDOWS:
+                if len(numeric_values) >= window:
+                    row[f"ma_{window}d"] = _moving_average(numeric_values, window)
+        enriched.append(row)
+
+    return enriched
+
+
+def _ath_from_points(points: list[dict[str, Any]]) -> dict[str, Any] | None:
+    ath: dict[str, Any] | None = None
+    for point in points:
+        value = _numeric_or_none(point.get("v"))
+        if value is None:
+            continue
+        if ath is None or value > ath["v"]:
+            ath = {"t": point.get("t"), "v": value}
+    return ath
+
+
+def _drop_pct_vs_ma_7d(latest: dict[str, Any] | None) -> float | None:
+    if latest is None:
+        return None
+    latest_value = _numeric_or_none(latest.get("v"))
+    ma_7d = _numeric_or_none(latest.get("ma_7d"))
+    if latest_value is None or ma_7d is None or ma_7d == 0:
+        return None
+    return ((ma_7d - latest_value) / ma_7d) * 100.0
+
+
+def _alerts_for_latest(
+    latest: dict[str, Any] | None,
+    drop_pct_vs_ma_7d: float | None,
+) -> list[dict[str, Any]]:
+    latest_value = _numeric_or_none((latest or {}).get("v"))
+    ma_7d = _numeric_or_none((latest or {}).get("ma_7d"))
+    if latest_value is None or ma_7d is None:
+        return []
+    if latest_value >= ma_7d * SHARP_DROP_RATIO:
+        return []
+    return [
+        {
+            "type": "sharp_drop",
+            "threshold_pct": SHARP_DROP_THRESHOLD_PCT,
+            "drop_pct_vs_ma_7d": drop_pct_vs_ma_7d,
+        }
+    ]
+
+
+def _moving_average(values: list[float], window: int) -> float:
+    return sum(values[-window:]) / float(window)
+
+
+def _distance_from_ath_pct(value: float, ath_value: float | None) -> float | None:
+    if ath_value is None:
+        return None
+    if ath_value == 0:
+        return 0.0 if value == 0 else None
+    return ((value - ath_value) / ath_value) * 100.0
+
+
+def _point_sort_key(point: dict[str, Any]) -> tuple[int, float]:
+    timestamp = _numeric_or_none(point.get("t"))
+    if timestamp is None:
+        return (1, math.inf)
+    return (0, timestamp)
+
+
+def _numeric_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+_SERVICE: MiningMetricService | None = None
+
+
+def get_mining_metric_service() -> MiningMetricService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = MiningMetricService()
+    return _SERVICE

--- a/backend/tests/unit/test_glassnode_service.py
+++ b/backend/tests/unit/test_glassnode_service.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from app.services.glassnode_service import (
+    GLASSNODE_MINING_METRICS,
     GLASSNODE_METRICS,
     GlassnodeConfigError,
     GlassnodeRateLimitError,
@@ -145,6 +146,24 @@ def test_unsupported_asset_and_metric_are_rejected() -> None:
 
     with pytest.raises(ValueError, match="Unsupported Glassnode metric"):
         service._normalize_metric("foo")
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_supports_mining_metric_endpoints() -> None:
+    client = FakeGlassnodeClient()
+    service = GlassnodeService(api_key="secret", client=client, rate_limit_per_minute=0)
+
+    result = await service.fetch_metric("hash_rate", "BTC", since=1, until=2)
+
+    assert result.metric == "hash_rate"
+    assert result.endpoint == GLASSNODE_MINING_METRICS["hash_rate"]
+    assert client.calls == [
+        {
+            "url": "https://api.glassnode.com/v1/metrics/mining/hash_rate_mean",
+            "params": {"a": "BTC", "i": "24h", "f": "json", "s": 1, "u": 2},
+            "headers": {"X-Api-Key": "secret"},
+        }
+    ]
 
 
 def test_normalize_points_preserves_glassnode_value_shapes() -> None:

--- a/backend/tests/unit/test_onchain_metrics_route.py
+++ b/backend/tests/unit/test_onchain_metrics_route.py
@@ -64,6 +64,44 @@ class FakeExchangeFlowService:
         }
 
 
+class FakeMiningMetricService:
+    async def fetch_mining_metrics(
+        self,
+        asset: str,
+        interval: str,
+        since: int | None,
+        until: int | None,
+    ):
+        assert asset == "BTC"
+        assert interval == "24h"
+        assert since == 1
+        assert until == 2
+        now = datetime(2026, 4, 27, tzinfo=timezone.utc)
+        return {
+            "asset": "BTC",
+            "interval": "24h",
+            "since": 1,
+            "until": 2,
+            "cached": False,
+            "metrics": [
+                {
+                    "metric": "hash_rate",
+                    "asset": "BTC",
+                    "interval": "24h",
+                    "endpoint": "/v1/metrics/mining/hash_rate_mean",
+                    "points": [{"t": 1, "v": 100.0}],
+                    "latest": {"t": 1, "v": 100.0},
+                    "ath": {"t": 1, "v": 100.0},
+                    "drop_pct_vs_ma_7d": None,
+                    "alerts": [],
+                    "fetched_at": now,
+                    "cached_until": now,
+                    "cached": False,
+                }
+            ],
+        }
+
+
 @pytest.mark.asyncio
 async def test_glassnode_onchain_route_returns_service_payload(monkeypatch) -> None:
     monkeypatch.setattr(onchain_metrics, "get_glassnode_service", lambda: FakeGlassnodeService())
@@ -96,6 +134,44 @@ async def test_glassnode_exchange_flows_route_returns_service_payload(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_glassnode_mining_metrics_route_returns_service_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_mining_metric_service",
+        lambda: FakeMiningMetricService(),
+    )
+
+    payload = await onchain_metrics.get_glassnode_mining_metrics(
+        asset="BTC",
+        interval="24h",
+        since=1,
+        until=2,
+    )
+
+    assert payload["asset"] == "BTC"
+    assert payload["metrics"][0]["metric"] == "hash_rate"
+    assert payload["metrics"][0]["ath"] == {"t": 1, "v": 100.0}
+
+
+@pytest.mark.asyncio
+async def test_glassnode_mining_metrics_route_rejects_non_daily_interval(monkeypatch) -> None:
+    class RejectingMiningMetricService:
+        async def fetch_mining_metrics(self, *_args, **_kwargs):
+            raise ValueError("Unsupported mining metric interval '1h'. Supported: 24h")
+
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_mining_metric_service",
+        lambda: RejectingMiningMetricService(),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await onchain_metrics.get_glassnode_mining_metrics(asset="BTC", interval="1h")
+
+    assert raised.value.status_code == 400
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("exc", "status_code"),
     [
@@ -119,6 +195,34 @@ async def test_glassnode_onchain_route_maps_service_errors(
 
     with pytest.raises(HTTPException) as raised:
         await onchain_metrics.get_glassnode_onchain_metrics(asset="BTC")
+
+    assert raised.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "status_code"),
+    [
+        (ValueError("bad asset"), 400),
+        (GlassnodeConfigError("missing key"), 503),
+        (GlassnodeRateLimitError("rate limited"), 429),
+    ],
+)
+async def test_glassnode_mining_metrics_route_maps_service_errors(
+    monkeypatch, exc: Exception, status_code: int
+) -> None:
+    class FailingMiningMetricService:
+        async def fetch_mining_metrics(self, *_args, **_kwargs):
+            raise exc
+
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_mining_metric_service",
+        lambda: FailingMiningMetricService(),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await onchain_metrics.get_glassnode_mining_metrics(asset="BTC")
 
     assert raised.value.status_code == status_code
 

--- a/backend/tests/unit/test_onchain_mining_metric_service.py
+++ b/backend/tests/unit/test_onchain_mining_metric_service.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services.glassnode_service import GlassnodeMetricSeries
+from app.services.onchain_mining_metric_service import (
+    MiningMetricService,
+    enrich_mining_metric_series,
+    normalize_mining_metric_interval,
+)
+
+
+def _series(metric: str, values: list[object], *, cached: bool = False) -> GlassnodeMetricSeries:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
+    return GlassnodeMetricSeries(
+        metric=metric,
+        asset="BTC",
+        interval="24h",
+        endpoint=f"/v1/metrics/mining/{metric}",
+        points=[{"t": index + 1, "v": value} for index, value in enumerate(values)],
+        fetched_at=now,
+        cached_until=now,
+        cached=cached,
+    )
+
+
+def test_mining_metric_enrichment_sorts_points_and_calculates_ma_and_ath() -> None:
+    raw_points = [{"t": timestamp, "v": float(timestamp)} for timestamp in range(30, 0, -1)]
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
+    series = GlassnodeMetricSeries(
+        metric="hash_rate",
+        asset="BTC",
+        interval="24h",
+        endpoint="/v1/metrics/mining/hash_rate_mean",
+        points=raw_points,
+        fetched_at=now,
+        cached_until=now,
+        cached=False,
+    )
+
+    payload = enrich_mining_metric_series(series)
+
+    assert [point["t"] for point in payload["points"]] == list(range(1, 31))
+    assert payload["latest"]["v"] == 30.0
+    assert payload["latest"]["ma_7d"] == pytest.approx(27.0)
+    assert payload["latest"]["ma_30d"] == pytest.approx(15.5)
+    assert payload["latest"]["distance_from_ath_pct"] == pytest.approx(0.0)
+    assert payload["ath"] == {"t": 30, "v": 30.0}
+    assert payload["alerts"] == []
+
+
+def test_mining_metric_enrichment_alerts_on_more_than_10_percent_drop() -> None:
+    payload = enrich_mining_metric_series(
+        _series("difficulty", [100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 80.0])
+    )
+
+    assert payload["latest"]["ma_7d"] == pytest.approx(97.14285714285714)
+    assert payload["drop_pct_vs_ma_7d"] == pytest.approx(17.647058823529413)
+    assert payload["alerts"] == [
+        {
+            "type": "sharp_drop",
+            "threshold_pct": 10.0,
+            "drop_pct_vs_ma_7d": pytest.approx(17.647058823529413),
+        }
+    ]
+
+
+def test_mining_metric_enrichment_does_not_alert_at_exact_10_percent_boundary() -> None:
+    boundary_latest = 540.0 / 6.1
+    payload = enrich_mining_metric_series(
+        _series(
+            "hash_rate",
+            [100.0, 100.0, 100.0, 100.0, 100.0, 100.0, boundary_latest],
+        )
+    )
+
+    assert payload["drop_pct_vs_ma_7d"] == pytest.approx(10.0)
+    assert payload["alerts"] == []
+
+
+def test_mining_metric_enrichment_ignores_non_numeric_values_without_crashing() -> None:
+    payload = enrich_mining_metric_series(
+        _series("miner_revenue_total", ["bad", float("nan"), 10.0, None])
+    )
+
+    assert payload["ath"] == {"t": 3, "v": 10.0}
+    assert "ma_7d" not in payload["points"][2]
+    assert payload["latest"] == {"t": 4, "v": None}
+    assert payload["drop_pct_vs_ma_7d"] is None
+    assert payload["alerts"] == []
+
+
+def test_mining_metric_enrichment_handles_empty_series() -> None:
+    payload = enrich_mining_metric_series(_series("hash_rate", []))
+
+    assert payload["points"] == []
+    assert payload["latest"] is None
+    assert payload["ath"] is None
+    assert payload["drop_pct_vs_ma_7d"] is None
+    assert payload["alerts"] == []
+
+
+def test_mining_metric_interval_is_daily_only() -> None:
+    assert normalize_mining_metric_interval("24H") == "24h"
+    with pytest.raises(ValueError, match="Unsupported mining metric interval"):
+        normalize_mining_metric_interval("1h")
+
+
+class FakeGlassnodeService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def fetch_metric(
+        self,
+        metric: str,
+        asset: str,
+        interval: str,
+        since: int | None,
+        until: int | None,
+    ):
+        self.calls.append(
+            {
+                "metric": metric,
+                "asset": asset,
+                "interval": interval,
+                "since": since,
+                "until": until,
+            }
+        )
+        return _series(metric, [1.0, 2.0, 3.0], cached=True)
+
+    def _normalize_asset(self, asset: str) -> str:
+        return asset.upper()
+
+
+@pytest.mark.asyncio
+async def test_mining_metric_service_fetches_required_glassnode_metrics() -> None:
+    fake_glassnode = FakeGlassnodeService()
+    service = MiningMetricService(glassnode_service=fake_glassnode)
+
+    payload = await service.fetch_mining_metrics("btc", since=1, until=2)
+
+    assert payload["asset"] == "BTC"
+    assert payload["interval"] == "24h"
+    assert payload["since"] == 1
+    assert payload["until"] == 2
+    assert payload["cached"] is True
+    assert [call["metric"] for call in fake_glassnode.calls] == [
+        "hash_rate",
+        "difficulty",
+        "miner_revenue_total",
+    ]
+    assert {metric["metric"] for metric in payload["metrics"]} == {
+        "hash_rate",
+        "difficulty",
+        "miner_revenue_total",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mining_metric_service_rejects_non_daily_interval_before_provider_call() -> None:
+    fake_glassnode = FakeGlassnodeService()
+    service = MiningMetricService(glassnode_service=fake_glassnode)
+
+    with pytest.raises(ValueError, match="Unsupported mining metric interval"):
+        await service.fetch_mining_metrics("btc", interval="1h")
+
+    assert fake_glassnode.calls == []

--- a/openspec/changes/collect-mining-network-metrics/.openspec.yaml
+++ b/openspec/changes/collect-mining-network-metrics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/collect-mining-network-metrics/design.md
+++ b/openspec/changes/collect-mining-network-metrics/design.md
@@ -1,0 +1,103 @@
+## Context
+
+O conector Glassnode existente já centraliza API key, cache, normalização básica de pontos, rate limit e erros de provider. Métricas de mineração entram na mesma família on-chain, mas as regras de média móvel, ATH e alerta são lógica de domínio e não devem ficar no cliente HTTP.
+
+Os endpoints de mineração usados nesta entrega foram conferidos na documentação da Glassnode:
+
+- `difficulty`: `/v1/metrics/mining/difficulty_latest`
+- `hash_rate`: `/v1/metrics/mining/hash_rate_mean`
+- `miner_revenue_total`: `/v1/metrics/mining/revenue_sum`
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Coletar hash rate, difficulty e receita total de mineração para assets suportados pelo conector.
+- Calcular média móvel trailing de 7 e 30 pontos diários por métrica.
+- Rastrear ATH por métrica dentro da série retornada pela consulta.
+- Emitir alerta quando o valor mais recente ficar mais de 10% abaixo da média móvel de 7d.
+- Reaproveitar cache, rate limit, API key e tratamento de erros do conector Glassnode.
+
+**Non-Goals:**
+
+- Persistir métricas de mineração em banco.
+- Criar UI para essas métricas.
+- Criar alertas assíncronos/notificações push.
+- Adicionar métricas por pool/miner individual.
+
+## Decisions
+
+### Separar conector e agregação
+
+`backend/app/services/glassnode_service.py` recebe apenas o mapping dos novos endpoints. A agregação fica em `backend/app/services/onchain_mining_metric_service.py`, seguindo o padrão já aplicado para exchange flows.
+
+Alternativa considerada: adicionar cálculo direto em `GlassnodeService.fetch_metrics`. Rejeitada porque misturaria regra de negócio com fetch/cache/rate-limit.
+
+### Contrato de rota
+
+Nova rota:
+
+`GET /api/onchain/glassnode/{asset}/mining-metrics`
+
+Query params:
+
+- `interval`: fixed/default `24h`
+- `since`: Unix timestamp opcional
+- `until`: Unix timestamp opcional
+
+Sem `since`, o provider pode retornar o histórico disponível; nesse caso o ATH é calculado sobre a série retornada. Com `since`, o ATH fica escopado à janela solicitada.
+
+Resposta:
+
+- `asset`
+- `interval`
+- `since`
+- `until`
+- `cached`
+- `metrics`: lista com `metric`, `endpoint`, `points`, `latest`, `ath`, `alerts`, `fetched_at`, `cached_until`, `cached`
+
+Cada ponto numérico da série inclui:
+
+- `t`
+- `v`
+- `ma_7d`
+- `ma_30d`
+- `distance_from_ath_pct`
+
+### Regras numéricas
+
+Valores não numéricos, ausentes, infinitos ou NaN são ignorados no cálculo de médias e ATH. Eles podem permanecer na lista de pontos sem campos derivados.
+
+As médias móveis são trailing sobre pontos diários (`interval=24h`) e exigem janela completa:
+
+- `ma_7d`: só aparece quando há pelo menos 7 valores numéricos até o ponto.
+- `ma_30d`: só aparece quando há pelo menos 30 valores numéricos até o ponto.
+
+O alerta `sharp_drop` é emitido apenas quando `latest.v` e `latest.ma_7d` existem e:
+
+`latest.v < latest.ma_7d * 0.9`
+
+### Métricas iniciais
+
+O set inicial fica pequeno para controlar custo de API:
+
+- `hash_rate`
+- `difficulty`
+- `miner_revenue_total`
+
+Novas métricas de mineração podem ser adicionadas depois apenas pelo mapping do conector e testes de contrato.
+
+## Risks / Trade-offs
+
+- [Risk] Consultas sem `since` podem retornar séries longas e consumir mais créditos/latência. -> Mitigation: manter cache existente e aceitar `since`/`until` para consultas operacionais menores.
+- [Risk] ATH sem persistência depende da série retornada pelo provider. -> Mitigation: declarar escopo no contrato e preservar `since`/`until` no payload.
+- [Risk] Algumas métricas Glassnode podem retornar payload não escalar. -> Mitigation: derivar MA/ATH/alerta apenas de valores numéricos finitos e preservar pontos brutos quando não forem numéricos.
+
+## Migration Plan
+
+1. Adicionar mappings de métricas de mineração no conector Glassnode.
+2. Implementar serviço de domínio para enriquecer séries com MA/ATH/alertas.
+3. Expor rota backend e modelos Pydantic.
+4. Cobrir agregação e rota com testes unitários.
+
+Rollback: remover a nova rota e o serviço de domínio. Como não há migração de banco, o rollback não exige alteração de dados.

--- a/openspec/changes/collect-mining-network-metrics/proposal.md
+++ b/openspec/changes/collect-mining-network-metrics/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+O sistema precisa acompanhar métricas estruturais de mineração para detectar pressão operacional na rede Bitcoin, separando sinais de infraestrutura de sinais puramente técnicos de preço.
+
+## What Changes
+
+- Coletar hash rate, difficulty e métricas de mineração a partir do conector Glassnode existente.
+- Expor médias móveis de 7d e 30d por métrica.
+- Rastrear ATH por métrica dentro da série retornada.
+- Emitir alerta quando o valor atual cair mais de 10% contra a média móvel de 7d.
+- Expor rota backend para consulta agregada por asset, mantendo cache/rate limit/API key do conector atual.
+
+## Capabilities
+
+### New Capabilities
+- `mining-network-metrics`: Coleta e agrega métricas de mineração com médias móveis, ATH e alerta de queda brusca.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Backend: novo serviço de domínio para agregação de métricas de mineração e nova rota em `onchain_metrics`.
+- Glassnode: novos mappings de endpoint para hash rate, difficulty e métrica de mineração.
+- Testes: cobertura unitária para médias móveis, ATH, alerta >10%, payload vazio e erro de provider/configuração.
+- OpenSpec: nova capability `mining-network-metrics` documentando contrato de API e regras de alerta.
+- Sem migração de banco nesta entrega.

--- a/openspec/changes/collect-mining-network-metrics/specs/mining-network-metrics/spec.md
+++ b/openspec/changes/collect-mining-network-metrics/specs/mining-network-metrics/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Mining metrics are collected from Glassnode
+The system SHALL collect mining network metrics for supported assets through the existing Glassnode connector.
+
+#### Scenario: Mining metrics requested
+- **WHEN** mining network metrics are requested for `BTC`
+- **THEN** the system SHALL fetch hash rate from `hash_rate_mean`
+- **AND** difficulty from `difficulty_latest`
+- **AND** total miner revenue from `revenue_sum`.
+
+### Requirement: Mining metrics expose moving averages
+The system SHALL calculate trailing 7d and 30d moving averages for each numeric daily mining metric series.
+
+#### Scenario: Full windows available
+- **GIVEN** a mining metric series contains at least 30 numeric daily points
+- **WHEN** the system enriches the series
+- **THEN** the latest point SHALL include `ma_7d`
+- **AND** `ma_30d`.
+
+#### Scenario: Insufficient windows available
+- **GIVEN** a mining metric series contains fewer than 7 numeric daily points
+- **WHEN** the system enriches the series
+- **THEN** moving average fields SHALL remain absent for those points
+- **AND** the response SHALL still be valid.
+
+#### Scenario: Non-daily interval rejected
+- **WHEN** mining network metrics are requested with an interval other than `24h`
+- **THEN** the system SHALL reject the request before calling Glassnode.
+
+### Requirement: Mining metrics track ATH
+The system SHALL track the all-time-high value within the fetched mining metric series.
+
+#### Scenario: ATH calculated
+- **GIVEN** a mining metric series contains numeric points
+- **WHEN** the system enriches the series
+- **THEN** the response SHALL include the maximum value and timestamp observed in that fetched series.
+
+### Requirement: Mining metrics alert on sharp drops
+The system SHALL emit a `sharp_drop` alert when the latest numeric value falls more than 10% below its 7d moving average.
+
+#### Scenario: Sharp drop detected
+- **GIVEN** a mining metric latest value is less than 90% of its 7d moving average
+- **WHEN** the system enriches the series
+- **THEN** the metric response SHALL include a `sharp_drop` alert
+- **AND** include the drop percentage versus the 7d moving average.
+
+#### Scenario: Boundary is not an alert
+- **GIVEN** a mining metric latest value is exactly 90% of its 7d moving average
+- **WHEN** the system enriches the series
+- **THEN** the metric response SHALL NOT include a `sharp_drop` alert.
+
+### Requirement: Mining metrics are exposed through API
+The system SHALL expose mining network metrics through the on-chain Glassnode API surface.
+
+#### Scenario: API returns mining metric payload
+- **WHEN** `GET /api/onchain/glassnode/BTC/mining-metrics` is requested
+- **THEN** the API SHALL return asset, interval, cached status, metric summaries, enriched points, ATH data, and alerts.
+
+#### Scenario: Provider errors are mapped
+- **WHEN** the mining metric service raises configuration, validation, or rate-limit errors
+- **THEN** the API SHALL map them to the same HTTP statuses used by the existing Glassnode routes.

--- a/openspec/changes/collect-mining-network-metrics/tasks.md
+++ b/openspec/changes/collect-mining-network-metrics/tasks.md
@@ -1,0 +1,31 @@
+## 1. OpenSpec And Contract
+
+- [x] 1.1 Create proposal, design, spec delta, and tasks.
+- [x] 1.2 Define mining metric endpoints, response contract, MA/ATH rules, and sharp-drop threshold.
+- [x] 1.3 Use relevant project skills and subagents for mapping, implementation validation, and review when applicable.
+
+## 2. Glassnode Connector
+
+- [x] 2.1 Add Glassnode mining metric endpoint mapping for hash rate, difficulty, and total miner revenue.
+- [x] 2.2 Preserve existing API key, cache, rate-limit, and provider error behavior.
+
+## 3. Backend Domain Service
+
+- [x] 3.1 Add mining network metric service using the existing Glassnode connector.
+- [x] 3.2 Sort and enrich numeric series points with 7d and 30d trailing moving averages.
+- [x] 3.3 Track ATH value/timestamp within the fetched series.
+- [x] 3.4 Emit `sharp_drop` alerts only when latest value is more than 10% below MA7.
+- [x] 3.5 Keep empty, insufficient, and non-numeric series valid without crashing.
+
+## 4. API Surface
+
+- [x] 4.1 Add `GET /api/onchain/glassnode/{asset}/mining-metrics`.
+- [x] 4.2 Return metric summaries, enriched points, ATH data, source metadata, and cached status.
+- [x] 4.3 Map validation/config/rate-limit errors to the existing Glassnode HTTP statuses.
+
+## 5. Validation
+
+- [x] 5.1 Add unit tests for moving averages, ATH, alert threshold, boundary behavior, and non-numeric payloads.
+- [x] 5.2 Add connector tests for mining endpoint mapping.
+- [x] 5.3 Add route tests for payload and error mapping.
+- [x] 5.4 Run OpenSpec validation and targeted backend tests.


### PR DESCRIPTION
## Summary
- Add OpenSpec change `collect-mining-network-metrics` with proposal, design, spec, and completed tasks.
- Add Glassnode mining metrics for hash rate, difficulty, and total miner revenue.
- Add `/api/onchain/glassnode/{asset}/mining-metrics` with daily MA7/MA30, ATH-in-series tracking, and `sharp_drop` alerts when latest value is more than 10% below MA7.
- Keep provider fetch/cache/rate-limit in `GlassnodeService`; domain aggregation lives in `onchain_mining_metric_service`.

## Validation
- `openspec validate collect-mining-network-metrics --type change --strict` ✅
- `./backend/.venv/bin/python -m pytest -q backend/tests/unit/test_glassnode_service.py backend/tests/unit/test_onchain_mining_metric_service.py backend/tests/unit/test_onchain_metrics_route.py` ✅ (`30 passed`)
- `./backend/.venv/bin/python -m black --check backend/app/services/glassnode_service.py backend/app/services/onchain_mining_metric_service.py backend/app/routes/onchain_metrics.py backend/tests/unit/test_glassnode_service.py backend/tests/unit/test_onchain_mining_metric_service.py backend/tests/unit/test_onchain_metrics_route.py` ✅
- `npm --prefix frontend run build` ✅
- Full local backend suite in the current working tree: ❌ one failure in `backend/tests/unit/test_background_services.py::test_news_localization_helpers_and_cache`, caused by pre-existing uncommitted local changes to `news_localization_service`/background-service tests that are not included in this PR.

## Notes
- Mining metrics intentionally accept only `interval=24h` so `ma_7d` and `ma_30d` are semantically daily windows.
- No database migration.
