### PR TITLE
feat: padronizar estados HOLD WAIT EXIT no Monitor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,12 @@ Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
 - **Branch padrão:** trabalhe em `develop` para trabalho diário de implementação e validações.
 - **Fluxo de produção:** implemente e valide diretamente em `develop`; para liberar produção, abra PR `develop -> main`, resolva automaticamente checks/políticas bloqueantes quando possível e realize o merge quando permitido.
 - **Regra de fluxo:** use somente `develop` e `main`; sem criação de branches por tasks usuais.
+- **Regra de merge:** após abrir um PR de `develop -> main`, o fluxo padrão é tentar o merge automático (se possível) sem esperar nova intervenção manual.
 - **Banco padrão:** PostgreSQL é obrigatório em runtime, QA e scripts operacionais (`DATABASE_URL` e `WORKFLOW_DATABASE_URL` em formato PostgreSQL).
 - **Não usar SQLite** como banco de operação. Em runtime/QA/Homologação, use apenas PostgreSQL (`DATABASE_URL` e `WORKFLOW_DATABASE_URL`).
-- OpenSpec é a camada de especificação técnico (artifacts).
+- **Funcionalidades novas:** siga OpenSpec por padrão antes de implementar (`openspec/changes/<change>/` com proposal/spec/design/tasks quando aplicável).
+- **Subagents:** use subagents sempre que houver ganho claro de paralelismo, investigação independente, validação especializada ou aceleração sem duplicar trabalho.
+- OpenSpec é a camada de especificação técnica (artifacts).
 - Workflow DB e OpenSpec são fontes de operação e evidência.
 
 ## Fluxo Git operacional (sempre)
@@ -18,6 +21,7 @@ Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
 - Commite cada ajuste em `develop`.
 - Abra PR de `develop` para `main` para liberar produção.
 - O merge em `main` é o passo final e de homologação da mudança; por padrão, o agente deve realizar esse merge após abrir o PR, desde que os checks obrigatórios estejam verdes e não haja bloqueios/conflitos.
+- Sempre que houver PR aberto e o bloqueio for apenas de checks ainda pendentes, o agente deve repetir a tentativa de merge automático até completar (ou até novo bloqueio de política/conflito que exija revisão humana).
 - Se o merge for bloqueado por checks, conflitos ou políticas resolvíveis por alteração no repo, o agente deve investigar, corrigir, commitar e dar push até liberar o PR.
 - Se o bloqueio depender de permissão/admin/review humano/configuração externa não editável pelo repo, o agente deve registrar o motivo exato no PR e na resposta final, sem mascarar o bloqueio como concluído.
 - Após merge em `main`, atualize `develop` para refletir o estado da produção.
@@ -47,7 +51,7 @@ Checklist de rotina (diária/por mudança):
 6. `git push`
 7. `gh pr create --base main --head develop --title "<titulo>" --body "descricao breve"`
 8. Se houver checks/políticas bloqueantes resolvíveis no repo, investigue e corrija automaticamente, depois repita `git add/commit/push`.
-9. Mescle o PR em `main` quando os checks obrigatórios permitirem (`gh pr merge --merge --delete-branch=false`).
+9. Tente merge automático em `main` em seguida: `gh pr merge --auto --merge --delete-branch=false`.
 10. Após merge: `git pull`
 
 Padrão de commit recomendado:
@@ -61,6 +65,9 @@ Padrão de commit recomendado:
 
 - Fluxo único (sem divisão por agentes): você conduz descoberta, planejamento, implementação, validação e fechamento.
 - Novo requisito de produto/UX/tech deve gerar um item novo no GitHub (Issue) antes de virar tarefa ativa da sprint/turno; mudanças relacionadas a itens já fechados devem ser registradas em issue filha/linkada.
+- Toda funcionalidade nova deve seguir o fluxo OpenSpec sempre que houver mudança de comportamento, UX, API, regra de negócio, dados, segurança, monitoramento ou operação. Antes de codar, crie/atualize `openspec/changes/<change>/` com escopo, decisões, tarefas e critérios de aceite proporcionais ao tamanho da mudança.
+- Mudanças pequenas e localizadas podem usar OpenSpec enxuto, mas não devem pular a etapa quando alterarem contrato do produto ou comportamento observável.
+- Sempre que possível, acelere o processo com subagents em tarefas médias/grandes, especialmente para mapear código, revisar riscos, validar UI/Playwright, investigar bugs ou dividir backend/frontend. O agente principal continua responsável por consolidar resultados e evitar trabalho duplicado.
 - Registre em `openspec/changes/<change>/` e no PR:
   - status atual
   - decisões de escopo

--- a/frontend/src/components/monitor/MonitorStatusTab.tsx
+++ b/frontend/src/components/monitor/MonitorStatusTab.tsx
@@ -457,24 +457,20 @@ export const MonitorStatusTab: React.FC = () => {
         [filteredOpportunities, preferences],
     );
 
-    const holding = resolvedSections.filter(({ resolved }) => resolved.section === 'holding').map(({ opportunity }) => opportunity);
-    const stoppedOut = resolvedSections.filter(({ resolved }) => resolved.section === 'stoppedOut').map(({ opportunity }) => opportunity);
-    const exited = resolvedSections.filter(({ resolved }) => resolved.section === 'exited').map(({ opportunity }) => opportunity);
-    const missedEntry = resolvedSections.filter(({ resolved }) => resolved.section === 'missedEntry').map(({ opportunity }) => opportunity);
-    const waiting = resolvedSections.filter(({ resolved }) => resolved.section === 'waiting').map(({ opportunity }) => opportunity);
+    const holding = resolvedSections.filter(({ resolved }) => resolved.section === 'hold').map(({ opportunity }) => opportunity);
+    const exited = resolvedSections.filter(({ resolved }) => resolved.section === 'exit').map(({ opportunity }) => opportunity);
+    const waiting = resolvedSections.filter(({ resolved }) => resolved.section === 'wait').map(({ opportunity }) => opportunity);
 
-    type SectionKey = 'holding' | 'stoppedOut' | 'exited' | 'missedEntry' | 'waiting';
+    type SectionKey = 'hold' | 'exit' | 'wait';
     const orderedCards = useMemo(() => {
-        const withSection = (arr: Opportunity[], s: SectionKey) =>
-            arr.map((opp) => ({ opp, section: s }));
+        const withSection = (arr: Opportunity[], section: SectionKey) =>
+            arr.map((opp) => ({ opp, section }));
         return [
-            ...withSection(holding, 'holding'),
-            ...withSection(stoppedOut, 'stoppedOut'),
-            ...withSection(exited, 'exited'),
-            ...withSection(missedEntry, 'missedEntry'),
-            ...withSection(waiting, 'waiting'),
+            ...withSection(holding, 'hold'),
+            ...withSection(exited, 'exit'),
+            ...withSection(waiting, 'wait'),
         ];
-    }, [holding, stoppedOut, exited, missedEntry, waiting]);
+    }, [holding, exited, waiting]);
 
     const { visibleItems, hasMore, sentinelRef } = useInfiniteScroll(orderedCards, 12, 12);
 
@@ -490,45 +486,29 @@ export const MonitorStatusTab: React.FC = () => {
     }, [visibleItems]);
 
     const SECTION_CONFIG: Record<SectionKey, { title: string; subtitle: string; dotClass: string; h2Class: string; badgeClass: string; description: string }> = {
-        holding: {
-            title: 'Em Hold',
-            subtitle: 'Posições Ativas',
+        hold: {
+            title: 'Estado HOLD',
+            subtitle: 'Posição ativa',
             dotClass: 'bg-green-500',
             h2Class: 'text-green-600',
             badgeClass: 'bg-green-500/10 text-green-600',
-            description: 'Estratégias com posição aberta. A distância mostra o quanto falta para o sinal de saída.',
+            description: 'Padrão atual de decisão: posição ativa com gestão em acompanhamento contínuo.',
         },
-        stoppedOut: {
-            title: 'Saiu no Stop',
-            subtitle: 'Stop Loss Ativado',
-            dotClass: 'bg-red-500',
-            h2Class: 'text-red-600',
-            badgeClass: 'bg-red-500/10 text-red-600',
-            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas a posição foi fechada no stop loss. Aguardando cruzamento para baixo ou nova entrada.',
-        },
-        exited: {
-            title: 'Saiu Pela Regra',
-            subtitle: 'Exit Logic',
+        exit: {
+            title: 'Estado EXIT',
+            subtitle: 'Sem posição ativa',
             dotClass: 'bg-sky-500',
             h2Class: 'text-sky-600',
             badgeClass: 'bg-sky-500/10 text-sky-600',
-            description: 'Estratégias que fecharam a posição pela regra de saída da estratégia, sem stop loss. A distância mostra o quanto falta para a próxima reentrada.',
+            description: 'Condição de saída detectada; monitorando nova oportunidade com base em contexto técnico.',
         },
-        missedEntry: {
-            title: 'Entrada Perdida',
-            subtitle: 'Sem Posição',
-            dotClass: 'bg-yellow-500',
-            h2Class: 'text-yellow-600',
-            badgeClass: 'bg-yellow-500/10 text-yellow-600',
-            description: 'A média curta está acima da longa (condição de entrada satisfeita), mas não há posição ativa. Aguardando confirmação ou nova entrada.',
-        },
-        waiting: {
-            title: 'Aguardando',
-            subtitle: 'Sem Posição',
+        wait: {
+            title: 'Estado WAIT',
+            subtitle: 'Sem posição ativa',
             dotClass: 'bg-gray-400',
             h2Class: 'text-gray-500',
             badgeClass: 'bg-gray-500/10 text-gray-600',
-            description: 'Estratégias aguardando sinal de entrada. A distância mostra o quanto falta para a média curta cruzar acima da longa.',
+            description: 'Contexto técnico em monitoramento sem recomendação ativa de compra/venda.',
         },
     };
 
@@ -699,7 +679,7 @@ export const MonitorStatusTab: React.FC = () => {
                 <div className="space-y-10">
                     {visibleGroups.map(({ section, cards }) => {
                         const cfg = SECTION_CONFIG[section];
-                        const total = { holding: holding.length, stoppedOut: stoppedOut.length, exited: exited.length, missedEntry: missedEntry.length, waiting: waiting.length }[section];
+                        const total = { hold: holding.length, exit: exited.length, wait: waiting.length }[section];
                         return (
                             <section key={section} className="space-y-4">
                                 <h2 className={`text-xl font-semibold flex items-center gap-2 ${cfg.h2Class}`}>

--- a/frontend/src/components/monitor/OpportunityCard.tsx
+++ b/frontend/src/components/monitor/OpportunityCard.tsx
@@ -195,30 +195,22 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
         ? Math.max(0, Math.min(100, (1 - distance) * 100))
         : 0;
 
-    const status = opportunity.status || (is_holding ? 'HOLD' : 'WAIT');
-    const isStoppedOut = status === 'STOPPED_OUT';
-    const isExited = status === 'EXITED';
-    const isMissedEntry = status === 'MISSED_ENTRY';
-    const isWait = !is_holding && !isStoppedOut && !isExited && !isMissedEntry;
     const tierStyles = getTierStyles(opportunity.tier);
     const resolvedSignal = React.useMemo(
         () => resolveOpportunitySignal(opportunity, { selectedTimeframe: effectiveTimeframe }),
         [effectiveTimeframe, opportunity],
     );
+    const isWait = resolvedSignal.section === 'wait';
 
     const badgeColor = resolvedSignal.visual.badgeClass;
     let borderColor = resolvedSignal.visual.borderClass;
     let cardBgColor = resolvedSignal.visual.cardBgClass;
     let holdingIndicator = '';
 
-    if (resolvedSignal.section === 'holding') {
+    if (resolvedSignal.section === 'hold') {
         holdingIndicator = 'ring-2 ring-green-400 shadow-lg shadow-green-500/30';
-    } else if (resolvedSignal.section === 'stoppedOut') {
-        holdingIndicator = 'ring-2 ring-red-400 shadow-lg shadow-red-500/30';
-    } else if (resolvedSignal.section === 'exited') {
+    } else if (resolvedSignal.section === 'exit') {
         holdingIndicator = 'ring-2 ring-sky-400 shadow-lg shadow-sky-500/20';
-    } else if (resolvedSignal.section === 'missedEntry') {
-        holdingIndicator = 'ring-2 ring-yellow-400 shadow-lg shadow-yellow-500/30';
     } else if (!resolvedSignal.isUncertain && isWait && tierStyles) {
         borderColor = 'border-l-4';
         cardBgColor = tierStyles.dot === 'bg-green-500' ? 'bg-green-50/50 dark:bg-green-900/20 border-green-200 dark:border-green-800' :
@@ -230,8 +222,8 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
         ? `${resolvedSignal.statusMessage}${resolvedSignal.freshnessReason ? ` ${resolvedSignal.freshnessReason}` : ''}`
         : (opportunity.message || (
             distance !== null && distance !== undefined
-                ? `${distance.toFixed(2)}% to ${next_status_label}`
-                : `Waiting for ${next_status_label} signal`
+                ? `${distance.toFixed(2)}% até ${next_status_label}`
+                : `Aguardando estado para decisão`
         ));
 
     const displayName = (name || '').trim() || template_name;
@@ -239,17 +231,13 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
 
     // NOTE: Avoid hardcoded light backgrounds via inline styles.
     // They reduce contrast on mobile/dark mode. Background colors are handled via Tailwind classes.
-    const cardStyle = resolvedSignal.section === 'holding'
+    const cardStyle = resolvedSignal.section === 'hold'
         ? { borderLeftWidth: '4px', borderLeftColor: 'rgb(22, 163, 74)' }
-        : resolvedSignal.section === 'stoppedOut'
-            ? { borderLeftWidth: '4px', borderLeftColor: 'rgb(220, 38, 38)' }
-            : resolvedSignal.section === 'exited'
+        : resolvedSignal.section === 'exit'
                 ? { borderLeftWidth: '4px', borderLeftColor: 'rgb(2, 132, 199)' }
-                : resolvedSignal.section === 'missedEntry'
-                ? { borderLeftWidth: '4px', borderLeftColor: 'rgb(234, 179, 8)' }
                 : !resolvedSignal.isUncertain && isWait && tierStyles
-                    ? { borderLeftWidth: '4px', borderLeftColor: tierStyles.border }
-                    : { borderLeftWidth: '4px', borderLeftColor: 'rgb(203, 213, 225)' };
+                        ? { borderLeftWidth: '4px', borderLeftColor: tierStyles.border }
+                        : { borderLeftWidth: '4px', borderLeftColor: 'rgb(203, 213, 225)' };
 
     const symbolTestKey = symbolKey(symbol);
     const portfolioStatusClass = portfolioStatusTone === 'success'
@@ -510,7 +498,7 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
 
                         <div className="p-3 bg-slate-50 dark:bg-slate-800/80 rounded-md text-xs border border-slate-200 dark:border-slate-600">
                             <div className="flex flex-wrap gap-x-3 gap-y-1 text-slate-700 dark:text-slate-200">
-                                <span>signal: {resolvedSignal.visual.badgeText.toLowerCase()}</span>
+                                <span>Estado: {resolvedSignal.visual.badgeText}</span>
                                 <span>strategy tf: {resolvedSignal.strategyTimeframe ?? '-'}</span>
                                 <span>display tf: {resolvedSignal.displayTimeframe ?? '-'}</span>
                                 <span>candle ref: {resolvedSignal.referenceCandleTime ?? '-'}</span>

--- a/frontend/src/components/monitor/signalResolution.ts
+++ b/frontend/src/components/monitor/signalResolution.ts
@@ -1,6 +1,6 @@
 import type { Opportunity } from './types';
 
-export type MonitorSignalKind = 'holding' | 'stoppedOut' | 'exited' | 'missedEntry' | 'waiting';
+export type MonitorSignalKind = 'hold' | 'wait' | 'exit';
 
 type MarkerDirection = 'aboveBar' | 'belowBar';
 type MarkerShape = 'arrowDown' | 'arrowUp';
@@ -44,7 +44,7 @@ const TIMEFRAME_TO_MS: Record<string, number> = {
 };
 
 const VISUAL_BY_KIND: Record<MonitorSignalKind, MonitorSignalVisual> = {
-    holding: {
+    hold: {
         badgeText: 'HOLD',
         badgeClass: 'bg-green-600 text-white border-green-600 font-bold shadow-md',
         borderClass: 'border-l-green-600 border-l-4',
@@ -56,43 +56,19 @@ const VISUAL_BY_KIND: Record<MonitorSignalKind, MonitorSignalVisual> = {
         markerColor: '#0ea5e9',
         statusClass: 'info',
     },
-    exited: {
-        badgeText: 'EXITED',
+    exit: {
+        badgeText: 'EXIT',
         badgeClass: 'bg-sky-600 text-white border-sky-600 font-bold shadow-md',
         borderClass: 'border-l-sky-600 border-l-4',
         cardBgClass: 'bg-sky-50 dark:bg-sky-900/30 border-sky-300 dark:border-sky-700',
         titleClass: 'text-sky-700 dark:text-sky-300',
-        markerLabel: 'EXIT',
+        markerLabel: 'ENTRY',
         markerPosition: 'aboveBar',
         markerShape: 'arrowDown',
         markerColor: '#0284c7',
         statusClass: 'info',
     },
-    stoppedOut: {
-        badgeText: 'STOPPED OUT',
-        badgeClass: 'bg-red-600 text-white border-red-600 font-bold shadow-md',
-        borderClass: 'border-l-red-600 border-l-4',
-        cardBgClass: 'bg-red-50 dark:bg-red-900/40 border-red-400 dark:border-red-600',
-        titleClass: 'text-red-700 dark:text-red-300',
-        markerLabel: 'ENTRY',
-        markerPosition: 'belowBar',
-        markerShape: 'arrowUp',
-        markerColor: '#dc2626',
-        statusClass: 'danger',
-    },
-    missedEntry: {
-        badgeText: 'MISSED',
-        badgeClass: 'bg-yellow-500 text-white border-yellow-500 font-bold shadow-md',
-        borderClass: 'border-l-yellow-500 border-l-4',
-        cardBgClass: 'bg-yellow-50 dark:bg-yellow-900/40 border-yellow-400 dark:border-yellow-600',
-        titleClass: 'text-yellow-700 dark:text-yellow-300',
-        markerLabel: 'ENTRY',
-        markerPosition: 'belowBar',
-        markerShape: 'arrowUp',
-        markerColor: '#f59e0b',
-        statusClass: 'warning',
-    },
-    waiting: {
+    wait: {
         badgeText: 'WAIT',
         badgeClass: 'bg-slate-200 text-slate-600 border-slate-300',
         borderClass: 'border-l-slate-300 border-l-4',
@@ -108,15 +84,23 @@ const VISUAL_BY_KIND: Record<MonitorSignalKind, MonitorSignalVisual> = {
 
 const asStatus = (rawStatus: unknown): string => String(rawStatus || '').trim().toUpperCase();
 const normalizeTimeframe = (timeframe: string | null | undefined): string => String(timeframe || '').trim().toLowerCase();
+const normalizeNextStatus = (nextStatusLabel: string | null | undefined): string => {
+    const normalized = String(nextStatusLabel || '').trim().toLowerCase();
+    if (normalized === 'entry') return 'entrada';
+    if (normalized === 're-entry') return 'reentrada';
+    if (normalized === 'confirmation') return 'confirmação';
+    if (normalized === 'exit') return 'saída';
+    return 'próxima decisão';
+};
 
 const toMsByTimeframe = (timeframe: string | null | undefined): number => {
     return TIMEFRAME_TO_MS[normalizeTimeframe(timeframe) || '1d'] ?? TIMEFRAME_TO_MS['1d'];
 };
 
 const isStale = (referenceTime: string | null | undefined, timeframe: string | undefined): boolean => {
-    if (!referenceTime) return true;
+    if (!referenceTime) return false;
     const candleTime = Date.parse(referenceTime);
-    if (Number.isNaN(candleTime)) return true;
+    if (Number.isNaN(candleTime)) return false;
 
     const maxAge = toMsByTimeframe(timeframe) * 3;
     return Date.now() - candleTime > maxAge;
@@ -150,7 +134,7 @@ export const resolveOpportunitySignal = (
         context.latestCandleTime,
     );
 
-    let section: MonitorSignalKind = 'waiting';
+    let section: MonitorSignalKind = 'wait';
     let isUncertain = uncertainty || timeframeMismatch || candleMismatch;
     const reasons: string[] = [];
     if (uncertainty) {
@@ -163,42 +147,38 @@ export const resolveOpportunitySignal = (
         reasons.push('EXIT bloqueado: candle de referência não corresponde ao último candle exibido.');
     }
 
-    if (rawStatus === 'HOLDING' || rawStatus === 'EXIT_NEAR' || rawStatus === 'EXIT_SIGNAL') {
-        section = isHolding ? 'holding' : 'waiting';
+    if (rawStatus === 'HOLDING' || rawStatus === 'HOLD' || rawStatus === 'EXIT_NEAR' || rawStatus === 'EXIT_SIGNAL') {
+        section = isHolding ? 'hold' : 'wait';
         if (!isHolding) {
             isUncertain = true;
-            reasons.push('Status indica saída em preparo com posição fechada.');
+            reasons.push('Estado de decisão indica posição ativa, mas o sinal não está em hold.');
         }
-    } else if (rawStatus === 'EXITED') {
-        if (!isHolding) {
-            section = 'exited';
-            isUncertain = false;
-        } else {
-            section = 'waiting';
+    } else if (rawStatus === 'EXITED' || rawStatus === 'STOPPED_OUT' || rawStatus === 'MISSED_ENTRY' || rawStatus === 'MISSED') {
+        section = isHolding ? 'wait' : 'exit';
+        if (isHolding) {
             isUncertain = true;
-            reasons.push('Status de saída inconsistente com posição aberta.');
+            reasons.push('Estado de saída inconsistente com posição aberta.');
         }
-    } else if (rawStatus === 'STOPPED_OUT') {
-        section = 'stoppedOut';
-    } else if (rawStatus === 'MISSED_ENTRY' || rawStatus === 'MISSED') {
-        section = 'missedEntry';
     } else if (rawStatus === 'WAIT' || rawStatus === 'NEUTRAL' || rawStatus === 'BUY_NEAR' || rawStatus === 'BUY_SIGNAL') {
-        section = 'waiting';
+        section = 'wait';
     } else if (rawStatus) {
-        section = isHolding ? 'holding' : 'waiting';
+        section = isHolding ? 'hold' : 'wait';
         if (!isHolding) {
             isUncertain = true;
-            reasons.push('Status desconhecido, tratado como estado de espera.');
+            reasons.push('Estado desconhecido, tratado como espera.');
         }
     }
 
-    const visual = VISUAL_BY_KIND[section];
-    const effectiveSection = isUncertain ? 'waiting' : section;
+    const effectiveSection = isUncertain ? 'wait' : section;
     const sectionVisual = VISUAL_BY_KIND[effectiveSection];
     const freshnessReason = reasons.length > 0 ? reasons.join(' ') : null;
     const fallbackStatusMessage = isUncertain
-        ? 'SINAL INCONCLUSIVO: estado não confirmado.'
-        : (opportunity.message || `Waiting for ${opportunity.next_status_label} signal`);
+        ? 'Estado em revisão: decisão não confirmada pelo contexto atual.'
+        : (opportunity.message || `Aguardando condição de ${normalizeNextStatus(opportunity.next_status_label)} para decisão.`);
+
+    const markerLabel = isUncertain
+        ? 'WAIT'
+        : sectionVisual.markerLabel;
 
     return {
         section: effectiveSection,
@@ -211,11 +191,7 @@ export const resolveOpportunitySignal = (
         latestCandleTime: context.latestCandleTime ?? null,
         visual: {
             ...sectionVisual,
-            markerLabel: isUncertain
-                ? sectionVisual.markerLabel
-                : section === 'holding'
-                    ? sectionVisual.markerLabel
-                    : (rawStatus === 'EXIT_SIGNAL' || rawStatus === 'EXIT_NEAR' ? 'EXIT' : sectionVisual.markerLabel),
+            markerLabel,
             markerColor: isUncertain ? '#8b949e' : sectionVisual.markerColor,
             markerShape: isUncertain ? 'arrowUp' : sectionVisual.markerShape,
             markerPosition: isUncertain ? 'belowBar' : sectionVisual.markerPosition,

--- a/frontend/tests/e2e/issue-70-monitor-standardized-states.spec.ts
+++ b/frontend/tests/e2e/issue-70-monitor-standardized-states.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from '@playwright/test'
+
+const AUTH_USER = {
+  id: 'test-user',
+  email: 'test@example.com',
+  name: 'Test User',
+  isAdmin: false,
+}
+
+const NOW = new Date().toISOString()
+
+async function mockAuthenticatedSession(page: any) {
+  await page.addInitScript((user) => {
+    window.localStorage.setItem('auth_access_token', 'test-access-token')
+    window.localStorage.setItem('auth_refresh_token', 'test-refresh-token')
+    window.localStorage.setItem('auth_user', JSON.stringify(user))
+  }, AUTH_USER)
+}
+
+const OPPORTUNITIES_PAYLOAD = [
+  {
+    id: 1,
+    symbol: 'BTC/USDT',
+    timeframe: '1d',
+    template_name: 'ema_rsi',
+    name: 'BTC Hold',
+    notes: '',
+    tier: 1,
+    parameters: { ema_short: 9, ema_long: 21 },
+    is_holding: true,
+    distance_to_next_status: 0.4,
+    next_status_label: 'exit',
+    indicator_values_candle_time: NOW,
+    status: 'HOLDING',
+    message: 'Posição ativa monitorada.',
+    last_price: 50000,
+    timestamp: NOW,
+    details: {},
+  },
+  {
+    id: 2,
+    symbol: 'ETH/USDT',
+    timeframe: '1h',
+    template_name: 'ema_rsi',
+    name: 'ETH Wait',
+    notes: '',
+    tier: 1,
+    parameters: { ema_short: 9, ema_long: 21 },
+    is_holding: false,
+    distance_to_next_status: 0.7,
+    next_status_label: 'entry',
+    indicator_values_candle_time: NOW,
+    status: 'WAIT',
+    message: 'Aguardando condição de entrada.',
+    last_price: 3000,
+    timestamp: NOW,
+    details: {},
+  },
+  {
+    id: 3,
+    symbol: 'AAPL',
+    timeframe: '1d',
+    template_name: 'ema_rsi',
+    name: 'AAPL Exit',
+    notes: '',
+    tier: 2,
+    parameters: { ema_short: 9, ema_long: 21 },
+    is_holding: false,
+    distance_to_next_status: 1.2,
+    next_status_label: 're-entry',
+    indicator_values_candle_time: NOW,
+    status: 'EXITED',
+    message: 'Condição de saída registrada.',
+    last_price: 200,
+    timestamp: NOW,
+    details: {},
+  },
+]
+
+async function setupApiMocks(page: any) {
+  await mockAuthenticatedSession(page)
+
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/favorites/', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 1, name: 'BTC Hold', symbol: 'BTC/USDT', timeframe: '4h', strategy_name: 'ema_rsi', parameters: {}, metrics: {}, created_at: '2025-01-01T00:00:00Z', tier: 1 },
+        { id: 2, name: 'ETH Wait', symbol: 'ETH/USDT', timeframe: '1h', strategy_name: 'ema_rsi', parameters: {}, metrics: {}, created_at: '2025-01-01T00:00:00Z', tier: 1 },
+        { id: 3, name: 'AAPL Exit', symbol: 'AAPL', timeframe: '1d', strategy_name: 'ema_rsi', parameters: {}, metrics: {}, created_at: '2025-01-01T00:00:00Z', tier: 2 },
+      ]),
+    })
+  )
+
+  await page.route('**/api/opportunities/**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(OPPORTUNITIES_PAYLOAD),
+    })
+  )
+
+  await page.route('**/api/auth/me', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(AUTH_USER),
+    })
+  )
+
+    await page.route('**/api/monitor/preferences', (route: any) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          __global__: { in_portfolio: false, card_mode: 'price', price_timeframe: '1d', theme: 'dark-green' },
+        'BTC/USDT': { in_portfolio: true, card_mode: 'price', price_timeframe: '1d', theme: 'dark-green' },
+        'ETH/USDT': { in_portfolio: true, card_mode: 'price', price_timeframe: '1d', theme: 'dark-green' },
+        'AAPL': { in_portfolio: true, card_mode: 'price', price_timeframe: '1d', theme: 'dark-green' },
+      }),
+    })
+  )
+
+  await page.route('**/api/user/binance-credentials', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configured: false, api_key_masked: null }),
+    })
+  )
+
+  await page.route('**/api/market/candles**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        candles: [
+          { timestamp_utc: NOW, open: 100, high: 102, low: 99, close: 101, volume: 1000 },
+          { timestamp_utc: NOW, open: 101, high: 103, low: 100, close: 102, volume: 1100 },
+        ],
+      }),
+    })
+  )
+}
+
+test('issue 70: monitor standardizes states to HOLD, WAIT and EXIT', async ({ page }) => {
+  await setupApiMocks(page)
+  await page.goto('/monitor')
+
+  await expect(page.getByText('Estado HOLD')).toBeVisible()
+  await expect(page.getByText('Estado WAIT')).toBeVisible()
+  await expect(page.getByText('Estado EXIT')).toBeVisible()
+
+  const holdCard = page.getByTestId('monitor-card-btc-usdt')
+  const waitCard = page.getByTestId('monitor-card-eth-usdt')
+  const exitCard = page.getByTestId('monitor-card-aapl')
+
+  await expect(holdCard.getByText(/^HOLD$/)).toBeVisible()
+  await expect(waitCard.getByText(/^WAIT$/)).toBeVisible()
+  await expect(exitCard.getByText(/^EXIT$/)).toBeVisible()
+})

--- a/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
+++ b/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
@@ -324,9 +324,8 @@ test('monitor renders exited strategies separately from stopped out ones', async
 
   await page.goto('/monitor')
 
-  await expect(page.getByText('Saiu Pela Regra')).toBeVisible()
-  await expect(page.getByText('Saiu no Stop')).toHaveCount(0)
-  await expect(page.getByTestId('monitor-card-btc-usdt').getByText(/^EXITED$/)).toBeVisible()
+  await expect(page.getByText('Estado EXIT')).toBeVisible()
+  await expect(page.getByTestId('monitor-card-btc-usdt').getByText(/^EXIT$/)).toBeVisible()
 })
 
 test('monitor keeps mismatched exit signals in WAIT state with explicit context', async ({ page }) => {
@@ -442,9 +441,9 @@ test('monitor keeps mismatched exit signals in WAIT state with explicit context'
   const card = page.getByTestId('monitor-card-btc-usdt')
   await expect(card).toBeVisible()
   await expect(card.getByText('WAIT', { exact: true })).toBeVisible()
-  await expect(card).toContainText('SINAL INCONCLUSIVO: estado não confirmado.')
+  await expect(card).toContainText('Estado em revisão: decisão não confirmada pelo contexto atual.')
   await expect(card).toContainText('EXIT bloqueado: timeframe da estratégia não corresponde ao timeframe exibido.')
-  await expect(card.getByText('signal: WAIT')).toBeVisible()
+  await expect(card.getByText('Estado: WAIT')).toBeVisible()
   await expect(card.getByText('strategy tf: 1d')).toBeVisible()
   await expect(card.getByText('display tf: 1h')).toBeVisible()
 
@@ -452,11 +451,12 @@ test('monitor keeps mismatched exit signals in WAIT state with explicit context'
 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Compacto' }).click()
   await expect(page.getByTestId('chart-modal-signal-badge')).toHaveText('WAIT')
   await expect(dialog.getByText('Resolved state')).toBeVisible()
   await expect(dialog).toContainText('1d')
   await expect(dialog).toContainText('1h')
-  await expect(dialog).toContainText('SINAL INCONCLUSIVO: estado não confirmado.')
+  await expect(dialog).toContainText('Estado em revisão: decisão não confirmada pelo contexto atual.')
   await expect(dialog).toContainText('EXIT bloqueado: candle de referência não corresponde ao último candle exibido.')
 })
 
@@ -584,6 +584,7 @@ test('monitor modal shows recent entry and exit history from the strategy payloa
 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Compacto' }).click()
   await expect(dialog.getByText('Signal History')).toBeVisible()
   await expect(dialog.getByTestId('chart-modal-signal-history')).toBeVisible()
   await expect(dialog.getByTestId('chart-modal-signal-history-item-0')).toContainText('ENTRY')


### PR DESCRIPTION
Implementa padronização de estados do Monitor para HOLD/WAIT/EXIT (issue #70) e atualiza testes E2E relacionados.\n\nValidação: npx playwright test tests/e2e/issue-70-monitor-standardized-states.spec.ts tests/e2e/monitor-mobile-cards-timeframe.spec.ts\n