### PR TITLE
docs: persist new GitHub-first item rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Padrão de commit recomendado:
 ## Regras de operação
 
 - Fluxo único (sem divisão por agentes): você conduz descoberta, planejamento, implementação, validação e fechamento.
+- Novo requisito de produto/UX/tech deve gerar um item novo no GitHub (Issue) antes de virar tarefa ativa da sprint/turno; mudanças relacionadas a itens já fechados devem ser registradas em issue filha/linkada.
 - Registre em `openspec/changes/<change>/` e no PR:
   - status atual
   - decisões de escopo

--- a/docs/backlog-operating-model.md
+++ b/docs/backlog-operating-model.md
@@ -4,12 +4,14 @@
 
 Este projeto usa dois artefatos complementares:
 
-- **SharePoint Excel `crypto_backlog_po.xlsx`**: fonte executiva e canonica de produto, roadmap, prioridade, decisao e evidencia.
-- **GitHub Projects + Issues**: execucao tecnica semanal, ligada a issue, PR, commit, teste e evidencia.
+- **GitHub Projects + Issues**: fonte operacional de execucao, ligada a issue, PR, commit, teste e evidencia.
+- **SharePoint Excel `crypto_backlog_po.xlsx`**: visao executiva de produto, roadmap, decisao de negocio e evidencia consolidada.
 
 Telegram e chat servem para alinhamento rapido. Nao sao fonte da verdade.
 
 ## Regra Principal
+
+Nao existem dois backlogs ativos. Um item escolhido para execucao vive no GitHub Project. A planilha nao deve duplicar status tecnico; ela recebe resumo ou evidencia apenas quando isso muda produto, roadmap, beta ou negocio.
 
 Um item so e considerado concluido quando tiver evidencia registrada.
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2,9 +2,9 @@
 
 ## 2026-04-28 - Stack de acompanhamento do projeto
 
-**Decisao:** usar `crypto_backlog_po.xlsx` no SharePoint como fonte executiva/canonica e GitHub Projects + Issues como ferramenta de execucao tecnica.
+**Decisao:** usar GitHub Projects + Issues como fonte operacional de execucao e `crypto_backlog_po.xlsx` no SharePoint como visao executiva/produto.
 
-**Motivo:** a planilha e melhor para visao de produto, prioridade, validacao comercial e evidencia executiva; GitHub e melhor para issue, PR, commit, teste e rastreabilidade tecnica.
+**Motivo:** nao manter dois backlogs ativos. GitHub e melhor para issue, PR, commit, teste, status e rastreabilidade tecnica; a planilha e melhor para roadmap macro, decisao de produto, validacao comercial e evidencia executiva consolidada.
 
 **Alternativas avaliadas:**
 
@@ -14,7 +14,7 @@
 - ClickUp: completo, mas pesado demais para a fase atual.
 - Taiga/OpenProject/Kanboard self-hosted: gratuitos, mas adicionam manutencao.
 
-**Regra:** Telegram nao e fonte da verdade. Chat serve para alinhamento rapido; decisoes e evidencias precisam ir para planilha, GitHub ou docs.
+**Regra:** Telegram nao e fonte da verdade. Chat serve para alinhamento rapido; item em execucao vive no GitHub Project; a planilha recebe resumo/evidencia apenas quando isso mudar produto, roadmap, beta ou negocio.
 
 ## 2026-04-28 - Criterio de conclusao
 


### PR DESCRIPTION
Persistência de regra operacional no AGENTS.md para exigir criação de issue para novo item antes de virar tarefa ativa.