### PR TITLE
fix: validate monitor signal history modal

### DIFF
--- a/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
+++ b/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
@@ -573,9 +573,9 @@ test('monitor modal shows recent entry and exit history from the strategy payloa
 
   await page.goto('/monitor')
 
-  const card = page.getByTestId('monitor-card-btc-usdt')
-  await expect(card).toBeVisible()
-  await card.click()
+  const row = page.getByTestId('monitor-row-btc-usdt')
+  await expect(row).toBeVisible()
+  await row.getByRole('button', { name: 'Abrir gráfico' }).click()
 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()

--- a/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/design.md
+++ b/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The chart modal already renders `Signal History` when `opportunity.signal_history` contains entries. The failing QA path tries to click `monitor-card-*`, but that element now lives inside a hidden detail row in the redesigned Monitor table.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use the visible `monitor-row-*` workflow to open the chart modal.
+- Keep validating that `Signal History` lists recent `ENTRY` and `EXIT` events.
+- Keep marker-alignment copy covered by E2E.
+
+**Non-Goals:**
+
+- Redesign the Monitor table.
+- Change signal history payload shape.
+- Change marker rendering logic.
+
+## Decisions
+
+- Reuse the stable row selector added for the current Monitor table workflow.
+- Keep assertions scoped to the modal history list and marker alignment text.
+- Treat the old hidden-card selector as obsolete for this E2E scenario.
+
+## Risks / Trade-offs
+
+- The test now validates the active row action rather than the hidden expanded card.
+- If the Monitor layout changes again, only the row-opening step should need updating.

--- a/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/proposal.md
+++ b/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Issue #83 reports that the Monitor chart modal does not expose recent `Signal History` entries from the strategy payload. The current Monitor layout uses a visible table row while the older QA path targets a hidden expanded detail card, so the modal is never opened through the active workflow.
+
+## What Changes
+
+- Align the E2E path with the current visible Monitor row workflow.
+- Verify the chart modal shows `Signal History` with recent `ENTRY` and `EXIT` entries from `signal_history`.
+- Preserve existing chart modal rendering and marker alignment behavior.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `opportunity-monitor`: The Monitor chart modal must expose recent entry/exit history when strategy payload includes `signal_history`.
+
+## Impact
+
+- Frontend Monitor E2E coverage.
+- Opportunity Monitor spec for signal-history context.

--- a/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/specs/opportunity-monitor/spec.md
+++ b/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/specs/opportunity-monitor/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Monitor chart modal exposes signal history
+The opportunity monitor SHALL show recent entry and exit history in the chart modal when the strategy payload includes `signal_history`.
+
+#### Scenario: Strategy payload includes recent signal history
+- **WHEN** the trader opens a strategy chart from a visible Monitor row and the payload includes `signal_history`
+- **THEN** the chart modal shows `Signal History` with recent `ENTRY` and `EXIT` entries.
+
+#### Scenario: Signal history markers match chart timeframe
+- **WHEN** signal history timestamps align with the displayed chart timeframe
+- **THEN** the chart modal states that markers are aligned with the chart timeframe.

--- a/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/tasks.md
+++ b/openspec/changes/archive/2026-05-01-issue-83-monitor-signal-history/tasks.md
@@ -1,0 +1,5 @@
+## Tasks
+
+- [x] Update the #83 E2E path to open the chart from the visible Monitor row action.
+- [x] Verify the modal shows `Signal History` with `ENTRY` and `EXIT` entries.
+- [x] Run focused Playwright validation for the signal history scenario.

--- a/openspec/specs/opportunity-monitor/spec.md
+++ b/openspec/specs/opportunity-monitor/spec.md
@@ -70,3 +70,14 @@ The opportunity monitor SHALL show explicit resolved signal context when a trade
 #### Scenario: Visible Monitor row opens strategy chart
 - **WHEN** the trader activates the chart action on a visible Monitor row
 - **THEN** the chart modal opens for that strategy without requiring the hidden expanded detail card.
+
+### Requirement: Monitor chart modal exposes signal history
+The opportunity monitor SHALL show recent entry and exit history in the chart modal when the strategy payload includes `signal_history`.
+
+#### Scenario: Strategy payload includes recent signal history
+- **WHEN** the trader opens a strategy chart from a visible Monitor row and the payload includes `signal_history`
+- **THEN** the chart modal shows `Signal History` with recent `ENTRY` and `EXIT` entries.
+
+#### Scenario: Signal history markers match chart timeframe
+- **WHEN** signal history timestamps align with the displayed chart timeframe
+- **THEN** the chart modal states that markers are aligned with the chart timeframe.


### PR DESCRIPTION
## Summary
- Fixes #83 by aligning the Signal History E2E path with the current visible Monitor row workflow.
- Verifies the chart modal shows Signal History with ENTRY/EXIT entries from signal_history.
- Archives OpenSpec change issue-83-monitor-signal-history and syncs opportunity-monitor spec.

## Validation
- npm --prefix frontend run test:e2e -- --grep "monitor modal shows recent entry and exit history"
- npm --prefix frontend run build
- ./restart OK: backend 8003, frontend 5173, redis 6379
