### PR TITLE
refactor: remove MiniMax news localization

### DIFF
--- a/backend/app/routes/ai_dashboard.py
+++ b/backend/app/routes/ai_dashboard.py
@@ -127,7 +127,7 @@ def _relative_time(value: datetime) -> str:
 
 
 async def _fetch_coingecko_news() -> list[DashboardNewsItem]:
-    """Fetch real crypto news from CoinGecko without blocking on MiniMax localization."""
+    """Fetch real crypto news from CoinGecko without blocking on localization."""
     try:
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
             response = await client.get(f"{COINGECKO_NEWS_URL}?per_page=5&page=1")

--- a/backend/app/routes/system_preferences.py
+++ b/backend/app/routes/system_preferences.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.middleware.authMiddleware import get_current_admin
 from app.services.system_preferences_service import (
-    MINIMAX_API_KEY_KEY,
     SIGNAL_HISTORY_ALLOW_AGGRESSIVE_KEY,
     SIGNAL_HISTORY_ALLOW_BUY_KEY,
     SIGNAL_HISTORY_ALLOW_CONSERVATIVE_KEY,
@@ -19,14 +18,10 @@ from app.services.system_preferences_service import (
     SIGNAL_HISTORY_MIN_CONFIDENCE_KEY,
     SIGNAL_HISTORY_MIN_REWARD_RISK_KEY,
     SIGNAL_HISTORY_MIN_RSI_KEY,
-    delete_system_preference_value,
     get_system_preference_bool,
     get_system_preference_float,
     get_system_preference_int,
-    get_system_preference_value,
-    mask_secret,
     set_optional_system_preference_value,
-    set_system_preference_value,
 )
 
 router = APIRouter(prefix="/api/system/preferences", tags=["system-preferences"])
@@ -45,8 +40,6 @@ DEFAULT_SIGNAL_HISTORY_ALLOW_AGGRESSIVE = True
 
 
 class SystemPreferencesResponse(BaseModel):
-    minimax_api_key_configured: bool
-    minimax_api_key_masked: str | None = None
     signal_history_min_confidence: int
     signal_history_min_reward_risk: float
     signal_history_max_reward_risk: float
@@ -61,7 +54,6 @@ class SystemPreferencesResponse(BaseModel):
 
 
 class SystemPreferencesPayload(BaseModel):
-    minimax_api_key: str | None = Field(default=None, min_length=10, max_length=512)
     signal_history_min_confidence: int = Field(
         default=DEFAULT_SIGNAL_HISTORY_MIN_CONFIDENCE, ge=0, le=100
     )
@@ -86,10 +78,7 @@ class SystemPreferencesPayload(BaseModel):
 
 
 def _build_response(db: Session) -> SystemPreferencesResponse:
-    value = get_system_preference_value(db, MINIMAX_API_KEY_KEY)
     return SystemPreferencesResponse(
-        minimax_api_key_configured=bool(value),
-        minimax_api_key_masked=mask_secret(value),
         signal_history_min_confidence=get_system_preference_int(
             db,
             SIGNAL_HISTORY_MIN_CONFIDENCE_KEY,
@@ -162,13 +151,6 @@ def put_system_preferences(
     admin_user_id: str = Depends(get_current_admin),
     db: Session = Depends(get_db),
 ):
-    if payload.minimax_api_key is not None:
-        set_system_preference_value(
-            db,
-            key=MINIMAX_API_KEY_KEY,
-            value=payload.minimax_api_key,
-            updated_by_user_id=admin_user_id,
-        )
     set_optional_system_preference_value(
         db,
         key=SIGNAL_HISTORY_MIN_CONFIDENCE_KEY,
@@ -243,5 +225,4 @@ def delete_system_preferences(
     _admin_user_id: str = Depends(get_current_admin),
     db: Session = Depends(get_db),
 ):
-    delete_system_preference_value(db, key=MINIMAX_API_KEY_KEY)
     return {"message": "System preferences cleared"}

--- a/backend/app/services/news_localization_service.py
+++ b/backend/app/services/news_localization_service.py
@@ -1,23 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
-import re
 import time
 from typing import Any
 
-import httpx
-
-from app.database import SessionLocal
-from app.services.system_preferences_service import MINIMAX_API_KEY_KEY, get_system_preference_value
-
 logger = logging.getLogger(__name__)
 
-MINIMAX_BASE_URL = str(os.getenv("MINIMAX_BASE_URL") or "https://api.minimax.io/v1").rstrip("/")
-MINIMAX_MODEL = str(os.getenv("MINIMAX_MODEL") or "MiniMax-M2.7").strip()
-REQUEST_TIMEOUT_SECONDS = float(os.getenv("MINIMAX_TIMEOUT_SECONDS") or "45")
 LOCALIZATION_CACHE_TTL_SECONDS = float(os.getenv("AI_DASHBOARD_NEWS_CACHE_TTL_SECONDS") or "900")
 
 _LOCALIZATION_CACHE: dict[str, Any] = {
@@ -29,15 +19,6 @@ _CACHE_LOCK = asyncio.Lock()
 _REFRESH_TASK: asyncio.Task | None = None
 
 
-def _get_minimax_api_key() -> str:
-    db = SessionLocal()
-    try:
-        stored = get_system_preference_value(db, MINIMAX_API_KEY_KEY)
-    finally:
-        db.close()
-    return stored or str(os.getenv("MINIMAX_API_KEY") or "").strip()
-
-
 def _fallback_summary(title: str, source: str) -> str:
     normalized_title = str(title or "").strip()
     normalized_source = str(source or "").strip()
@@ -46,48 +27,6 @@ def _fallback_summary(title: str, source: str) -> str:
     if normalized_source:
         return f"Resumo automático indisponível. Fonte original: {normalized_source}."
     return "Resumo automático indisponível."
-
-
-def _extract_json_object(raw_content: str) -> str:
-    text = str(raw_content or "").strip()
-    if text.startswith("```"):
-        lines = text.splitlines()
-        if lines and lines[0].startswith("```"):
-            lines = lines[1:]
-        if lines and lines[-1].strip() == "```":
-            lines = lines[:-1]
-        text = "\n".join(lines).strip()
-    return text
-
-
-def _parse_localized_content(raw_content: str) -> tuple[str, str]:
-    text = _extract_json_object(raw_content)
-    if not text:
-        return "", ""
-
-    try:
-        parsed = json.loads(text)
-        return (
-            str(parsed.get("title_pt") or "").strip(),
-            str(parsed.get("summary_pt") or "").strip(),
-        )
-    except Exception:
-        pass
-
-    title_match = re.search(r"TITLE_PT:\s*(.+)", text, re.IGNORECASE)
-    summary_match = re.search(r"SUMMARY_PT:\s*(.+)", text, re.IGNORECASE | re.DOTALL)
-    if title_match or summary_match:
-        return (
-            str(title_match.group(1) if title_match else "").strip(),
-            str(summary_match.group(1) if summary_match else "").strip(),
-        )
-
-    lines = [line.strip(" -\t") for line in text.splitlines() if line.strip()]
-    if not lines:
-        return "", ""
-    if len(lines) == 1:
-        return "", lines[0]
-    return lines[0], " ".join(lines[1:])
 
 
 def _build_fingerprint(news_items: list[dict[str, Any]]) -> tuple[tuple[str, str], ...]:
@@ -149,140 +88,28 @@ def schedule_news_localization_refresh(news_items: list[dict[str, Any]]) -> None
         try:
             await _refresh_localized_news_cache(items)
         except Exception as exc:
-            logger.warning("MiniMax background refresh failed: %r", exc)
+            logger.warning("News localization cache refresh failed: %r", exc)
 
     try:
         _REFRESH_TASK = asyncio.create_task(_runner())
     except RuntimeError:
-        logger.debug("MiniMax background refresh skipped: no running event loop")
+        logger.debug("News localization cache refresh skipped: no running event loop")
 
 
 async def localize_news_items(news_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Translate titles and generate short Portuguese summaries using MiniMax when configured."""
+    """Return local news titles and fallback summaries without paid external services."""
 
     items = [item for item in news_items if isinstance(item, dict)]
     if not items:
         return []
 
-    minimax_api_key = _get_minimax_api_key()
-    if not minimax_api_key:
-        return [
-            {
-                "id": str(item.get("id") or ""),
-                "title_pt": str(item.get("title") or ""),
-                "summary_pt": _fallback_summary(
-                    str(item.get("title") or ""), str(item.get("source") or "")
-                ),
-            }
-            for item in items
-        ]
-
-    prompt = (
-        "Voce eh um editor financeiro em portugues do Brasil. "
-        "Traduza o titulo para portugues e escreva um resumo curto em portugues, "
-        "em no maximo 2 frases, sem inventar fatos e sem mencionar traducao. "
-        "Responda somente com duas linhas neste formato exato:\n"
-        "TITLE_PT: <titulo em portugues>\n"
-        "SUMMARY_PT: <resumo em portugues>"
-    )
-    retry_prompt = (
-        "Voce deve responder obrigatoriamente com exatamente duas linhas, sem markdown e sem cercas de codigo.\n"
-        "Linha 1: TITLE_PT: <titulo em portugues do Brasil>\n"
-        "Linha 2: SUMMARY_PT: <resumo em portugues do Brasil em ate 2 frases>\n"
-        "Nao deixe nenhum dos dois campos vazio e nao invente fatos."
-    )
-
-    async def _request_localization(
-        item_id: str,
-        title: str,
-        source: str,
-        sentiment: str,
-        related_asset: Any,
-        client: httpx.AsyncClient,
-        instruction: str,
-    ) -> tuple[str, str]:
-        body = {
-            "model": MINIMAX_MODEL,
-            "messages": [
-                {"role": "system", "content": instruction},
-                {
-                    "role": "user",
-                    "content": json.dumps(
-                        {
-                            "id": item_id,
-                            "title": title,
-                            "source": source,
-                            "sentiment": sentiment,
-                            "related_asset": related_asset,
-                        },
-                        ensure_ascii=False,
-                    ),
-                },
-            ],
-            "temperature": 0.1,
-            "max_tokens": 220,
+    return [
+        {
+            "id": str(item.get("id") or ""),
+            "title_pt": str(item.get("title") or ""),
+            "summary_pt": _fallback_summary(
+                str(item.get("title") or ""), str(item.get("source") or "")
+            ),
         }
-        response = await client.post(
-            f"{MINIMAX_BASE_URL}/text/chatcompletion_v2",
-            headers={
-                "Authorization": f"Bearer {minimax_api_key}",
-                "Content-Type": "application/json",
-            },
-            json=body,
-        )
-        response.raise_for_status()
-        payload = response.json()
-        candidates = payload.get("choices") or []
-        message = (candidates[0] or {}).get("message") or {}
-        content = message.get("content")
-        if isinstance(content, list):
-            text_parts = [str(part.get("text") or "") for part in content if isinstance(part, dict)]
-            content = "\n".join(part for part in text_parts if part)
-        return _parse_localized_content(str(content or ""))
-
-    async def _localize_one(item: dict[str, Any], client: httpx.AsyncClient) -> dict[str, str]:
-        item_id = str(item.get("id") or "")
-        title = str(item.get("title") or "")
-        source = str(item.get("source") or "")
-        sentiment = str(item.get("sentiment") or "")
-        related_asset = item.get("related_asset")
-
-        try:
-            parsed_title, parsed_summary = await _request_localization(
-                item_id=item_id,
-                title=title,
-                source=source,
-                sentiment=sentiment,
-                related_asset=related_asset,
-                client=client,
-                instruction=prompt,
-            )
-            if not parsed_title or not parsed_summary:
-                retry_title, retry_summary = await _request_localization(
-                    item_id=item_id,
-                    title=title,
-                    source=source,
-                    sentiment=sentiment,
-                    related_asset=related_asset,
-                    client=client,
-                    instruction=retry_prompt,
-                )
-                parsed_title = parsed_title or retry_title
-                parsed_summary = parsed_summary or retry_summary
-            return {
-                "id": item_id,
-                "title_pt": parsed_title or title,
-                "summary_pt": parsed_summary or _fallback_summary(title, source),
-            }
-        except Exception as exc:
-            logger.warning("MiniMax news localization failed for %s: %r", item_id, exc)
-            return {
-                "id": item_id,
-                "title_pt": title,
-                "summary_pt": _fallback_summary(title, source),
-            }
-
-    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
-        localized_items = await asyncio.gather(*[_localize_one(item, client) for item in items])
-
-    return localized_items
+        for item in items
+    ]

--- a/backend/app/services/system_preferences_service.py
+++ b/backend/app/services/system_preferences_service.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import Session
 
 from app.models import SystemPreference
 
-MINIMAX_API_KEY_KEY = "minimax_api_key"
 SIGNAL_HISTORY_MIN_CONFIDENCE_KEY = "signal_history_min_confidence"
 SIGNAL_HISTORY_MIN_REWARD_RISK_KEY = "signal_history_min_reward_risk"
 SIGNAL_HISTORY_MAX_REWARD_RISK_KEY = "signal_history_max_reward_risk"

--- a/backend/tests/integration/test_system_preferences_admin.py
+++ b/backend/tests/integration/test_system_preferences_admin.py
@@ -24,7 +24,6 @@ def test_admin_can_put_get_and_delete_system_preferences(tmp_path: Path):
     with SessionLocal() as db:
         created = system_preferences.put_system_preferences(
             system_preferences.SystemPreferencesPayload(
-                minimax_api_key="minimax-secret-key-12345",
                 signal_history_min_confidence=78,
                 signal_history_min_reward_risk=2.4,
                 signal_history_max_reward_risk=4.5,
@@ -44,8 +43,6 @@ def test_admin_can_put_get_and_delete_system_preferences(tmp_path: Path):
         deleted = system_preferences.delete_system_preferences(_admin_user_id="admin-user", db=db)
         empty = system_preferences.get_system_preferences(_admin_user_id="admin-user", db=db)
 
-    assert created.minimax_api_key_configured is True
-    assert created.minimax_api_key_masked is not None
     assert created.signal_history_min_confidence == 78
     assert created.signal_history_min_reward_risk == 2.4
     assert created.signal_history_max_reward_risk == 4.5
@@ -57,8 +54,6 @@ def test_admin_can_put_get_and_delete_system_preferences(tmp_path: Path):
     assert created.signal_history_allow_conservative is False
     assert created.signal_history_allow_moderate is True
     assert created.signal_history_allow_aggressive is True
-    assert status.minimax_api_key_configured is True
-    assert status.minimax_api_key_masked is not None
     assert status.signal_history_min_confidence == 78
     assert status.signal_history_min_reward_risk == 2.4
     assert status.signal_history_max_reward_risk == 4.5
@@ -71,8 +66,6 @@ def test_admin_can_put_get_and_delete_system_preferences(tmp_path: Path):
     assert status.signal_history_allow_moderate is True
     assert status.signal_history_allow_aggressive is True
     assert deleted["message"] == "System preferences cleared"
-    assert empty.minimax_api_key_configured is False
-    assert empty.minimax_api_key_masked is None
     assert empty.signal_history_min_confidence == 78
     assert empty.signal_history_min_reward_risk == 2.4
     assert empty.signal_history_max_reward_risk == 4.5

--- a/backend/tests/unit/test_background_services.py
+++ b/backend/tests/unit/test_background_services.py
@@ -350,43 +350,10 @@ def test_signal_monitor_loop_and_lifecycle(monkeypatch):
 
 
 def test_news_localization_helpers_and_cache(monkeypatch):
-    class FakeSession:
-        def close(self):
-            self.closed = True
-
-    monkeypatch.setattr(news_localization_service, "SessionLocal", lambda: FakeSession())
-    monkeypatch.setattr(
-        news_localization_service, "get_system_preference_value", lambda db, key: "stored-key"
-    )
-    assert news_localization_service._get_minimax_api_key() == "stored-key"
-
-    monkeypatch.setattr(
-        news_localization_service, "get_system_preference_value", lambda db, key: ""
-    )
-    monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
-    assert news_localization_service._get_minimax_api_key() == "env-key"
-
     assert news_localization_service._fallback_summary("", "") == "Resumo indisponível no momento."
     assert (
         news_localization_service._fallback_summary("Alta do BTC", "CoinDesk")
         == "Resumo automático indisponível. Fonte original: CoinDesk."
-    )
-    assert (
-        news_localization_service._extract_json_object('```json\n{"title_pt":"Oi"}\n```')
-        == '{"title_pt":"Oi"}'
-    )
-    assert news_localization_service._parse_localized_content(
-        '{"title_pt":"Titulo","summary_pt":"Resumo"}'
-    ) == (
-        "Titulo",
-        "Resumo",
-    )
-    assert news_localization_service._parse_localized_content(
-        "TITLE_PT: Titulo\nSUMMARY_PT: Resumo"
-    ) == ("Titulo", "Resumo")
-    assert news_localization_service._parse_localized_content("Titulo\nResumo 1\nResumo 2") == (
-        "Titulo",
-        "Resumo 1 Resumo 2",
     )
     assert news_localization_service._build_fingerprint(
         [{"id": 1, "title": "BTC"}, "skip", {"id": 2, "title": "ETH"}]
@@ -457,61 +424,19 @@ def test_news_localization_scheduler_branches(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_localize_news_items_handles_empty_fallback_retry_and_failure(monkeypatch):
+async def test_localize_news_items_handles_empty_fallback():
     assert await news_localization_service.localize_news_items([]) == []
 
     items = [
         {"id": "1", "title": "BTC up", "source": "CoinDesk"},
         {"id": "2", "title": "ETH down", "source": "The Block"},
-        {"id": "3", "title": "SOL flat", "source": "Decrypt"},
     ]
 
-    monkeypatch.setattr(news_localization_service, "_get_minimax_api_key", lambda: "")
-    fallback = await news_localization_service.localize_news_items(items)
-    assert fallback[0]["title_pt"] == "BTC up"
-    assert fallback[0]["summary_pt"].startswith("Resumo automático indisponível")
-
-    monkeypatch.setattr(news_localization_service, "_get_minimax_api_key", lambda: "minimax-key")
-
-    class FakeResponse:
-        def __init__(self, content):
-            self._content = content
-
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return {"choices": [{"message": {"content": self._content}}]}
-
-    attempts: dict[str, int] = {}
-
-    class FakeAsyncClient:
-        def __init__(self, timeout=None):
-            self.timeout = timeout
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def post(self, url, headers=None, json=None):
-            payload = json_module.loads(json["messages"][1]["content"])
-            item_id = payload["id"]
-            attempts[item_id] = attempts.get(item_id, 0) + 1
-            if item_id == "1":
-                return FakeResponse("TITLE_PT: BTC sobe\nSUMMARY_PT: Resumo BTC")
-            if item_id == "2" and attempts[item_id] == 1:
-                return FakeResponse("TITLE_PT: ETH cai")
-            if item_id == "2":
-                return FakeResponse("TITLE_PT: ETH cai\nSUMMARY_PT: Resumo ETH")
-            raise RuntimeError("provider unavailable")
-
-    json_module = json
-    monkeypatch.setattr(news_localization_service.httpx, "AsyncClient", FakeAsyncClient)
     localized = await news_localization_service.localize_news_items(items)
 
-    assert localized[0] == {"id": "1", "title_pt": "BTC sobe", "summary_pt": "Resumo BTC"}
-    assert localized[1] == {"id": "2", "title_pt": "ETH cai", "summary_pt": "Resumo ETH"}
-    assert localized[2]["title_pt"] == "SOL flat"
-    assert localized[2]["summary_pt"].startswith("Resumo automático indisponível")
+    assert localized[0]["title_pt"] == "BTC up"
+    assert localized[0]["summary_pt"] == "Resumo automático indisponível. Fonte original: CoinDesk."
+    assert localized[1]["title_pt"] == "ETH down"
+    assert (
+        localized[1]["summary_pt"] == "Resumo automático indisponível. Fonte original: The Block."
+    )

--- a/frontend/src/pages/SystemPreferencesPage.tsx
+++ b/frontend/src/pages/SystemPreferencesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type FormEvent } from 'react'
-import { Shield, KeyRound, Trash2 } from 'lucide-react'
+import { Shield } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { useToast } from '@/components/ui/use-toast'
@@ -7,8 +7,6 @@ import { API_BASE_URL } from '@/lib/apiBase'
 import { authFetch } from '@/lib/authFetch'
 
 type SystemPreferencesResponse = {
-  minimax_api_key_configured: boolean
-  minimax_api_key_masked: string | null
   signal_history_min_confidence: number
   signal_history_min_reward_risk: number
   signal_history_max_reward_risk: number
@@ -24,8 +22,6 @@ type SystemPreferencesResponse = {
 
 export default function SystemPreferencesPage() {
   const { toast } = useToast()
-  const [data, setData] = useState<SystemPreferencesResponse | null>(null)
-  const [minimaxApiKey, setMinimaxApiKey] = useState('')
   const [signalHistoryMinConfidence, setSignalHistoryMinConfidence] = useState(55)
   const [signalHistoryMinRewardRisk, setSignalHistoryMinRewardRisk] = useState(1.2)
   const [signalHistoryMaxRewardRisk, setSignalHistoryMaxRewardRisk] = useState(5)
@@ -37,21 +33,17 @@ export default function SystemPreferencesPage() {
   const [signalHistoryAllowConservative, setSignalHistoryAllowConservative] = useState(false)
   const [signalHistoryAllowModerate, setSignalHistoryAllowModerate] = useState(true)
   const [signalHistoryAllowAggressive, setSignalHistoryAllowAggressive] = useState(true)
-  const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
-  const [isDeleting, setIsDeleting] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     const load = async () => {
-      setIsLoading(true)
       const response = await authFetch(`${API_BASE_URL}/system/preferences`)
       if (!response.ok) {
         throw new Error(`Falha ao carregar preferências do sistema (${response.status})`)
       }
       const payload = await response.json() as SystemPreferencesResponse
       if (!cancelled) {
-        setData(payload)
         setSignalHistoryMinConfidence(payload.signal_history_min_confidence)
         setSignalHistoryMinRewardRisk(payload.signal_history_min_reward_risk)
         setSignalHistoryMaxRewardRisk(payload.signal_history_max_reward_risk)
@@ -63,13 +55,11 @@ export default function SystemPreferencesPage() {
         setSignalHistoryAllowConservative(payload.signal_history_allow_conservative)
         setSignalHistoryAllowModerate(payload.signal_history_allow_moderate)
         setSignalHistoryAllowAggressive(payload.signal_history_allow_aggressive)
-        setIsLoading(false)
       }
     }
 
     load().catch((error: unknown) => {
       if (!cancelled) {
-        setIsLoading(false)
         toast({
           variant: 'destructive',
           title: 'Erro ao carregar preferências',
@@ -91,7 +81,6 @@ export default function SystemPreferencesPage() {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          minimax_api_key: minimaxApiKey.trim() || undefined,
           signal_history_min_confidence: signalHistoryMinConfidence,
           signal_history_min_reward_risk: signalHistoryMinRewardRisk,
           signal_history_max_reward_risk: signalHistoryMaxRewardRisk,
@@ -109,8 +98,6 @@ export default function SystemPreferencesPage() {
         throw new Error(`Falha ao salvar preferências do sistema (${response.status})`)
       }
       const payload = await response.json() as SystemPreferencesResponse
-      setData(payload)
-      setMinimaxApiKey('')
       setSignalHistoryMinConfidence(payload.signal_history_min_confidence)
       setSignalHistoryMinRewardRisk(payload.signal_history_min_reward_risk)
       setSignalHistoryMaxRewardRisk(payload.signal_history_max_reward_risk)
@@ -137,30 +124,6 @@ export default function SystemPreferencesPage() {
     }
   }
 
-  const handleDelete = async () => {
-    setIsDeleting(true)
-    try {
-      const response = await authFetch(`${API_BASE_URL}/system/preferences`, { method: 'DELETE' })
-      if (!response.ok) {
-        throw new Error(`Falha ao remover preferências do sistema (${response.status})`)
-      }
-      setData((current) => current ? { ...current, minimax_api_key_configured: false, minimax_api_key_masked: null } : null)
-      setMinimaxApiKey('')
-      toast({
-        title: 'API key removida',
-        description: 'A MiniMax API key foi apagada das preferências do sistema.',
-      })
-    } catch (error: unknown) {
-      toast({
-        variant: 'destructive',
-        title: 'Erro ao remover',
-        description: error instanceof Error ? error.message : 'Erro inesperado',
-      })
-    } finally {
-      setIsDeleting(false)
-    }
-  }
-
   return (
     <div className="app-page space-y-6 pb-20">
       <section className="page-card p-6 sm:p-7 lg:p-8">
@@ -174,58 +137,11 @@ export default function SystemPreferencesPage() {
             </div>
             <h1 className="section-title mt-2">Preferências do sistema</h1>
             <p className="section-copy mt-2">
-              Área administrativa para configurar segredos e preferências globais usadas pelos serviços internos.
+              Área administrativa para configurar preferências globais usadas pelos serviços internos.
             </p>
           </div>
         </div>
       </section>
-
-      <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
-        <CardContent className="p-6">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">MiniMax</div>
-              <h2 className="mt-2 text-xl font-semibold text-[var(--text-primary)]">API do MiniMax</h2>
-              <p className="mt-2 text-sm text-[var(--text-secondary)]">
-                Essa chave será usada pelo backend para traduzir e resumir notícias no AI Dashboard.
-              </p>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
-              <KeyRound className="h-5 w-5 text-sky-200" />
-            </div>
-          </div>
-
-          <div className="mt-5 page-card-muted px-4 py-3 text-sm text-[var(--text-secondary)]">
-            {isLoading ? 'Carregando status atual…' : data?.minimax_api_key_configured
-              ? `Chave configurada: ${data.minimax_api_key_masked ?? 'mascarada'}`
-              : 'Nenhuma chave configurada no sistema.'}
-          </div>
-
-          <form onSubmit={handleSubmit} className="mt-5 space-y-4">
-            <div className="space-y-1.5">
-              <label className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                API Key
-              </label>
-              <input
-                type="password"
-                value={minimaxApiKey}
-                onChange={(event) => setMinimaxApiKey(event.target.value)}
-                placeholder="Cole a chave da MiniMax"
-                className="w-full rounded-xl border border-[var(--border-default)] bg-[var(--bg-input)] px-4 py-3 text-sm text-[var(--text-primary)] placeholder-[var(--text-muted)] transition focus:border-[var(--accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-primary)]"
-              />
-            </div>
-
-            <div className="flex flex-wrap items-center gap-3">
-              <Button type="submit" loading={isSaving}>
-                Salvar API do MiniMax
-              </Button>
-              <Button type="button" variant="ghost" loading={isDeleting} onClick={handleDelete} icon={<Trash2 className="h-4 w-4" />}>
-                Remover chave
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
 
       <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
         <CardContent className="p-6">


### PR DESCRIPTION
## Summary
- Remove MiniMax API key handling from admin system preferences.
- Keep AI dashboard news localization local-only with fallback Portuguese summaries.
- Remove MiniMax card from the system preferences UI.
- Update backend tests for the local fallback/cache behavior.

## Validation
- `./backend/.venv/bin/python -m pytest -q` ✅ (`345 passed, 4 skipped`)
- `./backend/.venv/bin/python -m pytest -q backend/tests/unit/test_background_services.py::test_news_localization_helpers_and_cache backend/tests/unit/test_background_services.py::test_news_localization_scheduler_branches backend/tests/unit/test_background_services.py::test_localize_news_items_handles_empty_fallback backend/tests/integration/test_system_preferences_admin.py::test_admin_can_put_get_and_delete_system_preferences` ✅
- `./backend/.venv/bin/python -m black --check backend/app/routes/ai_dashboard.py backend/app/routes/system_preferences.py backend/app/services/news_localization_service.py backend/app/services/system_preferences_service.py backend/tests/integration/test_system_preferences_admin.py backend/tests/unit/test_background_services.py` ✅
- `npm --prefix frontend run lint` ✅ (existing warnings only; no warnings for `SystemPreferencesPage.tsx`)
- `npm --prefix frontend run build` ✅

## Scope
This PR does not include the pending `start.sh` localhost binding change or deletion of `frontend/.tmp/card93_*` scripts; those are separate commits.
