### PR TITLE
feat: define monitor as operational home route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { useEffect } from 'react'
 import { ProtectedLayout } from './components/ProtectedLayout'
 import { AuthLayout } from './components/AuthLayout'
@@ -63,7 +63,8 @@ function App() {
         </Route>
 
         <Route element={<ProtectedLayout />}>
-          <Route path="/" element={<HomePage />} />
+          <Route index element={<Navigate to="/monitor" replace />} />
+          <Route path="/home" element={<HomePage />} />
           <Route path="/favorites" element={<FavoritesDashboard />} />
           <Route path="/monitor" element={<MonitorPage />} />
           <Route path="/kanban" element={<KanbanPage />} />

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -5,7 +5,6 @@ import {
   Bookmark,
   ChartPie,
   ChevronLeft,
-  Home,
   Play,
   KeyRound,
   Layers,
@@ -33,9 +32,8 @@ type NavItemConfig = {
 }
 
 const mainNavItems: NavItemConfig[] = [
-  { to: '/', label: 'Playground', icon: Home },
-  { to: '/favorites', label: 'Favoritos', icon: Bookmark },
   { to: '/monitor', label: 'Monitor', icon: Activity },
+  { to: '/favorites', label: 'Favoritos', icon: Bookmark },
   { to: '/signals', label: 'Sinais', icon: TrendingUp },
   { to: '/signals/history', label: 'Histórico', icon: TrendingUp },
   { to: '/supply-distribution', label: 'Distribuição', icon: ChartPie },
@@ -62,9 +60,8 @@ export function openMobileMenu() {
 }
 
 function resolvePageTitle(pathname: string) {
-  if (pathname === '/') return 'Dashboard principal'
+  if (pathname === '/' || pathname === '/monitor') return 'Monitor de sinais'
   if (pathname === '/favorites') return 'Favoritos'
-  if (pathname === '/monitor') return 'Monitor de sinais'
   if (pathname === '/signals') return 'Sinais de trading'
   if (pathname === '/signals/history') return 'Histórico de Sinais'
   if (pathname === '/supply-distribution') return 'Distribuição de supply'
@@ -129,8 +126,8 @@ function NavSection({
       <div className="space-y-1">
         {items.map(({ to, label, icon: Icon }) => {
           const isActive =
-            to === '/'
-              ? pathname === '/'
+            to === '/monitor'
+              ? pathname === '/monitor' || pathname === '/'
               : to.startsWith('/combo')
                 ? pathname.startsWith('/combo')
                 : pathname === to || pathname.startsWith(`${to}/`)

--- a/frontend/src/components/ProtectedLayout.tsx
+++ b/frontend/src/components/ProtectedLayout.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { Layout } from './Layout'
 import { useAuth } from '@/stores/authStore'
 
@@ -8,6 +8,7 @@ import { useAuth } from '@/stores/authStore'
  */
 export function ProtectedLayout() {
   const { user, isLoading } = useAuth()
+  const location = useLocation()
 
   // Enquanto valida token, mostra loading
   if (isLoading) {
@@ -20,7 +21,7 @@ export function ProtectedLayout() {
 
   // Não autenticado → redireciona para login
   if (!user) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/login" replace state={{ returnTo: location.pathname }} />
   }
 
   // Autenticado → renderiza o Layout normal

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/stores/authStore'
 
 interface ProtectedRouteProps {
@@ -12,6 +12,7 @@ interface ProtectedRouteProps {
  */
 export function ProtectedRoute({ children, requireAdmin = false }: ProtectedRouteProps) {
   const { user, isLoading } = useAuth()
+  const location = useLocation()
 
   // Enquanto valida token, mostra loading
   if (isLoading) {
@@ -24,11 +25,11 @@ export function ProtectedRoute({ children, requireAdmin = false }: ProtectedRout
 
   // Não autenticado → redireciona para login
   if (!user) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/login" replace state={{ returnTo: location.pathname }} />
   }
 
   if (requireAdmin && !user.isAdmin) {
-    return <Navigate to="/" replace />
+    return <Navigate to="/monitor" replace />
   }
 
   return <>{children}</>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/stores/authStore'
 import axios from 'axios'
 import { Eye, EyeOff, TrendingUp } from 'lucide-react'
@@ -15,7 +15,11 @@ interface FormErrors {
 
 export default function LoginPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { login, register } = useAuth()
+
+  const fallbackRoute = '/monitor'
+  const destination = ((location.state as { returnTo?: string } | null)?.returnTo || fallbackRoute).trim() || fallbackRoute
 
   const [mode, setMode] = useState<Mode>('login')
   const [showPassword, setShowPassword] = useState(false)
@@ -66,10 +70,10 @@ export default function LoginPage() {
     try {
       if (mode === 'login') {
         await login(email, password)
-        navigate('/')
+        navigate(destination, { replace: true })
       } else {
         await register(name, email, password)
-        navigate('/')
+        navigate(destination, { replace: true })
       }
     } catch (err: unknown) {
       setIsLoading(false)
@@ -259,15 +263,6 @@ export default function LoginPage() {
         </form>
       </div>
 
-      {/* Back link */}
-      <div className="mt-6 text-center">
-        <Link
-          to="/"
-          className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition"
-        >
-          ← Voltar para o Playground
-        </Link>
-      </div>
     </div>
   )
 }

--- a/frontend/tests/e2e/homepage-real-data.spec.ts
+++ b/frontend/tests/e2e/homepage-real-data.spec.ts
@@ -145,7 +145,7 @@ test('HomePage desktop renders real data and explicit snapshot labels', async ({
   await blockExternalNetwork(page)
   await mockHomeApis(page)
 
-  await page.goto('/')
+  await page.goto('/home')
 
   await expect(page.getByRole('heading', { name: 'Seu snapshot diário de crypto' })).toBeVisible()
   await expect(page.getByTestId('home-kpi-best-strategy').getByText('Breakout Pro')).toBeVisible()
@@ -174,7 +174,7 @@ test('HomePage mobile shows empty and error fallbacks without blank sections', a
     marketPricesBody: { prices: [], fetched_at: null },
   })
 
-  await page.goto('/')
+  await page.goto('/home')
 
   await expect(page.getByTestId('home-kpi-best-strategy').getByText('Nenhuma estratégia favoritada')).toBeVisible()
   await expect(page.getByTestId('home-kpi-freshness').getByText('não disponível')).toBeVisible()

--- a/frontend/tests/e2e/issue-68-monitor-home.spec.ts
+++ b/frontend/tests/e2e/issue-68-monitor-home.spec.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+
+async function blockExternalNetwork(page: any) {
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+}
+
+async function mockMonitorApi(page: any) {
+  await page.route('**/api/opportunities/?tier=*', (route: any) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  })
+
+  await page.route('**/api/monitor/preferences', (route: any) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  })
+
+  await page.route('**/api/user/binance-credentials', (route: any) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configured: false, api_key_masked: null }),
+    })
+  })
+
+  await page.route('**/api/external/binance/spot/balances**', (route: any) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ balances: [], total_usd: 0, as_of: '2026-04-28T00:00:00Z' }),
+    })
+  })
+}
+
+async function mockLoginSuccess(page: any) {
+  await page.route('**/api/auth/login', (route: any) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        accessToken: 'test-access-token',
+        refreshToken: 'test-refresh-token',
+        id: 'test-user',
+        email: 'test@example.com',
+        name: 'Test User',
+        isAdmin: false,
+      }),
+    })
+  })
+}
+
+test('raiz autenticada deve abrir no Monitor', async ({ page }) => {
+  const evidenceDir = path.resolve(process.cwd(), '..', 'qa_artifacts', 'playwright', 'issue-68')
+  fs.mkdirSync(evidenceDir, { recursive: true })
+
+  await blockExternalNetwork(page)
+  await mockMonitorApi(page)
+
+  await page.goto('/')
+
+  await expect(page).toHaveURL('/monitor')
+  await expect(page.getByTestId('monitor-status-tab')).toBeVisible()
+  await page.screenshot({ path: path.join(evidenceDir, '01-root-to-monitor.png'), fullPage: true })
+})
+
+test('login deve redirecionar para /monitor', async ({ page }) => {
+  const evidenceDir = path.resolve(process.cwd(), '..', 'qa_artifacts', 'playwright', 'issue-68')
+  fs.mkdirSync(evidenceDir, { recursive: true })
+
+  await blockExternalNetwork(page)
+  await mockMonitorApi(page)
+  await mockLoginSuccess(page)
+
+  await page.route('**/api/auth/me', (route: any) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-user', email: 'test@example.com', name: 'Test User', isAdmin: false }),
+    })
+  })
+
+  await page.goto('/login')
+  await page.getByPlaceholder('seu@email.com').fill('test@example.com')
+  await page.getByPlaceholder('••••••••').first().fill('12345678')
+  await page.locator('form').getByRole('button', { name: 'Entrar' }).click()
+
+  await expect(page).toHaveURL('/monitor')
+  await expect(page.getByTestId('monitor-status-tab')).toBeVisible()
+  await page.screenshot({ path: path.join(evidenceDir, '02-login-to-monitor.png'), fullPage: true })
+})

--- a/openspec/changes/issue-68-monitor-home-on-login/proposal.md
+++ b/openspec/changes/issue-68-monitor-home-on-login/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: Definir Monitor como página inicial operacional após login
+
+## Why
+
+Com o redirecionamento atual, o fluxo de autenticação leva o usuário novamente para `/`
+após login/criação de conta. Isso mantém uma tela menos operacional e não reflete a
+posição atual do produto, onde o Monitor é a home funcional principal.
+
+## What
+
+Esta change ajusta o fluxo de pós-login para abrir `/monitor` e mantém o acesso autenticado
+à raiz (`/`) também apontado para o Monitor, reduzindo fricção e deixando a navegação
+alinhada com o uso real.
+
+Inclui também preservação de retorno (`returnTo`) para acesso a rotas protegidas profundas,
+além de alinhar o acesso principal do app para não expor “Playground” como rota de entrada.
+
+## Scope
+
+- Frontend:
+  - `frontend/src/pages/LoginPage.tsx`
+  - `frontend/src/App.tsx`
+- OpenSpec (evidência da alteração):
+  - `openspec/changes/issue-68-monitor-home-on-login/`
+
+## Out of Scope
+
+- Mudanças de backend de autenticação.
+- Redesenho de navegação lateral/labels.
+
+## Impact
+
+- Experiência pós-login passa a entrar direto no Monitor.
+- A rota pública raiz autenticada (`/`) passa a delegar para a home operacional.

--- a/openspec/changes/issue-68-monitor-home-on-login/specs/monitor-home-route/spec.md
+++ b/openspec/changes/issue-68-monitor-home-on-login/specs/monitor-home-route/spec.md
@@ -1,0 +1,35 @@
+# Monitor Home Route (Frontend)
+
+## Requirement
+
+- O fluxo de autenticação (login ou cadastro) deve terminar em `/monitor`.
+- A raiz autenticada da aplicação (`/`) deve atuar como entrada operacional e
+  redirecionar para `/monitor`.
+- Quando acesso protegido exigir autenticação, o retorno deve preservar a rota de origem em `location.state.returnTo`.
+- A navegação principal não deve chamar `/` de “Playground”; `/monitor` é a home operacional.
+
+### Scenario: Login bem-sucedido
+
+- **WHEN** um usuário autentica com credenciais válidas em `/login`
+- **THEN** o app navega para `/monitor` com `replace`.
+
+### Scenario: Cadastro/autologin bem-sucedido
+
+- **WHEN** um novo usuário finaliza o cadastro em `/login` (modo `register`)
+- **THEN** o app navega para `/monitor` com `replace`.
+
+### Scenario: Usuário autenticado abre `/`
+
+- **WHEN** um usuário autenticado acessa `/`
+- **THEN** a rota principal autenticada redireciona para `/monitor`.
+
+### Scenario: Usuário sem autenticação cai em /login e retorna após login
+
+- **WHEN** usuário sem autenticação acessa `/signals` e é enviado para `/login` com `state.returnTo`
+- **AND** faz login com sucesso
+- **THEN** a navegação retorna para `/signals`.
+
+### Scenario: Navegação principal reflete home operacional
+
+- **WHEN** usuário está no layout autenticado
+- **THEN** o item de acesso principal aponta para `Monitor` em `/monitor` e não para `Playground` em `/`.

--- a/openspec/changes/issue-68-monitor-home-on-login/tasks.md
+++ b/openspec/changes/issue-68-monitor-home-on-login/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Monitor as Post-Login Home
+
+- [x] [1] Atualizar `frontend/src/pages/LoginPage.tsx` para redirecionar para `/monitor` após login/cadastro.
+- [x] [2] Atualizar `frontend/src/App.tsx` para tornar `/` (index autenticado) um redirecionamento para `/monitor` e preservar `HomePage` em `/home`.
+- [x] [3] Ajustar fallback de autenticação em `frontend/src/components/ProtectedLayout.tsx` e `frontend/src/components/ProtectedRoute.tsx` para preservar retorno da rota original no `login`.
+- [x] [4] Ajustar navegação principal (`frontend/src/components/AppNav.tsx`) para evitar referência a `/` como “Playground”.
+- [x] [5] Atualizar teste E2E `frontend/tests/e2e/homepage-real-data.spec.ts` para consumir `/home` explicitamente.
+- [x] [6] Criar `frontend/tests/e2e/issue-68-monitor-home.spec.ts` cobrindo `/ -> /monitor` e login -> `/monitor`.
+- [x] [7] Registrar a mudança em `openspec/changes/issue-68-monitor-home-on-login/` com proposta, especificação e rastreio de tarefas.


### PR DESCRIPTION
## Resumo
- Define fluxo de entrada do MVP após autenticação para ir para /monitor.
- Mantém /home como rota de acesso legado.
- Preserva retorno (returnTo) no fluxo de login e proteção de rotas.
- Ajusta navegação para deixar /monitor como home operacional no menu.
- Corrige testes E2E existentes para ir em /home e adiciona teste dedicado do Issue #68.

## Validação
- npm --prefix frontend run build ✅
- npx playwright test tests/e2e/issue-68-monitor-home.spec.ts tests/e2e/homepage-real-data.spec.ts ✅ (4 passed)

## Issue
- https://github.com/oalansilva/crypto/issues/68