### PR TITLE
feat: listar estrategias favoritas no monitor

### DIFF
--- a/backend/app/services/opportunity_service.py
+++ b/backend/app/services/opportunity_service.py
@@ -491,7 +491,8 @@ class OpportunityService:
 
             normalized_tier_filter = str(tier_filter or "").strip().lower()
             if not normalized_tier_filter or normalized_tier_filter == "all":
-                query = query.filter(FavoriteStrategy.tier.in_([1, 2, 3]))
+                # Keep behavior consistent with API docs: "all"/empty = sem filtro por tier.
+                pass
             elif normalized_tier_filter == "none":
                 query = query.filter(FavoriteStrategy.tier.is_(None))
             else:
@@ -548,8 +549,8 @@ class OpportunityService:
             Filtered list of favorites
         """
         if not tier_filter or tier_filter.lower() == "all":
-            # "All" = apenas Tier 1, 2 e 3 (excluir Sem tier)
-            return [f for f in favorites if f.get("tier") in (1, 2, 3)]
+            # "all" = no filter (including Sem tier), aligned with docs.
+            return favorites
 
         tier_filter = tier_filter.lower().strip()
 

--- a/backend/tests/unit/test_opportunity_service_coverage.py
+++ b/backend/tests/unit/test_opportunity_service_coverage.py
@@ -192,3 +192,58 @@ def test_get_opportunities_ccxt_applies_continuity_fix(monkeypatch):
     assert len(out) == 1
     assert fixed["called"] is True
     assert out[0]["timeframe"] == "1h"
+
+
+def test_filter_by_tier_all_keeps_null_tier_favorites():
+    service = OpportunityService(db_path=":memory:")
+    favorites = [
+        {
+            "id": 1,
+            "name": "A",
+            "symbol": "BTC/USDT",
+            "timeframe": "1d",
+            "strategy_name": "s1",
+            "parameters": {},
+            "tier": 1,
+        },
+        {
+            "id": 2,
+            "name": "B",
+            "symbol": "ETH/USDT",
+            "timeframe": "1d",
+            "strategy_name": "s2",
+            "parameters": {},
+            "tier": None,
+        },
+    ]
+
+    assert service._filter_by_tier(favorites, None) == favorites
+    assert service._filter_by_tier(favorites, "all") == favorites
+
+
+def test_filter_by_tier_none_returns_only_null_tier_favorites():
+    service = OpportunityService(db_path=":memory:")
+    favorites = [
+        {
+            "id": 1,
+            "name": "A",
+            "symbol": "BTC/USDT",
+            "timeframe": "1d",
+            "strategy_name": "s1",
+            "parameters": {},
+            "tier": 1,
+        },
+        {
+            "id": 2,
+            "name": "B",
+            "symbol": "ETH/USDT",
+            "timeframe": "1d",
+            "strategy_name": "s2",
+            "parameters": {},
+            "tier": None,
+        },
+    ]
+
+    filtered = service._filter_by_tier(favorites, "none")
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == 2

--- a/frontend/src/components/monitor/MonitorStatusTab.tsx
+++ b/frontend/src/components/monitor/MonitorStatusTab.tsx
@@ -445,22 +445,8 @@ export const MonitorStatusTab: React.FC = () => {
         return afterAssetType.filter((opp) => portfolioStatusBySymbol[opp.symbol]?.inPortfolio === true);
     }, [assetTypeFilter, listFilter, portfolioStatusBySymbol, sortedOpportunities]);
 
-    // Render one card per symbol (preferences are per-symbol, and duplicate cards can fight over fetch/caches).
-    const dedupedOpportunities = useMemo(() => {
-        const seen = new Set<string>();
-        const out: Opportunity[] = [];
-        for (const opp of filteredOpportunities) {
-            const sym = String(opp.symbol || '').trim();
-            if (!sym) continue;
-            if (seen.has(sym)) continue;
-            seen.add(sym);
-            out.push(opp);
-        }
-        return out;
-    }, [filteredOpportunities]);
-
     const resolvedSections = useMemo(
-        () => dedupedOpportunities.map((opp) => {
+        () => filteredOpportunities.map((opp) => {
             const preference = preferences[opp.symbol] ?? DEFAULT_PREFERENCE;
             const effectiveTimeframe: MonitorPriceTimeframe = getOpportunityAssetType(opp) === 'crypto' ? preference.price_timeframe : '1d';
             return {
@@ -468,7 +454,7 @@ export const MonitorStatusTab: React.FC = () => {
                 resolved: resolveOpportunitySignal(opp, { selectedTimeframe: effectiveTimeframe }),
             };
         }),
-        [dedupedOpportunities, preferences],
+        [filteredOpportunities, preferences],
     );
 
     const holding = resolvedSections.filter(({ resolved }) => resolved.section === 'holding').map(({ opportunity }) => opportunity);

--- a/frontend/src/components/monitor/OpportunityCard.tsx
+++ b/frontend/src/components/monitor/OpportunityCard.tsx
@@ -67,6 +67,7 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
     const {
         symbol,
         name,
+        template_name,
         timeframe,
         is_holding,
         distance_to_next_status,
@@ -233,6 +234,9 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
                 : `Waiting for ${next_status_label} signal`
         ));
 
+    const displayName = (name || '').trim() || template_name;
+    const shouldShowTemplate = Boolean((template_name || '').trim()) && String(name || '').trim() !== String(template_name || '').trim();
+
     // NOTE: Avoid hardcoded light backgrounds via inline styles.
     // They reduce contrast on mobile/dark mode. Background colors are handled via Tailwind classes.
     const cardStyle = resolvedSignal.section === 'holding'
@@ -316,8 +320,13 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
                         ) : null}
                     </CardTitle>
                     <span className="text-sm text-gray-700 dark:text-gray-300 truncate max-w-[220px] font-medium">
-                        {name || opportunity.template_name}
+                        {displayName}
                     </span>
+                    {shouldShowTemplate ? (
+                        <span className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[220px]">
+                            {template_name}
+                        </span>
+                    ) : null}
                 </div>
 
                 <div className="flex flex-col items-end gap-2">
@@ -617,6 +626,6 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
                     </div>
                 )}
             </CardContent>
-        </Card>
+    </Card>
     );
 };

--- a/openspec/changes/issue-69-monitor-favorite-opportunities/proposal.md
+++ b/openspec/changes/issue-69-monitor-favorite-opportunities/proposal.md
@@ -1,0 +1,38 @@
+# Proposal: Exibir apenas estratégias favoritas no Monitor (Issue #69)
+
+## Why
+
+Atualmente o Monitor já consulta estratégias favoritas, mas havia lacunas funcionais que
+podiam ocultar estratégias favoritada quando:
+
+- o `tier` era `none` (sem tier definido);
+- o usuário tinha mais de uma estratégia para o mesmo ativo (deduplicação por símbolo).
+
+Isso fazia o Monitor não refletir fielmente o que foi escolhido/favoritado no Backtest.
+
+## What
+
+Esta change garante que o Monitor exiba **apenas estratégias favoritas** (sem perder casos
+sem tier), preservando variações por ativo/timeframe/estratégia e mantendo o comportamento
+de refresh.
+
+### Escopo do backend
+- Ajustar filtro de tier para que `tier=all` e vazio não removam favoritos com `tier is null`.
+- Manter escopo por usuário nas consultas (sem regressão de isolamento).
+- Preservar cache por usuário e filtro de tier existente.
+
+### Escopo do frontend
+- Remover deduplicação agressiva por símbolo em `MonitorStatusTab`.
+- Ajustar renderização do card para mostrar nome/estratégia com maior clareza.
+- Garantir que a lista atualizável continue representando o conjunto real de favoritos.
+
+## Out of Scope
+
+- Mudanças de modelo de dados de favorito (nome/campos de strategy).
+- Novas regras de seleção por carteira além do filtro atual do Monitor.
+
+## Impact
+
+- O Monitor passa a refletir fielmente todas as estratégias favoritas, inclusive sem tier.
+- Múltiplas estratégias no mesmo ativo continuam visíveis.
+- Refresh continua preservando a lista por usuário e filtro atual.

--- a/openspec/changes/issue-69-monitor-favorite-opportunities/specs/monitor-favorite-opportunities/spec.md
+++ b/openspec/changes/issue-69-monitor-favorite-opportunities/specs/monitor-favorite-opportunities/spec.md
@@ -1,0 +1,40 @@
+# Specification: Issue #69 — Listar estratégias favoritas no Monitor
+
+## Requisitos
+
+- O endpoint de oportunidades do Monitor deve retornar apenas estratégias favoritas do usuário autenticado.
+- O filtro `tier=all` deve incluir também favoritos com `tier IS NULL`.
+- O filtro `tier=none` deve retornar somente favoritos com `tier IS NULL`.
+- O filtro `tier` vazio/nulo deve manter contrato atual (sem filtro implícito por tier).
+
+## Persistência e desempenho
+- Refresh com `refresh=true` continua forçando recomputação.
+- O cache permanece por `(user_id, tier)` para evitar mistura entre modos de filtro.
+
+## Renderização no Monitor
+- Não pode haver deduplicação por símbolo que remova estratégias concorrentes com mesmo ativo.
+- Cada cartão deve exibir ativo, timeframe e estratégia correspondentes sem sobreposição.
+
+## Critérios de aceite
+
+1. Com entradas de `tier=all` contendo `tier=1,2,3,null`, o Monitor renderiza todas as estratégias.
+2. Ao trocar refresh, a lista permanece as mesmas estratégias de favorito.
+3. Com duas estratégias no mesmo ativo, ambas aparecem como cards distintos.
+
+## Cenários
+
+### Scenario: exibir favoritos com `tier=all`
+- **Given** um usuário com favoritos em `tier=1`, `tier=2`, `tier=3` e `tier=null`;
+- **When** consulta `GET /api/opportunities/?tier=all`;
+- **Then** a resposta inclui todos os itens favoritos;
+- **And** não inclui estratégias de outros usuários.
+
+### Scenario: listar múltiplas estratégias por símbolo
+- **Given** dois favoritos com `symbol=BTC/USDT` e estratégias diferentes;
+- **When** o Monitor renderiza a lista;
+- **Then** ambos os cards aparecem no resultado (sem deduplicação por símbolo).
+
+### Scenario: refresh preserva lista
+- **Given** uma lista não vazia de favoritos;
+- **When** o usuário aciona Refresh;
+- **Then** o Monitor mantém o mesmo escopo de cartões favoritados.

--- a/openspec/changes/issue-69-monitor-favorite-opportunities/tasks.md
+++ b/openspec/changes/issue-69-monitor-favorite-opportunities/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Issue #69 — Monitor com estratégias favoritas
+
+- [x] Ajustar `OpportunityService.get_favorites` para não aplicar filtro implícito de tier em `tier=all`/vazio.
+- [x] Ajustar `OpportunityService._filter_by_tier` para tratar `all`/vazio como sem filtro de tier.
+- [x] Remover deduplicação por símbolo no `MonitorStatusTab` para preservar múltiplos cartões por ativo/estratégia.
+- [x] Tornar `OpportunityCard` explícito no nome exibido da estratégia/label.
+- [x] Reforçar cobertura de regra `all` inclui `tier=null` em `backend/tests/unit/test_opportunity_service_coverage.py`.


### PR DESCRIPTION
Implementa Issue #69.

- Lista favoritos sem filtrar por tier implícito em all/vazio.
- Preserva favoritos sem tier no Monitor.
- Remove dedupe por símbolo para não ocultar múltiplas estratégias por ativo.
- Ajusta card do Monitor para mostrar estratégia claramente.
- Ajuste mínimo de cobertura unitária de filtro de tier.