### PR TITLE
fix: registrar rota de supply distribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
   4. Fazer **um único commit de encerramento** em `develop`.
   5. Subir para GitHub: push em `develop`, abrir/reusar PR `develop -> main`, fazer merge manual em `main` e atualizar `develop`.
   6. Só então mover o card para `Homologado`.
+- **Regra de não regressão de status:** depois que um card estiver em `Done`, nunca mova de volta para `In Progress` durante homologação, archive, commit, PR ou merge. Se aparecer falha, ajuste necessário ou reteste durante a homologação, corrija e reteste mantendo o card em `Done`; ele só deve mudar de `Done` diretamente para `Homologado` no último passo.
 - **Regra de confiabilidade por testes:** em qualquer etapa, se surgir erro de testes (locais ou CI), corrija, revalide e só então siga para próxima etapa de encerramento.
 - **Regra de commit único por entrega:** o único commit da entrega é o de encerramento, feito após a sua confirmação de homologação. Se CI/checks falharem depois do push, corrija preservando um commit final sempre que tecnicamente possível (ex.: amend + push seguro); se isso não for possível sem risco, registre a exceção e o motivo.
 - **Banco padrão:** PostgreSQL é obrigatório em runtime, QA e scripts operacionais (`DATABASE_URL` e `WORKFLOW_DATABASE_URL` em formato PostgreSQL).

--- a/backend/tests/unit/test_onchain_metrics_route.py
+++ b/backend/tests/unit/test_onchain_metrics_route.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+from fastapi import FastAPI
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 from app.routes import onchain_metrics
 from app.services.glassnode_service import GlassnodeConfigError, GlassnodeRateLimitError
@@ -106,12 +108,12 @@ class FakeSupplyDistributionService:
     async def fetch_supply_distribution(self, asset: str, basis: str, window: str):
         assert asset == "BTC"
         assert basis == "entity"
-        assert window == "7d"
+        assert window in {"24h", "7d"}
         now = datetime(2026, 4, 27, tzinfo=timezone.utc)
         return {
             "asset": "BTC",
             "basis": "entity",
-            "window": "7d",
+            "window": window,
             "interval": "24h",
             "since": 1,
             "until": 2,
@@ -171,6 +173,27 @@ class FakeSupplyDistributionService:
                 }
             },
         }
+
+
+def test_glassnode_supply_distribution_http_route_is_registered(monkeypatch) -> None:
+    monkeypatch.setattr(
+        onchain_metrics,
+        "get_supply_distribution_service",
+        lambda: FakeSupplyDistributionService(),
+    )
+
+    app = FastAPI()
+    app.include_router(onchain_metrics.router)
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/onchain/glassnode/BTC/supply-distribution",
+        params={"basis": "entity", "window": "24h"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["asset"] == "BTC"
+    assert response.json()["window"] == "24h"
 
 
 @pytest.mark.asyncio

--- a/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/design.md
@@ -1,0 +1,25 @@
+## Context
+
+The handler and service for supply distribution already exist, but the prior test coverage called the Python handler directly. That leaves a gap: a router registration or path mismatch can still produce 404 in the app while unit tests pass.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prove `/api/onchain/glassnode/{asset}/supply-distribution` is registered as an HTTP route.
+- Keep provider/configuration errors distinct from missing-route errors.
+- Preserve the existing response contract.
+
+**Non-Goals:**
+- Do not mock or bypass missing Glassnode credentials in production runtime.
+- Do not change the Supply Distribution UI.
+- Do not introduce a new on-chain API path.
+
+## Decisions
+
+- Add route-level coverage with a FastAPI `TestClient` app that includes the on-chain router. This catches missing route registration and path mismatches that direct handler tests miss.
+- Monkeypatch the supply distribution service in the route test to avoid external Glassnode calls and focus the test on HTTP routing behavior.
+- Treat live `503 GLASSNODE_API_KEY is required` as acceptable for route availability because it proves the endpoint exists and the failure is configuration, not 404.
+
+## Risks / Trade-offs
+
+- A router-level test does not prove the production process is restarted. Mitigation: run `./restart` before moving to Done and capture live HTTP status after restart.

--- a/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Issue #81 reports that the live backend returned 404 for `GET /api/onchain/glassnode/BTC/supply-distribution?basis=entity&window=24h`, breaking the Supply Distribution screen. The backend must expose this endpoint consistently so the UI receives data or a meaningful upstream/configuration error, never a missing-route response.
+
+## What Changes
+
+- Add HTTP-level route regression coverage for the supply distribution endpoint.
+- Verify the live runtime no longer returns 404 for the reported URL.
+- Keep existing service behavior for provider/configuration errors.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `backend`: on-chain supply distribution route availability must be covered as an HTTP endpoint.
+
+## Impact
+
+- Backend route tests for `app.routes.onchain_metrics`.
+- No database migration, API shape change, or frontend contract change expected.

--- a/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/specs/backend/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/specs/backend/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Supply distribution endpoint is registered
+The backend SHALL expose the supply distribution endpoint at `/api/onchain/glassnode/{asset}/supply-distribution`.
+
+#### Scenario: Route exists for BTC supply distribution
+- **WHEN** an authenticated backend client requests `GET /api/onchain/glassnode/BTC/supply-distribution?basis=entity&window=24h`
+- **THEN** the backend SHALL route the request to the supply distribution handler
+- **AND** the response SHALL NOT be HTTP 404
+
+#### Scenario: Provider configuration is missing
+- **WHEN** the supply distribution route is registered but Glassnode credentials are unavailable
+- **THEN** the backend SHALL return a service/configuration error instead of HTTP 404

--- a/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-81-supply-distribution-route/tasks.md
@@ -1,0 +1,6 @@
+## Tasks
+
+- [x] Confirm the reported live URL no longer returns HTTP 404.
+- [x] Add HTTP-level regression coverage for `/api/onchain/glassnode/{asset}/supply-distribution`.
+- [x] Run focused backend route tests for on-chain metrics.
+- [x] Run `/opsx:verify`, execute `./restart`, and capture live route status before moving the card to Done.

--- a/openspec/specs/backend/spec.md
+++ b/openspec/specs/backend/spec.md
@@ -326,3 +326,14 @@ The backend MUST stop exposing HTTP endpoints, runtime helpers, and trace/log st
 - **THEN** the backend MUST NOT execute a Lab run
 - **AND** the Lab-specific route surface is no longer available as a supported product capability
 
+### Requirement: Supply distribution endpoint is registered
+The backend SHALL expose the supply distribution endpoint at `/api/onchain/glassnode/{asset}/supply-distribution`.
+
+#### Scenario: Route exists for BTC supply distribution
+- **WHEN** an authenticated backend client requests `GET /api/onchain/glassnode/BTC/supply-distribution?basis=entity&window=24h`
+- **THEN** the backend SHALL route the request to the supply distribution handler
+- **AND** the response SHALL NOT be HTTP 404
+
+#### Scenario: Provider configuration is missing
+- **WHEN** the supply distribution route is registered but Glassnode credentials are unavailable
+- **THEN** the backend SHALL return a service/configuration error instead of HTTP 404


### PR DESCRIPTION
## Resumo
- Adiciona teste HTTP para garantir que /api/onchain/glassnode/{asset}/supply-distribution esta registrado
- Sincroniza e arquiva a change OpenSpec issue-81-supply-distribution-route
- Registra regra de nao regressao de status em AGENTS.md

## Validacao
- ./backend/.venv/bin/python -m pytest backend/tests/unit/test_onchain_metrics_route.py -q
- ./restart concluido com backend/frontend/redis saudaveis
- rota viva retorna 503 por GLASSNODE_API_KEY ausente, nao 404

Closes #81