### PR TITLE
feat: add supply distribution metrics

### DIFF
--- a/backend/app/routes/onchain_metrics.py
+++ b/backend/app/routes/onchain_metrics.py
@@ -14,6 +14,7 @@ from app.services.glassnode_service import (
 )
 from app.services.onchain_exchange_flow_service import get_exchange_flow_service
 from app.services.onchain_mining_metric_service import get_mining_metric_service
+from app.services.onchain_supply_distribution_service import get_supply_distribution_service
 
 router = APIRouter(prefix="/api/onchain", tags=["onchain"])
 
@@ -94,6 +95,72 @@ class MiningMetricsResponse(BaseModel):
     metrics: list[MiningMetricPayload]
 
 
+class SupplyDistributionSourcePayload(BaseModel):
+    endpoint: str
+    points: int
+    cached: bool
+    fetched_at: datetime
+    cached_until: datetime
+
+
+class SupplyDistributionBandPayload(BaseModel):
+    id: str
+    metric: str
+    label: str
+    min_btc: float | None
+    max_btc: float | None
+    latest: float | None
+    latest_timestamp: int | None
+    previous: float | None
+    previous_timestamp: int | None
+    change_abs: float | None
+    change_pct: float | None
+    share_pct: float | None
+
+
+class SupplyDistributionCohortPayload(BaseModel):
+    id: str
+    label: str
+    band_ids: list[str]
+    latest: float | None
+    latest_timestamp: int | None
+    previous: float | None
+    previous_timestamp: int | None
+    change_abs: float | None
+    change_pct: float | None
+    share_pct: float | None
+
+
+class SupplyDistributionWhaleMovementPayload(BaseModel):
+    threshold_btc: float
+    change_abs: float | None
+    direction: str
+    alert: bool
+
+
+class SupplyDistributionAlertPayload(BaseModel):
+    type: str
+    threshold_btc: float
+    change_abs: float | None
+    direction: str
+    window: str
+
+
+class SupplyDistributionResponse(BaseModel):
+    asset: str
+    basis: str
+    window: str
+    interval: str
+    since: int
+    until: int
+    cached: bool
+    bands: list[SupplyDistributionBandPayload]
+    cohorts: dict[str, SupplyDistributionCohortPayload]
+    whale_movement: SupplyDistributionWhaleMovementPayload
+    alerts: list[SupplyDistributionAlertPayload]
+    sources: dict[str, SupplyDistributionSourcePayload]
+
+
 @router.get("/glassnode/{asset}", response_model=GlassnodeMetricsResponse)
 async def get_glassnode_onchain_metrics(
     asset: str,
@@ -107,6 +174,30 @@ async def get_glassnode_onchain_metrics(
             interval=interval,
             since=since,
             until=until,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except GlassnodeConfigError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))
+    except GlassnodeRateLimitError as exc:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc))
+    return payload
+
+
+@router.get(
+    "/glassnode/{asset}/supply-distribution",
+    response_model=SupplyDistributionResponse,
+)
+async def get_glassnode_supply_distribution(
+    asset: str,
+    basis: str = Query(default="entity", pattern="^entity$"),
+    window: str = Query(default="24h", pattern="^(24h|7d|30d)$"),
+):
+    try:
+        payload = await get_supply_distribution_service().fetch_supply_distribution(
+            asset,
+            basis=basis,
+            window=window,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))

--- a/backend/app/services/glassnode_service.py
+++ b/backend/app/services/glassnode_service.py
@@ -29,6 +29,19 @@ GLASSNODE_MINING_METRICS: dict[str, str] = {
     "difficulty": "/v1/metrics/mining/difficulty_latest",
     "miner_revenue_total": "/v1/metrics/mining/revenue_sum",
 }
+GLASSNODE_SUPPLY_DISTRIBUTION_METRICS: dict[str, str] = {
+    "entity_supply_less_0001": "/v1/metrics/entities/supply_balance_less_0001",
+    "entity_supply_0001_001": "/v1/metrics/entities/supply_balance_0001_001",
+    "entity_supply_001_01": "/v1/metrics/entities/supply_balance_001_01",
+    "entity_supply_01_1": "/v1/metrics/entities/supply_balance_01_1",
+    "entity_supply_1_10": "/v1/metrics/entities/supply_balance_1_10",
+    "entity_supply_10_100": "/v1/metrics/entities/supply_balance_10_100",
+    "entity_supply_100_1k": "/v1/metrics/entities/supply_balance_100_1k",
+    "entity_supply_1k_10k": "/v1/metrics/entities/supply_balance_1k_10k",
+    "entity_supply_10k_100k": "/v1/metrics/entities/supply_balance_10k_100k",
+    "entity_supply_more_100k": "/v1/metrics/entities/supply_balance_more_100k",
+    "lth_supply": "/v1/metrics/supply/lth_sum",
+}
 
 
 class GlassnodeConfigError(RuntimeError):
@@ -252,11 +265,13 @@ class GlassnodeService:
             normalized not in GLASSNODE_METRICS
             and normalized not in GLASSNODE_EXCHANGE_FLOW_METRICS
             and normalized not in GLASSNODE_MINING_METRICS
+            and normalized not in GLASSNODE_SUPPLY_DISTRIBUTION_METRICS
         ):
             metric_names = (
                 *GLASSNODE_METRICS.keys(),
                 *GLASSNODE_EXCHANGE_FLOW_METRICS.keys(),
                 *GLASSNODE_MINING_METRICS.keys(),
+                *GLASSNODE_SUPPLY_DISTRIBUTION_METRICS.keys(),
             )
             supported = ", ".join(sorted(metric_names))
             raise ValueError(f"Unsupported Glassnode metric '{metric}'. Supported: {supported}")
@@ -265,7 +280,8 @@ class GlassnodeService:
     @staticmethod
     def _metric_endpoint(metric: str) -> str:
         endpoint = GLASSNODE_METRICS.get(metric) or GLASSNODE_EXCHANGE_FLOW_METRICS.get(metric)
-        return endpoint or GLASSNODE_MINING_METRICS[metric]
+        endpoint = endpoint or GLASSNODE_MINING_METRICS.get(metric)
+        return endpoint or GLASSNODE_SUPPLY_DISTRIBUTION_METRICS[metric]
 
     @staticmethod
     def _normalize_asset(asset: str) -> str:

--- a/backend/app/services/onchain_supply_distribution_service.py
+++ b/backend/app/services/onchain_supply_distribution_service.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.services.glassnode_service import (
+    DEFAULT_GLASSNODE_INTERVAL,
+    GLASSNODE_SUPPLY_DISTRIBUTION_METRICS,
+    GlassnodeMetricSeries,
+    get_glassnode_service,
+)
+
+SUPPORTED_SUPPLY_DISTRIBUTION_BASIS = "entity"
+SUPPORTED_SUPPLY_DISTRIBUTION_INTERVAL = DEFAULT_GLASSNODE_INTERVAL
+SUPPORTED_SUPPLY_DISTRIBUTION_WINDOWS: dict[str, timedelta] = {
+    "24h": timedelta(days=1),
+    "7d": timedelta(days=7),
+    "30d": timedelta(days=30),
+}
+DAILY_PROVIDER_LOOKBACK = timedelta(days=1)
+WHALE_ALERT_THRESHOLD_BTC = 1000.0
+
+
+@dataclass(frozen=True)
+class SupplyBandDefinition:
+    id: str
+    metric: str
+    label: str
+    min_btc: float | None
+    max_btc: float | None
+
+
+ENTITY_SUPPLY_BANDS: tuple[SupplyBandDefinition, ...] = (
+    SupplyBandDefinition("less_0001", "entity_supply_less_0001", "< 0.001 BTC", None, 0.001),
+    SupplyBandDefinition("0001_001", "entity_supply_0001_001", "0.001 - 0.01 BTC", 0.001, 0.01),
+    SupplyBandDefinition("001_01", "entity_supply_001_01", "0.01 - 0.1 BTC", 0.01, 0.1),
+    SupplyBandDefinition("01_1", "entity_supply_01_1", "0.1 - 1 BTC", 0.1, 1.0),
+    SupplyBandDefinition("1_10", "entity_supply_1_10", "1 - 10 BTC", 1.0, 10.0),
+    SupplyBandDefinition("10_100", "entity_supply_10_100", "10 - 100 BTC", 10.0, 100.0),
+    SupplyBandDefinition("100_1k", "entity_supply_100_1k", "100 - 1k BTC", 100.0, 1000.0),
+    SupplyBandDefinition("1k_10k", "entity_supply_1k_10k", "1k - 10k BTC", 1000.0, 10000.0),
+    SupplyBandDefinition(
+        "10k_100k",
+        "entity_supply_10k_100k",
+        "10k - 100k BTC",
+        10000.0,
+        100000.0,
+    ),
+    SupplyBandDefinition("more_100k", "entity_supply_more_100k", "> 100k BTC", 100000.0, None),
+)
+SHRIMP_BAND_IDS = {"less_0001", "0001_001", "001_01", "01_1"}
+WHALE_BAND_IDS = {"1k_10k", "10k_100k", "more_100k"}
+
+
+class SupplyDistributionService:
+    def __init__(self, *, glassnode_service=None, now=None) -> None:
+        self._glassnode_service = glassnode_service or get_glassnode_service()
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    async def fetch_supply_distribution(
+        self,
+        asset: str,
+        *,
+        basis: str = SUPPORTED_SUPPLY_DISTRIBUTION_BASIS,
+        window: str,
+        interval: str = SUPPORTED_SUPPLY_DISTRIBUTION_INTERVAL,
+    ) -> dict[str, Any]:
+        normalized_basis = normalize_supply_distribution_basis(basis)
+        normalized_window = normalize_supply_distribution_window(window)
+        normalized_interval = normalize_supply_distribution_interval(interval)
+        window_delta = SUPPORTED_SUPPLY_DISTRIBUTION_WINDOWS[normalized_window]
+        since, until, provider_since = supply_distribution_bounds(self._now(), window_delta)
+
+        metric_rows: dict[str, GlassnodeMetricSeries] = {}
+        for metric in GLASSNODE_SUPPLY_DISTRIBUTION_METRICS:
+            metric_rows[metric] = await self._glassnode_service.fetch_metric(
+                metric,
+                asset,
+                interval=normalized_interval,
+                since=provider_since,
+                until=until,
+            )
+
+        band_rows = [
+            summarize_supply_band(
+                definition,
+                metric_rows[definition.metric],
+                int(window_delta.total_seconds()),
+            )
+            for definition in ENTITY_SUPPLY_BANDS
+        ]
+        represented_supply = sum(
+            value
+            for value in (_numeric_or_none(row.get("latest")) for row in band_rows)
+            if value is not None
+        )
+        for row in band_rows:
+            latest = _numeric_or_none(row.get("latest"))
+            row["share_pct"] = _share_pct(latest, represented_supply)
+
+        cohorts = {
+            "shrimps": summarize_supply_cohort(
+                "shrimps",
+                "Shrimps (< 1 BTC)",
+                [row for row in band_rows if row["id"] in SHRIMP_BAND_IDS],
+                represented_supply,
+            ),
+            "whales": summarize_supply_cohort(
+                "whales",
+                "Whales (>= 1000 BTC)",
+                [row for row in band_rows if row["id"] in WHALE_BAND_IDS],
+                represented_supply,
+            ),
+            "hodlers": summarize_hodler_cohort(
+                metric_rows["lth_supply"],
+                represented_supply,
+                int(window_delta.total_seconds()),
+            ),
+        }
+        whale_movement = summarize_whale_movement(cohorts["whales"])
+        alerts = alerts_for_whale_movement(whale_movement, normalized_window)
+        sources = {
+            metric: {
+                "endpoint": series.endpoint,
+                "points": len(series.points),
+                "cached": series.cached,
+                "fetched_at": series.fetched_at,
+                "cached_until": series.cached_until,
+            }
+            for metric, series in metric_rows.items()
+        }
+        normalized_asset = self._glassnode_service._normalize_asset(asset)
+        return {
+            "asset": normalized_asset,
+            "basis": normalized_basis,
+            "window": normalized_window,
+            "interval": normalized_interval,
+            "since": since,
+            "until": until,
+            "cached": all(series.cached for series in metric_rows.values()),
+            "bands": band_rows,
+            "cohorts": cohorts,
+            "whale_movement": whale_movement,
+            "alerts": alerts,
+            "sources": sources,
+        }
+
+
+def normalize_supply_distribution_basis(basis: str) -> str:
+    normalized = str(basis or "").strip().lower()
+    if normalized != SUPPORTED_SUPPLY_DISTRIBUTION_BASIS:
+        raise ValueError(
+            "Unsupported supply distribution basis "
+            f"'{basis}'. Supported: {SUPPORTED_SUPPLY_DISTRIBUTION_BASIS}"
+        )
+    return normalized
+
+
+def normalize_supply_distribution_window(window: str) -> str:
+    normalized = str(window or "").strip().lower()
+    if normalized not in SUPPORTED_SUPPLY_DISTRIBUTION_WINDOWS:
+        supported = ", ".join(SUPPORTED_SUPPLY_DISTRIBUTION_WINDOWS)
+        raise ValueError(
+            f"Unsupported supply distribution window '{window}'. Supported: {supported}"
+        )
+    return normalized
+
+
+def normalize_supply_distribution_interval(interval: str) -> str:
+    normalized = str(interval or "").strip().lower()
+    if normalized != SUPPORTED_SUPPLY_DISTRIBUTION_INTERVAL:
+        raise ValueError(
+            "Unsupported supply distribution interval "
+            f"'{interval}'. Supported: {SUPPORTED_SUPPLY_DISTRIBUTION_INTERVAL}"
+        )
+    return normalized
+
+
+def supply_distribution_bounds(now: datetime, window: timedelta) -> tuple[int, int, int]:
+    until_dt = _ensure_utc(now)
+    anchor_dt = until_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    since_dt = anchor_dt - window
+    provider_since_dt = since_dt - DAILY_PROVIDER_LOOKBACK
+    return int(since_dt.timestamp()), int(until_dt.timestamp()), int(provider_since_dt.timestamp())
+
+
+def summarize_supply_band(
+    definition: SupplyBandDefinition,
+    series: GlassnodeMetricSeries,
+    window_seconds: int | None = None,
+) -> dict[str, Any]:
+    summary = summarize_numeric_series(series.points, window_seconds=window_seconds)
+    return {
+        "id": definition.id,
+        "metric": definition.metric,
+        "label": definition.label,
+        "min_btc": definition.min_btc,
+        "max_btc": definition.max_btc,
+        **summary,
+        "share_pct": None,
+    }
+
+
+def summarize_supply_cohort(
+    cohort_id: str,
+    label: str,
+    bands: list[dict[str, Any]],
+    represented_supply: float,
+) -> dict[str, Any]:
+    latest = _sum_optional(row.get("latest") for row in bands)
+    previous = _sum_optional(row.get("previous") for row in bands)
+    change_abs = _change_abs(latest, previous)
+    return {
+        "id": cohort_id,
+        "label": label,
+        "band_ids": [str(row["id"]) for row in bands],
+        "latest": latest,
+        "latest_timestamp": _max_timestamp(row.get("latest_timestamp") for row in bands),
+        "previous": previous,
+        "previous_timestamp": _min_timestamp(row.get("previous_timestamp") for row in bands),
+        "change_abs": change_abs,
+        "change_pct": _change_pct(change_abs, previous),
+        "share_pct": _share_pct(latest, represented_supply),
+    }
+
+
+def summarize_hodler_cohort(
+    series: GlassnodeMetricSeries,
+    represented_supply: float,
+    window_seconds: int | None = None,
+) -> dict[str, Any]:
+    summary = summarize_numeric_series(series.points, window_seconds=window_seconds)
+    return {
+        "id": "hodlers",
+        "label": "Long-term holders",
+        "band_ids": [],
+        **summary,
+        "share_pct": _share_pct(_numeric_or_none(summary.get("latest")), represented_supply),
+    }
+
+
+def summarize_numeric_series(
+    points: list[dict[str, Any]],
+    *,
+    window_seconds: int | None = None,
+) -> dict[str, Any]:
+    numeric_points = _numeric_points(points)
+    latest = numeric_points[-1] if numeric_points else None
+    previous = _baseline_point(numeric_points, latest, window_seconds)
+    latest_value = latest["v"] if latest else None
+    previous_value = previous["v"] if previous else None
+    change_abs = _change_abs(latest_value, previous_value)
+    return {
+        "latest": latest_value,
+        "latest_timestamp": latest.get("t") if latest else None,
+        "previous": previous_value,
+        "previous_timestamp": previous.get("t") if previous else None,
+        "change_abs": change_abs,
+        "change_pct": _change_pct(change_abs, previous_value),
+    }
+
+
+def _baseline_point(
+    numeric_points: list[dict[str, float | int | None]],
+    latest: dict[str, float | int | None] | None,
+    window_seconds: int | None,
+) -> dict[str, float | int | None] | None:
+    if latest is None or len(numeric_points) < 2:
+        return None
+    if window_seconds is None:
+        return numeric_points[0]
+
+    latest_timestamp = _timestamp_or_none(latest.get("t"))
+    if latest_timestamp is None:
+        return numeric_points[0]
+
+    target_timestamp = latest_timestamp - window_seconds
+    candidates = [
+        point
+        for point in numeric_points[:-1]
+        if (timestamp := _timestamp_or_none(point.get("t"))) is not None
+        and timestamp <= target_timestamp
+    ]
+    return candidates[-1] if candidates else numeric_points[0]
+
+
+def summarize_whale_movement(whale_cohort: dict[str, Any]) -> dict[str, Any]:
+    change_abs = _numeric_or_none(whale_cohort.get("change_abs"))
+    direction = "flat"
+    if change_abs is not None and change_abs > 0:
+        direction = "accumulation"
+    elif change_abs is not None and change_abs < 0:
+        direction = "distribution"
+    return {
+        "threshold_btc": WHALE_ALERT_THRESHOLD_BTC,
+        "change_abs": change_abs,
+        "direction": direction,
+        "alert": change_abs is not None and abs(change_abs) >= WHALE_ALERT_THRESHOLD_BTC,
+    }
+
+
+def alerts_for_whale_movement(
+    whale_movement: dict[str, Any],
+    window: str,
+) -> list[dict[str, Any]]:
+    if not whale_movement.get("alert"):
+        return []
+    return [
+        {
+            "type": "whale-alert",
+            "threshold_btc": WHALE_ALERT_THRESHOLD_BTC,
+            "change_abs": whale_movement.get("change_abs"),
+            "direction": whale_movement.get("direction"),
+            "window": window,
+        }
+    ]
+
+
+def _numeric_points(points: list[dict[str, Any]]) -> list[dict[str, float | int | None]]:
+    numeric: list[dict[str, float | int | None]] = []
+    for point in sorted(points, key=_point_sort_key):
+        value = _numeric_or_none(point.get("v"))
+        if value is None:
+            continue
+        timestamp = _timestamp_or_none(point.get("t"))
+        numeric.append({"t": timestamp, "v": value})
+    return numeric
+
+
+def _change_abs(latest: Any, previous: Any) -> float | None:
+    latest_value = _numeric_or_none(latest)
+    previous_value = _numeric_or_none(previous)
+    if latest_value is None or previous_value is None:
+        return None
+    return latest_value - previous_value
+
+
+def _change_pct(change_abs: Any, previous: Any) -> float | None:
+    change_value = _numeric_or_none(change_abs)
+    previous_value = _numeric_or_none(previous)
+    if change_value is None or previous_value is None:
+        return None
+    if previous_value == 0:
+        return 0.0 if change_value == 0 else None
+    return (change_value / previous_value) * 100.0
+
+
+def _share_pct(value: Any, represented_supply: float) -> float | None:
+    numeric = _numeric_or_none(value)
+    if numeric is None or represented_supply <= 0:
+        return None
+    return (numeric / represented_supply) * 100.0
+
+
+def _sum_optional(values: Any) -> float | None:
+    total = 0.0
+    found = False
+    for value in values:
+        numeric = _numeric_or_none(value)
+        if numeric is None:
+            continue
+        total += numeric
+        found = True
+    return total if found else None
+
+
+def _max_timestamp(values: Any) -> int | None:
+    timestamps = [
+        value for value in (_timestamp_or_none(value) for value in values) if value is not None
+    ]
+    return max(timestamps) if timestamps else None
+
+
+def _min_timestamp(values: Any) -> int | None:
+    timestamps = [
+        value for value in (_timestamp_or_none(value) for value in values) if value is not None
+    ]
+    return min(timestamps) if timestamps else None
+
+
+def _point_sort_key(point: dict[str, Any]) -> tuple[int, float]:
+    timestamp = _numeric_or_none(point.get("t"))
+    if timestamp is None:
+        return (1, math.inf)
+    return (0, timestamp)
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _timestamp_or_none(value: Any) -> int | None:
+    numeric = _numeric_or_none(value)
+    if numeric is None:
+        return None
+    return int(numeric)
+
+
+def _numeric_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+_SERVICE: SupplyDistributionService | None = None
+
+
+def get_supply_distribution_service() -> SupplyDistributionService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = SupplyDistributionService()
+    return _SERVICE

--- a/backend/tests/unit/test_glassnode_service.py
+++ b/backend/tests/unit/test_glassnode_service.py
@@ -8,6 +8,7 @@ import pytest
 from app.services.glassnode_service import (
     GLASSNODE_MINING_METRICS,
     GLASSNODE_METRICS,
+    GLASSNODE_SUPPLY_DISTRIBUTION_METRICS,
     GlassnodeConfigError,
     GlassnodeRateLimitError,
     GlassnodeService,
@@ -160,6 +161,24 @@ async def test_fetch_metric_supports_mining_metric_endpoints() -> None:
     assert client.calls == [
         {
             "url": "https://api.glassnode.com/v1/metrics/mining/hash_rate_mean",
+            "params": {"a": "BTC", "i": "24h", "f": "json", "s": 1, "u": 2},
+            "headers": {"X-Api-Key": "secret"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_supports_supply_distribution_metric_endpoints() -> None:
+    client = FakeGlassnodeClient()
+    service = GlassnodeService(api_key="secret", client=client, rate_limit_per_minute=0)
+
+    result = await service.fetch_metric("entity_supply_1k_10k", "BTC", since=1, until=2)
+
+    assert result.metric == "entity_supply_1k_10k"
+    assert result.endpoint == GLASSNODE_SUPPLY_DISTRIBUTION_METRICS["entity_supply_1k_10k"]
+    assert client.calls == [
+        {
+            "url": "https://api.glassnode.com/v1/metrics/entities/supply_balance_1k_10k",
             "params": {"a": "BTC", "i": "24h", "f": "json", "s": 1, "u": 2},
             "headers": {"X-Api-Key": "secret"},
         }

--- a/backend/tests/unit/test_onchain_metrics_route.py
+++ b/backend/tests/unit/test_onchain_metrics_route.py
@@ -102,6 +102,77 @@ class FakeMiningMetricService:
         }
 
 
+class FakeSupplyDistributionService:
+    async def fetch_supply_distribution(self, asset: str, basis: str, window: str):
+        assert asset == "BTC"
+        assert basis == "entity"
+        assert window == "7d"
+        now = datetime(2026, 4, 27, tzinfo=timezone.utc)
+        return {
+            "asset": "BTC",
+            "basis": "entity",
+            "window": "7d",
+            "interval": "24h",
+            "since": 1,
+            "until": 2,
+            "cached": True,
+            "bands": [
+                {
+                    "id": "1k_10k",
+                    "metric": "entity_supply_1k_10k",
+                    "label": "1k - 10k BTC",
+                    "min_btc": 1000.0,
+                    "max_btc": 10000.0,
+                    "latest": 2600.0,
+                    "latest_timestamp": 2,
+                    "previous": 1000.0,
+                    "previous_timestamp": 1,
+                    "change_abs": 1600.0,
+                    "change_pct": 160.0,
+                    "share_pct": 40.0,
+                }
+            ],
+            "cohorts": {
+                "whales": {
+                    "id": "whales",
+                    "label": "Whales (>= 1000 BTC)",
+                    "band_ids": ["1k_10k"],
+                    "latest": 2600.0,
+                    "latest_timestamp": 2,
+                    "previous": 1000.0,
+                    "previous_timestamp": 1,
+                    "change_abs": 1600.0,
+                    "change_pct": 160.0,
+                    "share_pct": 40.0,
+                }
+            },
+            "whale_movement": {
+                "threshold_btc": 1000.0,
+                "change_abs": 1600.0,
+                "direction": "accumulation",
+                "alert": True,
+            },
+            "alerts": [
+                {
+                    "type": "whale-alert",
+                    "threshold_btc": 1000.0,
+                    "change_abs": 1600.0,
+                    "direction": "accumulation",
+                    "window": "7d",
+                }
+            ],
+            "sources": {
+                "entity_supply_1k_10k": {
+                    "endpoint": "/v1/metrics/entities/supply_balance_1k_10k",
+                    "points": 2,
+                    "cached": True,
+                    "fetched_at": now,
+                    "cached_until": now,
+                }
+            },
+        }
+
+
 @pytest.mark.asyncio
 async def test_glassnode_onchain_route_returns_service_payload(monkeypatch) -> None:
     monkeypatch.setattr(onchain_metrics, "get_glassnode_service", lambda: FakeGlassnodeService())
@@ -151,6 +222,27 @@ async def test_glassnode_mining_metrics_route_returns_service_payload(monkeypatc
     assert payload["asset"] == "BTC"
     assert payload["metrics"][0]["metric"] == "hash_rate"
     assert payload["metrics"][0]["ath"] == {"t": 1, "v": 100.0}
+
+
+@pytest.mark.asyncio
+async def test_glassnode_supply_distribution_route_returns_service_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_supply_distribution_service",
+        lambda: FakeSupplyDistributionService(),
+    )
+
+    payload = await onchain_metrics.get_glassnode_supply_distribution(
+        asset="BTC",
+        basis="entity",
+        window="7d",
+    )
+
+    assert payload["asset"] == "BTC"
+    assert payload["basis"] == "entity"
+    assert payload["bands"][0]["id"] == "1k_10k"
+    assert payload["cohorts"]["whales"]["change_abs"] == 1600.0
+    assert payload["alerts"][0]["type"] == "whale-alert"
 
 
 @pytest.mark.asyncio
@@ -251,5 +343,33 @@ async def test_glassnode_exchange_flows_route_maps_service_errors(
 
     with pytest.raises(HTTPException) as raised:
         await onchain_metrics.get_glassnode_exchange_flows(asset="BTC")
+
+    assert raised.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "status_code"),
+    [
+        (ValueError("bad basis"), 400),
+        (GlassnodeConfigError("missing key"), 503),
+        (GlassnodeRateLimitError("rate limited"), 429),
+    ],
+)
+async def test_glassnode_supply_distribution_route_maps_service_errors(
+    monkeypatch, exc: Exception, status_code: int
+) -> None:
+    class FailingSupplyDistributionService:
+        async def fetch_supply_distribution(self, *_args, **_kwargs):
+            raise exc
+
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_supply_distribution_service",
+        lambda: FailingSupplyDistributionService(),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await onchain_metrics.get_glassnode_supply_distribution(asset="BTC")
 
     assert raised.value.status_code == status_code

--- a/backend/tests/unit/test_onchain_supply_distribution_service.py
+++ b/backend/tests/unit/test_onchain_supply_distribution_service.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.glassnode_service import (
+    GLASSNODE_SUPPLY_DISTRIBUTION_METRICS,
+    GlassnodeMetricSeries,
+)
+from app.services.onchain_supply_distribution_service import (
+    SupplyDistributionService,
+    alerts_for_whale_movement,
+    normalize_supply_distribution_basis,
+    normalize_supply_distribution_interval,
+    normalize_supply_distribution_window,
+    summarize_numeric_series,
+    summarize_whale_movement,
+    supply_distribution_bounds,
+)
+
+
+def _series(metric: str, values: list[object], *, cached: bool = False) -> GlassnodeMetricSeries:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
+    return GlassnodeMetricSeries(
+        metric=metric,
+        asset="BTC",
+        interval="24h",
+        endpoint=f"/v1/metrics/{metric}",
+        points=[{"t": index + 1, "v": value} for index, value in enumerate(values)],
+        fetched_at=now,
+        cached_until=now,
+        cached=cached,
+    )
+
+
+def _series_with_points(
+    metric: str,
+    points: list[tuple[int, object]],
+    *,
+    cached: bool = False,
+) -> GlassnodeMetricSeries:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
+    return GlassnodeMetricSeries(
+        metric=metric,
+        asset="BTC",
+        interval="24h",
+        endpoint=f"/v1/metrics/{metric}",
+        points=[{"t": timestamp, "v": value} for timestamp, value in points],
+        fetched_at=now,
+        cached_until=now,
+        cached=cached,
+    )
+
+
+def test_supply_distribution_normalizers_reject_unsupported_inputs() -> None:
+    assert normalize_supply_distribution_basis("ENTITY") == "entity"
+    assert normalize_supply_distribution_window("7D") == "7d"
+    assert normalize_supply_distribution_interval("24H") == "24h"
+
+    with pytest.raises(ValueError, match="Unsupported supply distribution basis"):
+        normalize_supply_distribution_basis("address")
+    with pytest.raises(ValueError, match="Unsupported supply distribution window"):
+        normalize_supply_distribution_window("90d")
+    with pytest.raises(ValueError, match="Unsupported supply distribution interval"):
+        normalize_supply_distribution_interval("1h")
+
+
+def test_supply_distribution_bounds_align_daily_series_and_fetch_extra_point() -> None:
+    now = datetime(2026, 4, 27, 12, 30, tzinfo=timezone.utc)
+
+    since, until, provider_since = supply_distribution_bounds(now, timedelta(days=1))
+
+    assert since == int(datetime(2026, 4, 26, tzinfo=timezone.utc).timestamp())
+    assert until == int(now.timestamp())
+    assert provider_since == int(datetime(2026, 4, 25, tzinfo=timezone.utc).timestamp())
+
+
+def test_summarize_numeric_series_sorts_and_handles_sparse_values() -> None:
+    summary = summarize_numeric_series(
+        [
+            {"t": 3, "v": 30.0},
+            {"t": 1, "v": 10.0},
+            {"t": 2, "v": "bad"},
+            {"t": 4, "v": float("nan")},
+        ]
+    )
+
+    assert summary["latest"] == 30.0
+    assert summary["latest_timestamp"] == 3
+    assert summary["previous"] == 10.0
+    assert summary["previous_timestamp"] == 1
+    assert summary["change_abs"] == 20.0
+    assert summary["change_pct"] == 200.0
+
+    sparse = summarize_numeric_series([{"t": 1, "v": 10.0}])
+
+    assert sparse["latest"] == 10.0
+    assert sparse["previous"] is None
+    assert sparse["change_abs"] is None
+
+
+def test_summarize_numeric_series_uses_daily_window_baseline() -> None:
+    day_25 = int(datetime(2026, 4, 25, tzinfo=timezone.utc).timestamp())
+    day_26 = int(datetime(2026, 4, 26, tzinfo=timezone.utc).timestamp())
+    day_27 = int(datetime(2026, 4, 27, tzinfo=timezone.utc).timestamp())
+
+    summary = summarize_numeric_series(
+        [
+            {"t": day_25, "v": 100.0},
+            {"t": day_26, "v": 130.0},
+            {"t": day_27, "v": 160.0},
+        ],
+        window_seconds=24 * 60 * 60,
+    )
+
+    assert summary["latest"] == 160.0
+    assert summary["previous"] == 130.0
+    assert summary["change_abs"] == 30.0
+
+
+def test_whale_movement_alerts_on_absolute_1000_btc_boundary() -> None:
+    movement = summarize_whale_movement({"change_abs": 1000.0})
+
+    assert movement == {
+        "threshold_btc": 1000.0,
+        "change_abs": 1000.0,
+        "direction": "accumulation",
+        "alert": True,
+    }
+    assert alerts_for_whale_movement(movement, "7d") == [
+        {
+            "type": "whale-alert",
+            "threshold_btc": 1000.0,
+            "change_abs": 1000.0,
+            "direction": "accumulation",
+            "window": "7d",
+        }
+    ]
+
+
+def test_whale_movement_alerts_on_distribution_and_skips_below_threshold() -> None:
+    distribution = summarize_whale_movement({"change_abs": -1500.0})
+    quiet = summarize_whale_movement({"change_abs": 999.99})
+
+    assert distribution["direction"] == "distribution"
+    assert distribution["alert"] is True
+    assert quiet["direction"] == "accumulation"
+    assert quiet["alert"] is False
+    assert alerts_for_whale_movement(quiet, "24h") == []
+
+
+class FakeGlassnodeService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def fetch_metric(
+        self,
+        metric: str,
+        asset: str,
+        interval: str,
+        since: int | None,
+        until: int | None,
+    ):
+        self.calls.append(
+            {
+                "metric": metric,
+                "asset": asset,
+                "interval": interval,
+                "since": since,
+                "until": until,
+            }
+        )
+        values_by_metric = {
+            "entity_supply_less_0001": [10.0, 11.0],
+            "entity_supply_0001_001": [20.0, 22.0],
+            "entity_supply_001_01": [30.0, 33.0],
+            "entity_supply_01_1": [40.0, 44.0],
+            "entity_supply_1_10": [50.0, 55.0],
+            "entity_supply_10_100": [60.0, 66.0],
+            "entity_supply_100_1k": [70.0, 77.0],
+            "entity_supply_1k_10k": [2000.0, 2600.0],
+            "entity_supply_10k_100k": [3000.0, 3500.0],
+            "entity_supply_more_100k": [4000.0, 4100.0],
+            "lth_supply": [8000.0, 8100.0],
+        }
+        return _series(metric, values_by_metric[metric], cached=True)
+
+    def _normalize_asset(self, asset: str) -> str:
+        return asset.upper()
+
+
+class DailyFakeGlassnodeService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.day_25 = int(datetime(2026, 4, 25, tzinfo=timezone.utc).timestamp())
+        self.day_26 = int(datetime(2026, 4, 26, tzinfo=timezone.utc).timestamp())
+
+    async def fetch_metric(
+        self,
+        metric: str,
+        asset: str,
+        interval: str,
+        since: int | None,
+        until: int | None,
+    ):
+        self.calls.append(
+            {
+                "metric": metric,
+                "asset": asset,
+                "interval": interval,
+                "since": since,
+                "until": until,
+            }
+        )
+        values_by_metric = {
+            "entity_supply_1k_10k": [(self.day_25, 1000.0), (self.day_26, 1600.0)],
+            "entity_supply_10k_100k": [(self.day_25, 2000.0), (self.day_26, 2500.0)],
+            "entity_supply_more_100k": [(self.day_25, 3000.0), (self.day_26, 3100.0)],
+            "lth_supply": [(self.day_25, 8000.0), (self.day_26, 8050.0)],
+        }
+        points = values_by_metric.get(metric, [(self.day_25, 100.0), (self.day_26, 100.0)])
+        filtered = [
+            (timestamp, value)
+            for timestamp, value in points
+            if (since is None or timestamp >= since) and (until is None or timestamp <= until)
+        ]
+        return _series_with_points(metric, filtered, cached=True)
+
+    def _normalize_asset(self, asset: str) -> str:
+        return asset.upper()
+
+
+@pytest.mark.asyncio
+async def test_supply_distribution_service_fetches_bands_and_aggregates_cohorts() -> None:
+    fake_glassnode = FakeGlassnodeService()
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
+    service = SupplyDistributionService(
+        glassnode_service=fake_glassnode,
+        now=lambda: now,
+    )
+
+    payload = await service.fetch_supply_distribution("btc", window="7d")
+
+    assert payload["asset"] == "BTC"
+    assert payload["basis"] == "entity"
+    assert payload["window"] == "7d"
+    expected_since = int(datetime(2026, 4, 20, tzinfo=timezone.utc).timestamp())
+    expected_provider_since = int(datetime(2026, 4, 19, tzinfo=timezone.utc).timestamp())
+    assert payload["since"] == expected_since
+    assert payload["until"] == int(now.timestamp())
+    assert payload["cached"] is True
+    assert [call["metric"] for call in fake_glassnode.calls] == list(
+        GLASSNODE_SUPPLY_DISTRIBUTION_METRICS
+    )
+    assert {call["interval"] for call in fake_glassnode.calls} == {"24h"}
+    assert len(payload["bands"]) == 10
+    assert {call["since"] for call in fake_glassnode.calls} == {expected_provider_since}
+    assert payload["bands"][0]["id"] == "less_0001"
+    assert payload["bands"][0]["change_abs"] == 1.0
+    assert payload["bands"][0]["change_pct"] == 10.0
+    assert payload["cohorts"]["shrimps"]["latest"] == 110.0
+    assert payload["cohorts"]["shrimps"]["change_abs"] == 10.0
+    assert payload["cohorts"]["whales"]["latest"] == 10200.0
+    assert payload["cohorts"]["whales"]["change_abs"] == 1200.0
+    assert payload["cohorts"]["hodlers"]["latest"] == 8100.0
+    assert payload["whale_movement"]["alert"] is True
+    assert payload["alerts"][0]["type"] == "whale-alert"
+    assert payload["sources"]["entity_supply_1k_10k"]["cached"] is True
+
+
+@pytest.mark.asyncio
+async def test_supply_distribution_service_24h_fetches_prior_daily_point_for_delta() -> None:
+    fake_glassnode = DailyFakeGlassnodeService()
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
+    service = SupplyDistributionService(
+        glassnode_service=fake_glassnode,
+        now=lambda: now,
+    )
+
+    payload = await service.fetch_supply_distribution("btc", window="24h")
+
+    expected_since = int(datetime(2026, 4, 26, tzinfo=timezone.utc).timestamp())
+    expected_provider_since = int(datetime(2026, 4, 25, tzinfo=timezone.utc).timestamp())
+    assert payload["since"] == expected_since
+    assert {call["since"] for call in fake_glassnode.calls} == {expected_provider_since}
+    assert payload["cohorts"]["whales"]["previous_timestamp"] == expected_provider_since
+    assert payload["cohorts"]["whales"]["latest_timestamp"] == expected_since
+    assert payload["cohorts"]["whales"]["change_abs"] == 1200.0
+    assert payload["whale_movement"]["alert"] is True
+    assert payload["alerts"][0]["type"] == "whale-alert"
+
+
+@pytest.mark.asyncio
+async def test_supply_distribution_service_rejects_invalid_basis_before_provider_call() -> None:
+    fake_glassnode = FakeGlassnodeService()
+    service = SupplyDistributionService(glassnode_service=fake_glassnode)
+
+    with pytest.raises(ValueError, match="Unsupported supply distribution basis"):
+        await service.fetch_supply_distribution("btc", basis="address", window="7d")
+
+    assert fake_glassnode.calls == []

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import ExternalBalancesPage from './pages/ExternalBalancesPage'
 import KanbanPage from './pages/KanbanPage'
 import SignalsPage from './pages/SignalsPage'
 import SignalsHistoryPage from './pages/SignalsHistoryPage'
+import SupplyDistributionPage from './pages/SupplyDistributionPage'
 import LoginPage from './pages/LoginPage'
 import ForgotPasswordPage from './pages/ForgotPasswordPage'
 import SystemPreferencesPage from './pages/SystemPreferencesPage'
@@ -68,6 +69,7 @@ function App() {
           <Route path="/kanban" element={<KanbanPage />} />
           <Route path="/signals" element={<SignalsPage />} />
           <Route path="/signals/history" element={<SignalsHistoryPage />} />
+          <Route path="/supply-distribution" element={<SupplyDistributionPage />} />
           <Route path="/combo/select" element={<ComboSelectPage />} />
           {/* Backward-compat route (old link/bookmark) */}
           <Route path="/combo/selectCrypto" element={<ComboSelectPage />} />

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation, useNavigate } from 'react-router-dom'
 import {
   Activity,
   Bookmark,
+  ChartPie,
   ChevronLeft,
   Home,
   Play,
@@ -37,6 +38,7 @@ const mainNavItems: NavItemConfig[] = [
   { to: '/monitor', label: 'Monitor', icon: Activity },
   { to: '/signals', label: 'Sinais', icon: TrendingUp },
   { to: '/signals/history', label: 'Histórico', icon: TrendingUp },
+  { to: '/supply-distribution', label: 'Distribuição', icon: ChartPie },
 ]
 
 const strategyNavItems: NavItemConfig[] = [
@@ -65,6 +67,7 @@ function resolvePageTitle(pathname: string) {
   if (pathname === '/monitor') return 'Monitor de sinais'
   if (pathname === '/signals') return 'Sinais de trading'
   if (pathname === '/signals/history') return 'Histórico de Sinais'
+  if (pathname === '/supply-distribution') return 'Distribuição de supply'
   if (pathname.startsWith('/combo')) return 'Combo estratégias'
   if (pathname.startsWith('/external')) return 'Carteira'
   if (pathname.startsWith('/profile')) return 'Meu Perfil'

--- a/frontend/src/pages/SupplyDistributionPage.tsx
+++ b/frontend/src/pages/SupplyDistributionPage.tsx
@@ -1,0 +1,352 @@
+import { useMemo, useState } from 'react'
+import { AlertTriangle, ArrowDownRight, ArrowUpRight, CircleGauge, RefreshCw, ShieldAlert, WalletCards } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Card, CardContent } from '@/components/ui/Card'
+import { apiUrl } from '@/lib/apiBase'
+import { authFetch } from '@/lib/authFetch'
+
+type SupplyWindow = '24h' | '7d' | '30d'
+
+type SupplyBand = {
+  id: string
+  label: string
+  min_btc: number | null
+  max_btc: number | null
+  latest: number | null
+  previous: number | null
+  change_abs: number | null
+  change_pct: number | null
+  share_pct: number | null
+}
+
+type SupplyCohort = {
+  latest?: number | null
+  previous?: number | null
+  change_abs?: number | null
+  change_pct?: number | null
+  share_pct?: number | null
+}
+
+type WhaleMovement = {
+  threshold_btc: number | null
+  change_abs: number | null
+  direction: string | null
+  alert: boolean
+}
+
+type SupplyAlert = {
+  type: string
+  threshold_btc?: number | null
+  change_abs?: number | null
+  direction?: string | null
+}
+
+type SupplyDistributionResponse = {
+  asset: string
+  basis: string
+  window: SupplyWindow
+  interval: string
+  since: number | string | null
+  until: number | string | null
+  cached: boolean
+  bands: SupplyBand[]
+  cohorts: Record<string, SupplyCohort | null>
+  whale_movement: WhaleMovement | null
+  alerts: SupplyAlert[]
+  sources: Record<string, unknown>
+}
+
+const WINDOWS: SupplyWindow[] = ['24h', '7d', '30d']
+
+const COHORT_LABELS: Record<string, string> = {
+  shrimps: 'Shrimps',
+  whales: 'Whales',
+  hodlers: 'Hodlers',
+}
+
+function formatBtc(value: number | null | undefined) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  return new Intl.NumberFormat('pt-BR', {
+    maximumFractionDigits: Math.abs(value) >= 100 ? 0 : 4,
+  }).format(value)
+}
+
+function formatPct(value: number | null | undefined) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${value.toFixed(2)}%`
+}
+
+function formatDate(value: number | string | null | undefined) {
+  if (value === null || value === undefined || value === '') return '—'
+  const parsed = typeof value === 'number' ? new Date(value * 1000) : new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return new Intl.DateTimeFormat('pt-BR', { dateStyle: 'short', timeStyle: 'short' }).format(parsed)
+}
+
+function changeTone(value: number | null | undefined) {
+  if (value === null || value === undefined || !Number.isFinite(value) || value === 0) {
+    return 'text-[var(--text-tertiary)]'
+  }
+  return value > 0 ? 'text-emerald-300' : 'text-rose-300'
+}
+
+function directionLabel(direction: string | null | undefined) {
+  if (!direction) return 'Sem movimento'
+  if (direction === 'accumulation' || direction === 'increase') return 'Acumulação'
+  if (direction === 'distribution' || direction === 'decrease') return 'Distribuição'
+  return direction
+}
+
+function sourceCount(sources: Record<string, unknown> | undefined) {
+  if (!sources) return 0
+  return Object.keys(sources).length
+}
+
+async function fetchSupplyDistribution(window: SupplyWindow) {
+  const url = apiUrl('/onchain/glassnode/BTC/supply-distribution')
+  url.searchParams.set('basis', 'entity')
+  url.searchParams.set('window', window)
+
+  const response = await authFetch(url.toString())
+  if (!response.ok) {
+    throw new Error(`Falha ao carregar distribuição (${response.status})`)
+  }
+  return (await response.json()) as SupplyDistributionResponse
+}
+
+function CohortCard({ id, cohort }: { id: string; cohort: SupplyCohort | null | undefined }) {
+  const label = COHORT_LABELS[id] ?? id
+  const change = cohort?.change_pct
+
+  return (
+    <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">{label}</p>
+            <p className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">{formatBtc(cohort?.latest)} BTC</p>
+          </div>
+          <div className={`flex items-center gap-1 text-sm font-semibold ${changeTone(change)}`}>
+            {(change ?? 0) >= 0 ? <ArrowUpRight className="h-4 w-4" /> : <ArrowDownRight className="h-4 w-4" />}
+            <span>{formatPct(change)}</span>
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+          <div className="page-card-muted px-3 py-2">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Share</p>
+            <p className="mt-1 font-semibold text-[var(--text-primary)]">{formatPct(cohort?.share_pct)}</p>
+          </div>
+          <div className="page-card-muted px-3 py-2">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Delta</p>
+            <p className={`mt-1 font-semibold ${changeTone(cohort?.change_abs)}`}>{formatBtc(cohort?.change_abs)} BTC</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function BandRow({ band, maxShare }: { band: SupplyBand; maxShare: number }) {
+  const share = typeof band.share_pct === 'number' && Number.isFinite(band.share_pct) ? band.share_pct : 0
+  const width = maxShare > 0 ? Math.max(2, Math.min(100, (share / maxShare) * 100)) : 2
+
+  return (
+    <div className="page-card-muted px-4 py-3" data-testid={`supply-band-${band.id}`}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-semibold text-[var(--text-primary)]">{band.label}</h3>
+            <Badge variant="outline">{formatPct(band.share_pct)} share</Badge>
+          </div>
+          <p className="mt-1 text-xs text-[var(--text-tertiary)]">
+            {formatBtc(band.min_btc)} - {band.max_btc === null ? '∞' : formatBtc(band.max_btc)} BTC
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-right text-sm sm:grid-cols-3">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Atual</p>
+            <p className="font-semibold text-[var(--text-primary)]">{formatBtc(band.latest)}</p>
+          </div>
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Delta</p>
+            <p className={`font-semibold ${changeTone(band.change_abs)}`}>{formatBtc(band.change_abs)}</p>
+          </div>
+          <div className="col-span-2 sm:col-span-1">
+            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Var.</p>
+            <p className={`font-semibold ${changeTone(band.change_pct)}`}>{formatPct(band.change_pct)}</p>
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-white/[0.06]">
+        <div className="h-full rounded-full bg-[linear-gradient(90deg,rgba(34,197,94,0.95),rgba(56,189,248,0.9))]" style={{ width: `${width}%` }} />
+      </div>
+    </div>
+  )
+}
+
+export default function SupplyDistributionPage() {
+  const [windowValue, setWindowValue] = useState<SupplyWindow>('24h')
+
+  const query = useQuery({
+    queryKey: ['supply-distribution', windowValue],
+    queryFn: () => fetchSupplyDistribution(windowValue),
+    placeholderData: (previousData) => previousData,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  })
+
+  const cohortEntries = useMemo(() => {
+    const cohorts = query.data?.cohorts ?? {}
+    return ['shrimps', 'whales', 'hodlers'].map((id) => [id, cohorts[id]] as const)
+  }, [query.data?.cohorts])
+  const maxShare = useMemo(() => {
+    return Math.max(0, ...(query.data?.bands ?? []).map((band) => (typeof band.share_pct === 'number' ? band.share_pct : 0)))
+  }, [query.data?.bands])
+
+  const whaleAlert = query.data?.alerts?.find((alert) => alert.type === 'whale-alert')
+  const whaleMovement = query.data?.whale_movement
+  const isEmpty = query.data && query.data.bands.length === 0 && Object.keys(query.data.cohorts ?? {}).length === 0
+
+  return (
+    <div className="app-page space-y-6 pb-20">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--text-muted)]">Glassnode / BTC</p>
+          <h1 className="mt-2 text-3xl font-bold text-[var(--text-primary)]">Distribuição de supply</h1>
+          <p className="mt-2 max-w-3xl text-sm text-[var(--text-secondary)]">
+            Supply por bandas de entidade, cohorts agregados e alerta de movimentação whale.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Janela de distribuição">
+          {WINDOWS.map((item) => (
+            <button
+              key={item}
+              type="button"
+              onClick={() => setWindowValue(item)}
+              className={[
+                'inline-flex h-10 min-w-14 items-center justify-center rounded-2xl border px-4 text-sm font-semibold transition',
+                windowValue === item
+                  ? 'border-emerald-300/30 bg-emerald-400/14 text-emerald-100'
+                  : 'border-white/10 bg-white/[0.04] text-[var(--text-secondary)] hover:bg-white/[0.08] hover:text-white',
+              ].join(' ')}
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <section className="page-card p-5 sm:p-6" aria-label="Resumo">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{query.data?.asset ?? 'BTC'}</Badge>
+            <Badge variant="outline">Basis {query.data?.basis ?? 'entity'}</Badge>
+            {query.data?.cached ? <Badge variant="warning">Cache</Badge> : <Badge variant="success">Fresh</Badge>}
+            {query.isFetching ? <Badge variant="outline">Atualizando</Badge> : null}
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-[var(--text-secondary)]">
+            <span>Intervalo: {query.data?.interval ?? '—'}</span>
+            <span>Desde: {formatDate(query.data?.since)}</span>
+            <span>Até: {formatDate(query.data?.until)}</span>
+            <span>Fontes: {sourceCount(query.data?.sources)}</span>
+          </div>
+        </div>
+      </section>
+
+      {query.isLoading ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="page-card h-44 animate-pulse" />
+          ))}
+        </div>
+      ) : query.error && !query.data ? (
+        <Card className="border-red-400/25 bg-red-500/8">
+          <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="mt-1 h-5 w-5 shrink-0 text-red-300" />
+              <div>
+                <h2 className="text-lg font-semibold text-red-100">Não foi possível carregar distribuição</h2>
+                <p className="text-sm text-red-100/80">Verifique a API on-chain e tente novamente.</p>
+              </div>
+            </div>
+            <Button onClick={() => void query.refetch()} icon={<RefreshCw className="h-4 w-4" />}>
+              Recarregar
+            </Button>
+          </CardContent>
+        </Card>
+      ) : isEmpty ? (
+        <Card>
+          <CardContent className="p-8 text-center">
+            <WalletCards className="mx-auto h-8 w-8 text-[var(--text-tertiary)]" />
+            <h2 className="mt-3 text-lg font-semibold text-[var(--text-primary)]">Nenhuma banda disponível</h2>
+            <p className="mt-2 text-sm text-[var(--text-secondary)]">A janela selecionada ainda não retornou dados de supply.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-3" aria-label="Cohorts">
+            {cohortEntries.map(([id, cohort]) => (
+              <CohortCard key={id} id={id} cohort={cohort} />
+            ))}
+          </section>
+
+          <section className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+            <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
+              <CardContent className="p-5 sm:p-6">
+                <div className="mb-4 flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Bandas</p>
+                    <h2 className="mt-1 text-xl font-semibold text-[var(--text-primary)]">Supply por faixa</h2>
+                  </div>
+                  <CircleGauge className="h-5 w-5 text-sky-300" />
+                </div>
+                <div className="space-y-3">
+                  {query.data?.bands.map((band) => (
+                    <BandRow key={band.id} band={band} maxShare={maxShare} />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="page-card border-white/8 bg-[linear-gradient(180deg,rgba(16,28,42,0.98),rgba(12,22,34,0.94))]">
+              <CardContent className="p-5 sm:p-6">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Whale alert</p>
+                    <h2 className="mt-1 text-xl font-semibold text-[var(--text-primary)]">
+                      {whaleAlert || whaleMovement?.alert ? 'Ativo' : 'Normal'}
+                    </h2>
+                  </div>
+                  <ShieldAlert className={['h-6 w-6', whaleAlert || whaleMovement?.alert ? 'text-amber-300' : 'text-emerald-300'].join(' ')} />
+                </div>
+
+                <div className="mt-5 space-y-3">
+                  <div className="page-card-muted px-4 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Direção</p>
+                    <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{directionLabel(whaleMovement?.direction ?? whaleAlert?.direction)}</p>
+                  </div>
+                  <div className="page-card-muted px-4 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Threshold</p>
+                    <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                      {formatBtc(whaleMovement?.threshold_btc ?? whaleAlert?.threshold_btc)} BTC
+                    </p>
+                  </div>
+                  <div className="page-card-muted px-4 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Delta whale</p>
+                    <p className={`mt-1 text-lg font-semibold ${changeTone(whaleMovement?.change_abs ?? whaleAlert?.change_abs)}`}>
+                      {formatBtc(whaleMovement?.change_abs ?? whaleAlert?.change_abs)} BTC
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/tests/e2e/supply-distribution.spec.ts
+++ b/frontend/tests/e2e/supply-distribution.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test'
+
+async function setupApiMocks(page: any) {
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/onchain/glassnode/BTC/supply-distribution**', async (route: any) => {
+    const url = new URL(route.request().url())
+    const window = url.searchParams.get('window') || '24h'
+    const multiplier = window === '30d' ? 3 : window === '7d' ? 2 : 1
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        asset: 'BTC',
+        basis: 'entity',
+        window,
+        interval: '24h',
+        since: 1777161600,
+        until: 1777248000,
+        cached: false,
+        bands: [
+          {
+            id: 'shrimp',
+            label: '< 1 BTC',
+            min_btc: 0,
+            max_btc: 1,
+            latest: 1120000,
+            previous: 1118000,
+            change_abs: 2000 * multiplier,
+            change_pct: 0.18 * multiplier,
+            share_pct: 6.1,
+          },
+          {
+            id: 'whales',
+            label: '1k+ BTC',
+            min_btc: 1000,
+            max_btc: null,
+            latest: 7420000,
+            previous: 7400000,
+            change_abs: 20000 * multiplier,
+            change_pct: 0.27 * multiplier,
+            share_pct: 40.2,
+          },
+        ],
+        cohorts: {
+          shrimps: { latest: 1120000, previous: 1118000, change_abs: 2000, change_pct: 0.18, share_pct: 6.1 },
+          whales: { latest: 7420000, previous: 7400000, change_abs: 20000, change_pct: 0.27, share_pct: 40.2 },
+          hodlers: { latest: 14800000, previous: 14750000, change_abs: 50000, change_pct: 0.34, share_pct: 74.8 },
+        },
+        whale_movement: {
+          threshold_btc: 1000,
+          change_abs: 20000 * multiplier,
+          direction: 'accumulation',
+          alert: true,
+        },
+        alerts: [{ type: 'whale-alert', threshold_btc: 1000, change_abs: 20000 * multiplier, direction: 'accumulation' }],
+        sources: { glassnode: { metric: 'supply_distribution' } },
+      }),
+    })
+  })
+}
+
+test('Supply distribution dashboard renders cohorts, bands, window filter, and whale alert', async ({ page }) => {
+  await setupApiMocks(page)
+
+  await page.goto('/supply-distribution')
+
+  await expect(page.getByRole('heading', { name: 'Distribuição de supply' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '24h' })).toBeVisible()
+  await expect(page.getByText('Shrimps')).toBeVisible()
+  await expect(page.getByText('Whales')).toBeVisible()
+  await expect(page.getByText('Hodlers')).toBeVisible()
+  await expect(page.getByTestId('supply-band-shrimp')).toContainText('< 1 BTC')
+  await expect(page.getByTestId('supply-band-whales')).toContainText('1k+ BTC')
+  await expect(page.getByText('Whale alert')).toBeVisible()
+  await expect(page.getByText('Ativo')).toBeVisible()
+
+  await page.getByRole('button', { name: '7d' }).click()
+  await expect(page.getByRole('button', { name: '7d' })).toHaveClass(/border-emerald/)
+  await expect(page.getByText('40.000 BTC')).toBeVisible()
+
+  await page
+    .getByRole('navigation', { name: 'Navegação principal' })
+    .getByRole('link', { name: 'Distribuição', exact: true })
+    .click()
+  await expect(page).toHaveURL(/\/supply-distribution/)
+})

--- a/openspec/changes/collect-supply-distribution-metrics/.openspec.yaml
+++ b/openspec/changes/collect-supply-distribution-metrics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/collect-supply-distribution-metrics/design.md
+++ b/openspec/changes/collect-supply-distribution-metrics/design.md
@@ -1,0 +1,93 @@
+## Context
+
+O conector Glassnode existente centraliza API key, cache, rate limit, normalizacao de pontos e erros de provider. Distribuicao de supply deve seguir o mesmo padrao das entregas on-chain anteriores: o conector conhece endpoints, o servico de dominio calcula janelas/cohorts/alertas, e a rota apenas adapta payload e erros HTTP.
+
+Os endpoints desta entrega foram conferidos na documentacao oficial da Glassnode:
+
+- Entity supply bands: `/v1/metrics/entities/supply_balance_less_0001`, `/supply_balance_0001_001`, `/supply_balance_001_01`, `/supply_balance_01_1`, `/supply_balance_1_10`, `/supply_balance_10_100`, `/supply_balance_100_1k`, `/supply_balance_1k_10k`, `/supply_balance_10k_100k`, `/supply_balance_more_100k`
+- Long-Term Holder Supply: `/v1/metrics/supply/lth_sum`
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Coletar supply por faixas de saldo de entities para assets suportados pelo conector, com foco operacional inicial em BTC.
+- Expor API e dashboard por faixa de wallets/entities nas janelas `24h`, `7d` e `30d`.
+- Calcular latest, baseline da janela, delta absoluto, delta percentual e share de cada faixa.
+- Agregar `shrimps` como entities com menos de `1 BTC`, `whales` como entities com pelo menos `1000 BTC`, e `hodlers` a partir de LTH supply.
+- Emitir `whale-alert` quando a variacao absoluta de supply das faixas whale for maior ou igual a `1000 BTC`.
+- Reaproveitar cache, rate limit, API key e erros do conector Glassnode.
+
+**Non-Goals:**
+
+- Criar alerta transacional em tempo real de transferencias grandes.
+- Persistir historico ou alertas em banco.
+- Enviar notificacoes push, Telegram, email ou WebSocket.
+- Adicionar suporte para bases alternativas alem de `entity` nesta entrega.
+
+## Decisions
+
+### Base entity para whales e shrimps
+
+O contrato inicial usa `basis=entity`, porque a Glassnode documenta faixas por entities e isso se aproxima melhor de comportamento de whales do que enderecos crus.
+
+Alternativa considerada: misturar address bands e entity bands. Rejeitada porque criaria leituras inconsistentes entre holders, whales e shrimps.
+
+### Whale movement como delta de supply da cohort
+
+`whale_movement` sera a diferenca entre o latest e o primeiro ponto numerico da janela nas faixas `1k-10k`, `10k-100k` e `>100k`. Direcao:
+
+- `accumulation`: delta positivo
+- `distribution`: delta negativo
+- `flat`: delta zero ou indisponivel
+
+Alternativa considerada: usar um feed de transferencias whale. Rejeitada nesta entrega porque o criterio pede coleta de supply e o provider configurado entrega serie diaria por faixa; feed transacional exigiria outra fonte/semantica.
+
+### Janelas diarias alinhadas em UTC
+
+As series de supply usadas nesta entrega sao diarias. A consulta ao provider busca um dia extra antes do inicio da janela e calcula o baseline pelo ponto diario correspondente a `latest - window`, evitando que a visao `24h` fique sem delta quando `now` cai apos a meia-noite UTC.
+
+### Threshold do alerta
+
+O alerta `whale-alert` dispara quando `abs(whale_movement.change_abs) >= 1000`. O payload inclui threshold, direcao, delta e janela para que o dashboard explique o sinal.
+
+### Contrato de rota
+
+Nova rota:
+
+`GET /api/onchain/glassnode/{asset}/supply-distribution?basis=entity&window=7d`
+
+Query params:
+
+- `basis`: default/fixo `entity`
+- `window`: `24h`, `7d` ou `30d`
+
+Resposta:
+
+- `asset`, `basis`, `window`, `interval`, `since`, `until`, `cached`
+- `bands`: faixas com `id`, `label`, `min_btc`, `max_btc`, `latest`, `previous`, `change_abs`, `change_pct`, `share_pct`
+- `cohorts`: `shrimps`, `whales`, `hodlers`
+- `whale_movement`: delta agregado da cohort whale e status do alerta
+- `alerts`: lista de alertas, inicialmente `whale-alert`
+- `sources`: metadata por metrica Glassnode
+
+### Dashboard frontend
+
+A tela fica em rota protegida `/supply-distribution`, com controles compactos de janela, cards de cohorts, tabela/barras por faixa e painel de alerta. A UI consome a rota backend e usa estado de loading, erro e vazio sem depender de credenciais Glassnode no navegador.
+
+## Risks / Trade-offs
+
+- [Risk] Algumas metricas Glassnode podem exigir plano pago ou ter suporte limitado por asset. -> Mitigation: manter erros de provider/configuracao explicitos e validar primeiro com testes mockados.
+- [Risk] `whale-alert` pode ser confundido com alerta transacional em tempo real. -> Mitigation: nomear no payload como variacao de supply por janela e documentar non-goal.
+- [Risk] Buscar muitas faixas aumenta creditos/latencia. -> Mitigation: usar intervalo diario, janelas pequenas e cache existente.
+- [Risk] Share de supply depende das faixas retornadas pelo provider. -> Mitigation: calcular share contra a soma das faixas numericas retornadas e preservar sources/points no payload.
+
+## Migration Plan
+
+1. Adicionar mappings de supply/entity bands no conector Glassnode.
+2. Implementar servico de dominio para janelas, bandas, cohorts e alertas.
+3. Expor rota backend e modelos Pydantic.
+4. Adicionar dashboard frontend e navegacao.
+5. Cobrir servico, conector, rota e UI com testes.
+
+Rollback: remover rota, servico, dashboard e mappings adicionados. Como nao ha migracao de banco, nao ha rollback de dados.

--- a/openspec/changes/collect-supply-distribution-metrics/proposal.md
+++ b/openspec/changes/collect-supply-distribution-metrics/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+O sistema precisa acompanhar distribuicao de supply por faixa de wallets/entities para separar acumulacao estrutural de varejo, holder e grandes carteiras dos sinais puramente tecnicos de preco.
+
+## What Changes
+
+- Coletar distribuicao de supply via Glassnode por faixas de saldo em entities.
+- Expor dashboard operacional por faixa de wallets/entities com latest, baseline da janela, delta absoluto, delta percentual e share de supply.
+- Agregar cohorts de `shrimps`, `whales` e `hodlers` para leitura direta.
+- Detectar movimentacao de whales como variacao do supply nas faixas `>= 1000 BTC` dentro da janela selecionada.
+- Emitir alerta `whale-alert` quando a movimentacao absoluta de whales for maior ou igual a `1000 BTC`.
+- Expor rota backend e tela frontend para consulta de `24h`, `7d` e `30d`, reaproveitando cache/rate limit/API key do conector Glassnode.
+
+## Capabilities
+
+### New Capabilities
+- `supply-distribution-metrics`: Coleta, agrega e apresenta supply por faixa de wallets/entities, cohorts de shrimps/whales/hodlers e alerta de movimentacao de whales.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Backend: novos mappings Glassnode para entity supply bands e LTH supply, novo servico de dominio e nova rota em `onchain_metrics`.
+- Frontend: nova pagina de dashboard de supply, item de navegacao e consumo da rota on-chain.
+- Glassnode: uso de endpoints de entities/supply com intervalo diario e cache existente.
+- Testes: cobertura unit/CQ para mapping, agregacao, alertas, rota e tela com API mockada.
+- OpenSpec: nova capability `supply-distribution-metrics` documentando contrato de API, dashboard e semantica do alerta.
+- Sem migracao de banco nesta entrega.

--- a/openspec/changes/collect-supply-distribution-metrics/specs/supply-distribution-metrics/spec.md
+++ b/openspec/changes/collect-supply-distribution-metrics/specs/supply-distribution-metrics/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Supply distribution is collected from Glassnode
+The system SHALL collect supply distribution for supported assets through the existing Glassnode connector using daily entity supply-band metrics and long-term holder supply.
+
+#### Scenario: Supply distribution requested
+- **WHEN** supply distribution is requested for `BTC`
+- **THEN** the system SHALL fetch entity supply bands from `supply_balance_less_0001`, `supply_balance_0001_001`, `supply_balance_001_01`, `supply_balance_01_1`, `supply_balance_1_10`, `supply_balance_10_100`, `supply_balance_100_1k`, `supply_balance_1k_10k`, `supply_balance_10k_100k`, and `supply_balance_more_100k`
+- **AND** long-term holder supply from `lth_sum`.
+
+#### Scenario: Unsupported basis rejected
+- **WHEN** supply distribution is requested with a basis other than `entity`
+- **THEN** the system SHALL reject the request before calling Glassnode.
+
+### Requirement: Supply dashboard payload exposes wallet bands
+The system SHALL expose dashboard-ready supply bands with latest value, previous window value, absolute change, percentage change, and share of represented supply.
+
+#### Scenario: Numeric band series available
+- **GIVEN** a supply band contains at least two numeric points in the selected window
+- **WHEN** the system aggregates the band
+- **THEN** the band payload SHALL include latest supply, previous supply, absolute change, percentage change, and share percentage.
+
+#### Scenario: Sparse band series remains valid
+- **GIVEN** a supply band contains fewer than two numeric points
+- **WHEN** the system aggregates the band
+- **THEN** the band payload SHALL remain present
+- **AND** unavailable derived fields SHALL be `null`.
+
+### Requirement: Supply cohorts are aggregated
+The system SHALL aggregate supply cohorts for shrimps, whales, and hodlers.
+
+#### Scenario: Shrimp and whale cohorts calculated
+- **WHEN** supply bands are aggregated
+- **THEN** `shrimps` SHALL include entity bands with balance below `1 BTC`
+- **AND** `whales` SHALL include entity bands with balance greater than or equal to `1000 BTC`.
+
+#### Scenario: Hodler cohort calculated
+- **WHEN** long-term holder supply is returned by Glassnode
+- **THEN** `hodlers` SHALL include latest, previous, absolute change, and percentage change from the fetched `lth_sum` series.
+
+### Requirement: Whale movement and alerts are detected
+The system SHALL detect whale movement as the windowed change in aggregate supply held by entities with balance greater than or equal to `1000 BTC`.
+
+#### Scenario: Whale accumulation alert emitted
+- **GIVEN** whale supply increases by at least `1000 BTC` over the selected window
+- **WHEN** the system aggregates supply distribution
+- **THEN** the response SHALL include a `whale-alert` alert
+- **AND** `whale_movement.direction` SHALL be `accumulation`.
+
+#### Scenario: Whale distribution alert emitted
+- **GIVEN** whale supply decreases by at least `1000 BTC` over the selected window
+- **WHEN** the system aggregates supply distribution
+- **THEN** the response SHALL include a `whale-alert` alert
+- **AND** `whale_movement.direction` SHALL be `distribution`.
+
+#### Scenario: Movement below threshold is not an alert
+- **GIVEN** whale supply changes by less than `1000 BTC` over the selected window
+- **WHEN** the system aggregates supply distribution
+- **THEN** the response SHALL NOT include a `whale-alert` alert.
+
+### Requirement: Supply distribution is exposed through API
+The system SHALL expose supply distribution through the on-chain Glassnode API surface.
+
+#### Scenario: API returns supply distribution payload
+- **WHEN** `GET /api/onchain/glassnode/BTC/supply-distribution?basis=entity&window=7d` is requested
+- **THEN** the API SHALL return asset, basis, window, interval, cached status, bands, cohorts, whale movement, alerts, and source metadata.
+
+#### Scenario: Provider errors are mapped
+- **WHEN** the supply distribution service raises configuration, validation, or rate-limit errors
+- **THEN** the API SHALL map them to the same HTTP statuses used by the existing Glassnode routes.
+
+### Requirement: Supply distribution dashboard is available
+The system SHALL provide a protected frontend dashboard for supply distribution.
+
+#### Scenario: Dashboard renders wallet bands
+- **WHEN** a user opens `/supply-distribution`
+- **THEN** the dashboard SHALL request supply distribution from the backend
+- **AND** display wallet/entity bands, shrimp/whale/hodler cohorts, whale movement, and alert state.
+
+#### Scenario: Dashboard window changes
+- **WHEN** a user selects `24h`, `7d`, or `30d`
+- **THEN** the dashboard SHALL refresh the backend request with the selected window.

--- a/openspec/changes/collect-supply-distribution-metrics/tasks.md
+++ b/openspec/changes/collect-supply-distribution-metrics/tasks.md
@@ -1,0 +1,39 @@
+## 1. OpenSpec And Coordination
+
+- [x] 1.1 Create proposal, design, spec, and tasks for supply distribution.
+- [x] 1.2 Use project skills and subagents for mapping, implementation validation, and review when applicable.
+- [x] 1.3 Record the alert semantics and non-goals in the OpenSpec artifacts.
+
+## 2. Glassnode Connector
+
+- [x] 2.1 Add Glassnode endpoint mappings for entity supply bands and long-term holder supply.
+- [x] 2.2 Preserve existing API key, cache, rate-limit, asset validation, and provider error behavior.
+
+## 3. Backend Domain Service
+
+- [x] 3.1 Add supply distribution service using the existing Glassnode connector.
+- [x] 3.2 Normalize `basis=entity`, `window=24h|7d|30d`, and fixed daily interval.
+- [x] 3.3 Aggregate band latest, previous, change, change percent, and share percent.
+- [x] 3.4 Aggregate shrimp, whale, and hodler cohorts.
+- [x] 3.5 Emit `whale-alert` when whale supply movement is at least `1000 BTC` in absolute value.
+- [x] 3.6 Keep empty, sparse, and non-numeric series valid without crashing.
+
+## 4. API Surface
+
+- [x] 4.1 Add `GET /api/onchain/glassnode/{asset}/supply-distribution`.
+- [x] 4.2 Return bands, cohorts, whale movement, alerts, sources, cache status, and query metadata.
+- [x] 4.3 Map validation/config/rate-limit errors to the existing Glassnode HTTP statuses.
+
+## 5. Frontend Dashboard
+
+- [x] 5.1 Add protected `/supply-distribution` dashboard route and navigation entry.
+- [x] 5.2 Render wallet/entity bands, cohorts, whale movement, alerts, loading, empty, and error states.
+- [x] 5.3 Add window controls for `24h`, `7d`, and `30d` that refresh the API query.
+
+## 6. Validation
+
+- [x] 6.1 Add unit tests for connector mappings.
+- [x] 6.2 Add unit tests for service aggregation, cohorts, threshold, boundary, and sparse payloads.
+- [x] 6.3 Add route tests for payload and error mapping.
+- [x] 6.4 Add frontend test for dashboard render, alert state, and window switching.
+- [x] 6.5 Run OpenSpec validation, targeted backend tests, frontend build/test, and formatting checks.


### PR DESCRIPTION
## Summary
- add Glassnode supply distribution mappings for entity supply bands and LTH supply
- add backend aggregation for wallet bands, shrimps, whales, hodlers, whale movement, and whale-alert
- add protected frontend dashboard at /supply-distribution with 24h/7d/30d controls
- add OpenSpec change artifacts for collect-supply-distribution-metrics

## Validation
- openspec validate collect-supply-distribution-metrics --type change --strict
- ./backend/.venv/bin/python -m black --check backend/app/services/glassnode_service.py backend/app/services/onchain_supply_distribution_service.py backend/app/routes/onchain_metrics.py backend/tests/unit/test_glassnode_service.py backend/tests/unit/test_onchain_supply_distribution_service.py backend/tests/unit/test_onchain_metrics_route.py
- ./backend/.venv/bin/python -m pytest -q backend/tests/unit/test_glassnode_service.py backend/tests/unit/test_onchain_supply_distribution_service.py backend/tests/unit/test_onchain_metrics_route.py
- ./backend/.venv/bin/python -m pytest -q backend/tests/unit
- npm --prefix frontend run build
- npm --prefix frontend run test:e2e -- tests/e2e/supply-distribution.spec.ts
- npm --prefix frontend run lint (passes with existing warnings)

## Notes
- whale-alert is defined as daily supply movement in the >=1000 BTC entity cohorts, not a real-time transaction feed.
- Glassnode endpoints checked against official docs: https://docs.glassnode.com/basic-api/endpoints/entities and https://docs.glassnode.com/basic-api/endpoints/supply