### PR TITLE
fix: restore monitor resolved state context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
 ## TL;DR
 
 - **Branch padrão:** trabalhe em `develop` para trabalho diário de implementação e validações.
+- **Comunicação padrão com Alan:** usar sempre a skill `caveman` em modo `lite`: curto, direto, sem filler, mantendo clareza técnica. Só desligar se Alan pedir explicitamente `stop caveman` ou `normal mode`.
 - **Fluxo de produção:** implemente e valide diretamente em `develop`; para liberar produção, abra PR `develop -> main`, resolva checks/políticas bloqueantes quando possível e realize o merge manual quando permitido, sem auto-merge.
 - **Regra de fluxo:** use somente `develop` e `main`; sem criação de branches por tasks usuais.
 - **Regra de merge:** após abrir um PR de `develop -> main`, execute o merge manualmente quando os checks estiverem verdes e não houver bloqueios.
@@ -220,7 +221,7 @@ O time é composto por 5 agentes, cada um com papel definido:
 **Template base:** Orion (productivity)
 
 Orquestra o time, coordena workflow, delegation, status reports, prazos.
-- Mantém conversa com Alan curta/gerencial
+- Mantém conversa com Alan curta/gerencial, usando `caveman lite` como padrão permanente
 - Consulte workflow DB e OpenSpec como fonte principal.
 - Move status de mudança no workflow, celebra marcos, identifica riscos proativamente
 - Fornece próximo passo após completar tarefa

--- a/frontend/src/components/monitor/ChartModal.tsx
+++ b/frontend/src/components/monitor/ChartModal.tsx
@@ -1014,7 +1014,10 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                                         <div className="space-y-5">
                                             <section>
                                                 <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Signal Context</p>
-                                                <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
+                                                <div
+                                                    className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3"
+                                                    data-testid="chart-modal-signal-context"
+                                                >
                                                     <div className="flex justify-between gap-3">
                                                         <span className="text-[#8b949e]">Resolved state</span>
                                                         <span className="font-mono text-[#e6edf3]">{resolvedSignal.visual.badgeText}</span>

--- a/frontend/src/components/monitor/MonitorStatusTab.tsx
+++ b/frontend/src/components/monitor/MonitorStatusTab.tsx
@@ -73,6 +73,7 @@ const DEFAULT_THEME: MonitorTheme = 'black';
 const BINANCE_MONITOR_PORTFOLIO_MIN_USD = 1;
 const FAVORITES_STORAGE_KEY = 'crypto-monitor-favorites-v1';
 const SPARKLINE_LIMIT = 14;
+const symbolTestKey = (symbol: string): string => symbol.replace(/[^a-zA-Z0-9]+/g, '-').toLowerCase();
 const toFavoriteKey = (opportunity: Opportunity): string => String(opportunity.id);
 const normalizeFavoriteKey = (value: string | null | undefined): string => String(value || '').trim();
 
@@ -1096,6 +1097,7 @@ export const MonitorStatusTab: React.FC = () => {
                                                                 <tr
                                                                     className={`head-row ${expanded ? 'expanded' : ''}`}
                                                                     data-idx={rowKey}
+                                                                    data-testid={`monitor-row-${symbolTestKey(opportunity.symbol)}`}
                                                                     onClick={(event) => handleRowClick(event, rowKey)}
                                                                 >
                                                                     <td>

--- a/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
+++ b/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
@@ -438,26 +438,21 @@ test('monitor keeps mismatched exit signals in WAIT state with explicit context'
 
   await page.goto('/monitor')
 
-  const card = page.getByTestId('monitor-card-btc-usdt')
-  await expect(card).toBeVisible()
-  await expect(card.getByText('WAIT', { exact: true })).toBeVisible()
-  await expect(card).toContainText('Estado em revisão: decisão não confirmada pelo contexto atual.')
-  await expect(card).toContainText('EXIT bloqueado: timeframe da estratégia não corresponde ao timeframe exibido.')
-  await expect(card.getByText('Estado: WAIT')).toBeVisible()
-  await expect(card.getByText('strategy tf: 1d')).toBeVisible()
-  await expect(card.getByText('display tf: 1h')).toBeVisible()
-
-  await card.click()
+  const row = page.getByTestId('monitor-row-btc-usdt')
+  await expect(row).toBeVisible()
+  await expect(row.getByText('WAIT', { exact: true })).toBeVisible()
+  await row.getByRole('button', { name: 'Abrir gráfico' }).click()
 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
   await dialog.getByRole('button', { name: 'Compacto' }).click()
   await expect(page.getByTestId('chart-modal-signal-badge')).toHaveText('WAIT')
-  await expect(dialog.getByText('Resolved state')).toBeVisible()
-  await expect(dialog).toContainText('1d')
-  await expect(dialog).toContainText('1h')
-  await expect(dialog).toContainText('Estado em revisão: decisão não confirmada pelo contexto atual.')
-  await expect(dialog).toContainText('EXIT bloqueado: candle de referência não corresponde ao último candle exibido.')
+  const signalContext = dialog.getByTestId('chart-modal-signal-context')
+  await expect(signalContext.getByText('Resolved state')).toBeVisible()
+  await expect(signalContext).toContainText('1d')
+  await expect(signalContext).toContainText('1h')
+  await expect(signalContext).toContainText('Estado em revisão: decisão não confirmada pelo contexto atual.')
+  await expect(signalContext).toContainText('EXIT bloqueado: candle de referência não corresponde ao último candle exibido.')
 })
 
 test('monitor modal shows recent entry and exit history from the strategy payload', async ({ page }) => {

--- a/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/design.md
@@ -1,0 +1,29 @@
+## Context
+
+The Monitor screen was redesigned around a compact row/table layout. The older QA test still looked for the hidden expanded `OpportunityCard`, so it failed before opening the chart modal. The visible workflow now starts from the Monitor row and its chart action.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the current Monitor row/table layout.
+- Make the visible Monitor row addressable by test id.
+- Make the chart modal's signal context block addressable and verify that it shows the resolved state.
+- Preserve the existing signal-resolution logic.
+
+**Non-Goals:**
+
+- Redesign Monitor cards or restore the old mobile-only card list.
+- Change backend opportunity payloads.
+- Change HOLD/WAIT/EXIT resolution rules.
+
+## Decisions
+
+- Add stable test ids to the visible row and modal signal context instead of coupling QA to a hidden detail card.
+- Keep the modal copy unchanged: `Resolved state`, strategy timeframe, displayed timeframe, reference candle, latest displayed candle, and status/freshness explanation.
+- Update the E2E path for #82 to open the modal through the visible chart button.
+
+## Risks / Trade-offs
+
+- Existing tests that still target hidden detail cards may need separate follow-up alignment.
+- The fix validates current UX rather than reviving older card-click behavior.

--- a/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Issue #82 reports that the Monitor chart modal can hide the resolved signal context expected by QA. Without this block, the trader loses the explanation for why a raw EXIT signal is being treated as WAIT.
+
+## What Changes
+
+- Ensure the Monitor chart modal exposes the resolved signal state and timeframe/candle context in the non-algorithmic chart view.
+- Keep the visible badge, card state, and modal context aligned for mismatched exit signals.
+- Preserve existing compact/non-compact modal behavior and chart interactions.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `opportunity-monitor`: The Monitor chart modal must show explicit resolved-state context for strategy signal decisions.
+
+## Impact
+
+- Frontend Monitor chart modal rendering.
+- Signal resolution context displayed to the trader.
+- Playwright E2E coverage for mismatched exit signals in the Monitor modal.

--- a/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/specs/opportunity-monitor/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/specs/opportunity-monitor/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Monitor chart modal exposes resolved signal context
+The opportunity monitor SHALL show explicit resolved signal context when a trader opens a strategy chart from the visible Monitor row.
+
+#### Scenario: Mismatched exit signal opens with resolved state context
+- **WHEN** a raw exit signal is downgraded to WAIT because the strategy timeframe or candle context does not match the displayed chart
+- **THEN** the chart modal shows the resolved state, strategy timeframe, displayed timeframe, and explanatory context.
+
+#### Scenario: Visible Monitor row opens strategy chart
+- **WHEN** the trader activates the chart action on a visible Monitor row
+- **THEN** the chart modal opens for that strategy without requiring the hidden expanded detail card.

--- a/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-82-monitor-resolved-state/tasks.md
@@ -1,0 +1,5 @@
+## Tasks
+
+- [x] Add stable selectors for visible Monitor rows and modal signal context.
+- [x] Update the #82 E2E path to open the chart from the visible row action and assert `Resolved state`.
+- [x] Run focused Playwright validation for the mismatched exit signal scenario.

--- a/openspec/specs/opportunity-monitor/spec.md
+++ b/openspec/specs/opportunity-monitor/spec.md
@@ -60,3 +60,13 @@ The opportunity monitor MUST expose zoom controls as standard interactive UI con
 - **WHEN** the trader activates a zoom control using keyboard or click
 - **THEN** the visible chart range changes in the same way as the corresponding direct zoom action
 
+### Requirement: Monitor chart modal exposes resolved signal context
+The opportunity monitor SHALL show explicit resolved signal context when a trader opens a strategy chart from the visible Monitor row.
+
+#### Scenario: Mismatched exit signal opens with resolved state context
+- **WHEN** a raw exit signal is downgraded to WAIT because the strategy timeframe or candle context does not match the displayed chart
+- **THEN** the chart modal shows the resolved state, strategy timeframe, displayed timeframe, and explanatory context.
+
+#### Scenario: Visible Monitor row opens strategy chart
+- **WHEN** the trader activates the chart action on a visible Monitor row
+- **THEN** the chart modal opens for that strategy without requiring the hidden expanded detail card.

--- a/rules.md
+++ b/rules.md
@@ -30,3 +30,7 @@ Este arquivo define as regras obrigatorias e curtas do projeto. O `AGENTS.md` de
 
 7. Apos validacao e evidencia, o agente tem autonomia para executar o fluxo manual de fechamento previsto no `AGENTS.md`, sem solicitar nova autorizacao para cada etapa.
    - Essa autonomia nao autoriza pular teste, OpenSpec, homologacao, commit unico ou merge manual.
+
+8. Usar a skill `caveman` em modo `lite` como padrao de comunicacao com Alan.
+   - Manter respostas curtas, diretas e sem filler, preservando clareza tecnica, seguranca e ordem correta em instrucoes criticas.
+   - Desativar somente quando Alan pedir explicitamente `stop caveman` ou `normal mode`.


### PR DESCRIPTION
## Summary
- Fixes #82 by validating the current Monitor row workflow and resolved signal context in the chart modal.
- Adds stable test selectors for the visible Monitor row and Signal Context panel.
- Archives OpenSpec change issue-82-monitor-resolved-state and syncs opportunity-monitor spec.
- Records caveman lite communication rule in AGENTS.md/rules.md per Alan request.

## Validation
- npm --prefix frontend run test:e2e -- --grep "monitor keeps mismatched exit signals"
- npm --prefix frontend run build
- ./restart OK during implementation: backend 8003, frontend 5173, redis 6379
