### PR TITLE
fix: exibir feedback ao atualizar perfil

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,5 +1,5 @@
 // src/components/ui/Input.tsx
-import type { InputHTMLAttributes, ReactNode } from 'react'
+import { useId, type InputHTMLAttributes, type ReactNode } from 'react'
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     label?: string
@@ -12,12 +12,19 @@ export function Input({
     error,
     icon,
     className = '',
+    id,
+    'aria-describedby': ariaDescribedBy,
     ...props
 }: InputProps) {
+    const generatedId = useId()
+    const inputId = id ?? generatedId
+    const errorId = error ? `${inputId}-error` : undefined
+    const describedBy = [ariaDescribedBy, errorId].filter(Boolean).join(' ') || undefined
+
     return (
         <div className="w-full">
             {label && (
-                <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                <label htmlFor={inputId} className="mb-2 block text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
                     {label}
                 </label>
             )}
@@ -28,12 +35,15 @@ export function Input({
                     </div>
                 )}
                 <input
+                    id={inputId}
+                    aria-invalid={error ? true : undefined}
+                    aria-describedby={describedBy}
                     className={`input ${icon ? 'pl-12' : ''} ${error ? 'border-red-500 ring-2 ring-red-500/20 focus:border-red-500 focus:ring-red-500/20' : ''} ${className}`}
                     {...props}
                 />
             </div>
             {error && (
-                <p className="mt-1 text-xs text-red-400">{error}</p>
+                <p id={errorId} className="mt-1 text-xs text-red-400">{error}</p>
             )}
         </div>
     )

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -19,17 +19,17 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
 export const ToastViewport = React.forwardRef<
     HTMLOListElement,
     React.HTMLAttributes<HTMLOListElement>
->(({ className, ...props }, ref) => (
-    <div
-        className="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]"
-    >
-        {/* Placeholder for where toasts render */}
-    </div>
+>(({ className = "", ...props }, ref) => (
+    <ol
+        ref={ref}
+        className={`fixed left-1/2 top-4 z-[100] flex max-h-screen w-[calc(100vw-2rem)] -translate-x-1/2 flex-col gap-2 p-0 sm:top-5 md:max-w-[420px] ${className}`}
+        {...props}
+    />
 ))
 ToastViewport.displayName = "ToastViewport"
 
 export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
-    ({ className, variant, open, onOpenChange, ...props }, ref) => {
+    ({ className = "", variant, open, onOpenChange, ...props }, ref) => {
         // Simple visibility handling. 
         // In real radix, this handles animations/portaling. 
         // Here we just render normally or use CSS classes.
@@ -39,10 +39,12 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
         return (
             <div
                 ref={ref}
-                className={`group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full 
+                role={variant === "destructive" ? "alert" : "status"}
+                aria-live={variant === "destructive" ? "assertive" : "polite"}
+                className={`group pointer-events-auto relative flex w-full items-start justify-between gap-4 overflow-hidden rounded-lg border p-4 pr-10 shadow-[0_20px_60px_rgba(0,0,0,0.38)] backdrop-blur transition-all
                 ${variant === 'destructive'
-                        ? 'destructive group border-destructive bg-destructive text-destructive-foreground'
-                        : 'border bg-background text-foreground'} 
+                        ? 'destructive border-red-400/35 bg-[rgba(54,20,24,0.96)] text-red-50'
+                        : 'border-emerald-300/30 bg-[rgba(12,22,34,0.98)] text-[var(--text-primary)]'}
                 ${className}`}
                 {...props}
             />
@@ -69,7 +71,9 @@ export const ToastClose = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <button
         ref={ref}
-        className={`absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 ${className}`}
+        type="button"
+        aria-label="Fechar notificação"
+        className={`absolute right-2 top-2 rounded-md p-1 text-[var(--text-secondary)] opacity-80 transition hover:text-[var(--text-primary)] hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-emerald-300/50 group-[.destructive]:text-red-200 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 ${className}`}
         toast-close=""
         {...props}
     >

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -9,25 +9,26 @@ import {
 import { useToast } from "@/components/ui/use-toast"
 
 export function Toaster() {
-    const { toasts } = useToast()
+    const { dismiss, toasts } = useToast()
 
     return (
         <ToastProvider>
-            {toasts.map(function ({ id, title, description, action, ...props }) {
-                return (
-                    <Toast key={id} {...props}>
-                        <div className="grid gap-1">
-                            {title && <ToastTitle>{title}</ToastTitle>}
-                            {description && (
-                                <ToastDescription>{description}</ToastDescription>
-                            )}
-                        </div>
-                        {action}
-                        <ToastClose />
-                    </Toast>
-                )
-            })}
-            <ToastViewport />
+            <ToastViewport>
+                {toasts.filter(({ open }) => open !== false).map(function ({ id, title, description, action, ...props }) {
+                    return (
+                        <Toast key={id} {...props}>
+                            <div className="grid gap-1">
+                                {title && <ToastTitle>{title}</ToastTitle>}
+                                {description && (
+                                    <ToastDescription>{description}</ToastDescription>
+                                )}
+                            </div>
+                            {action}
+                            <ToastClose onClick={() => dismiss(id)} />
+                        </Toast>
+                    )
+                })}
+            </ToastViewport>
         </ToastProvider>
     )
 }

--- a/frontend/tests/e2e/profile-update-feedback.spec.ts
+++ b/frontend/tests/e2e/profile-update-feedback.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test'
+
+type TestUser = {
+  id: string
+  email: string
+  name: string
+  isAdmin: boolean
+}
+
+const user: TestUser = {
+  id: 'profile-user',
+  email: 'profile@example.com',
+  name: 'Nome Atual',
+  isAdmin: false,
+}
+
+async function setupAuthenticatedProfile(page: any) {
+  await page.addInitScript((authUser: TestUser) => {
+    window.localStorage.setItem('auth_access_token', 'test-access-token')
+    window.localStorage.setItem('auth_refresh_token', 'test-refresh-token')
+    window.localStorage.setItem('auth_user', JSON.stringify(authUser))
+  }, user)
+
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/auth/me', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(user),
+    })
+  )
+
+  await page.route('**/api/users/me', async (route: any) => {
+    if (route.request().method() === 'PUT') {
+      const body = JSON.parse(route.request().postData() || '{}') as { name?: string }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...user,
+          name: body.name || user.name,
+          createdAt: '2026-05-01T10:00:00Z',
+          lastLogin: '2026-05-02T10:00:00Z',
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...user,
+        createdAt: '2026-05-01T10:00:00Z',
+        lastLogin: '2026-05-02T10:00:00Z',
+      }),
+    })
+  })
+}
+
+test('profile save shows visible success feedback', async ({ page }) => {
+  await setupAuthenticatedProfile(page)
+
+  await page.goto('/profile')
+  await expect(page.getByRole('heading', { name: 'Meu Perfil' })).toBeVisible()
+
+  await page.getByLabel('Nome').fill('Nome Atualizado')
+  await page.getByRole('button', { name: 'Salvar perfil' }).click()
+
+  const successToast = page.getByRole('status').filter({ hasText: 'Perfil atualizado' })
+  await expect(successToast).toBeVisible()
+  await expect(successToast).toContainText('Seu nome foi salvo com sucesso.')
+
+  await successToast.getByRole('button', { name: 'Fechar notificação' }).click()
+  await expect(successToast).not.toBeVisible()
+})

--- a/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/design.md
+++ b/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`ProfilePage` already dispatches a success toast after `PUT /users/me` succeeds. The global toaster is mounted in `App.tsx`, but the current `ToastViewport` renders an empty fixed container and the actual toast nodes are rendered outside that container, so the confirmation can be missed or appear in the normal document flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render toast messages in a fixed, visible viewport above app content.
+- Keep existing `useToast` call sites working without API changes.
+- Add a focused E2E regression for the profile save flow.
+
+**Non-Goals:**
+- Redesign the toast system or introduce Radix/shadcn dependencies.
+- Change backend profile APIs or validation rules.
+- Add inline profile-only success state unless the shared toast path remains insufficient.
+
+## Decisions
+
+- Update `ToastViewport` to accept and render children, then place mapped toast elements inside it from `Toaster`.
+  Rationale: this fixes the shared notification surface while preserving the existing hook and call-site API.
+- Position the viewport near the top center and style the toast with the app's dark elevated surface tokens.
+  Rationale: this avoids the bottom-right placement that felt disconnected from the workflow.
+- Wire the close control to `dismiss(id)`.
+  Rationale: the current close button is visual only and does not update toast state.
+- Keep the existing profile success copy: "Perfil atualizado" and "Seu nome foi salvo com sucesso."
+  Rationale: the issue is visibility, not copy or backend behavior.
+- Add Playwright coverage for `/profile` with mocked auth and profile endpoints.
+  Rationale: the bug is user-observable and best validated in the browser.
+
+## Risks / Trade-offs
+
+- [Risk] Changing the shared toaster affects all toasts.
+  Mitigation: keep markup and classes close to current primitives and validate with the focused profile E2E plus frontend build.
+- [Risk] A fixed toast can overlap content on small screens.
+  Mitigation: constrain width to the viewport, keep it top-centered, and preserve a compact max width on desktop.

--- a/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/proposal.md
+++ b/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Ao salvar dados em "Meu Perfil", o usuario nao recebe uma confirmacao visivel de que a atualizacao foi concluida. O fluxo ja dispara uma notificacao, mas o sistema global de toast nao renderiza as mensagens dentro do viewport fixo, deixando o feedback imperceptivel.
+
+## What Changes
+
+- Corrigir o componente global de toast para renderizar notificacoes visiveis em uma area fixa da tela.
+- Preservar o toast de sucesso existente no fluxo de atualizacao de perfil.
+- Adicionar cobertura E2E para confirmar que salvar o perfil exibe feedback visivel.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `frontend-ux`: feedback de sucesso/erro acionado por formularios deve aparecer de forma visivel para o usuario.
+
+## Impact
+
+- Frontend: `frontend/src/components/ui/toast.tsx`, `frontend/src/components/ui/toaster.tsx`.
+- Testes: novo teste Playwright para `/profile`.
+- APIs: sem mudanca de contrato; o teste usa mocks para `GET/PUT /api/users/me`.

--- a/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/specs/frontend-ux/spec.md
+++ b/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/specs/frontend-ux/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Form success feedback is visible
+The frontend UI SHALL render success feedback from form submissions in a visible notification surface that is fixed near the top center of the viewport, above the app content.
+
+#### Scenario: Profile update success
+- **WHEN** an authenticated user updates and saves "Meu Perfil" successfully
+- **THEN** the UI SHALL display a visible confirmation message that the profile was updated
+
+#### Scenario: Shared toast viewport renders messages
+- **WHEN** any screen dispatches a toast notification
+- **THEN** the notification content SHALL render inside the fixed toast viewport instead of an empty placeholder
+
+#### Scenario: User dismisses a toast
+- **WHEN** a notification is visible and the user clicks the close button
+- **THEN** the notification SHALL close visually

--- a/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/tasks.md
+++ b/openspec/changes/archive/2026-05-02-issue-109-profile-update-feedback/tasks.md
@@ -1,0 +1,11 @@
+## 1. Frontend
+
+- [x] 1.1 Corrigir `ToastViewport`/`Toaster` para renderizar toasts dentro do viewport fixo visivel.
+- [x] 1.2 Preservar a notificacao de sucesso existente ao salvar "Meu Perfil".
+
+## 2. Validacao
+
+- [x] 2.1 Adicionar teste E2E para salvar perfil e verificar a confirmacao visivel.
+- [x] 2.2 Rodar build frontend, E2E focado, `/opsx:verify` e `./restart`.
+
+Nota: usar `$crypto-frontend` para validar padroes de UI e Playwright quando aplicavel.

--- a/openspec/specs/frontend-ux/spec.md
+++ b/openspec/specs/frontend-ux/spec.md
@@ -189,3 +189,18 @@ The system layout update SHALL NOT change route behavior, admin-only menu visibi
 #### Scenario: Mobile user opens navigation
 - **WHEN** a user opens the app on a mobile viewport
 - **THEN** the main menu SHALL remain reachable and usable without horizontal scrolling
+
+### Requirement: Form success feedback is visible
+The frontend UI SHALL render success feedback from form submissions in a visible notification surface that is fixed near the top center of the viewport, above the app content.
+
+#### Scenario: Profile update success
+- **WHEN** an authenticated user updates and saves "Meu Perfil" successfully
+- **THEN** the UI SHALL display a visible confirmation message that the profile was updated
+
+#### Scenario: Shared toast viewport renders messages
+- **WHEN** any screen dispatches a toast notification
+- **THEN** the notification content SHALL render inside the fixed toast viewport instead of an empty placeholder
+
+#### Scenario: User dismisses a toast
+- **WHEN** a notification is visible and the user clicks the close button
+- **THEN** the notification SHALL close visually


### PR DESCRIPTION
## Resumo
- Corrige o toast global para exibir feedback visivel no topo/centro.
- Faz o botao X fechar a notificacao visualmente.
- Associa labels aos inputs e adiciona E2E para salvar Meu Perfil.
- Arquiva OpenSpec issue-109-profile-update-feedback.

## Evidencias
- npm --prefix frontend run build
- npm --prefix frontend run test:e2e -- profile-update-feedback.spec.ts --reporter=line
- openspec validate issue-109-profile-update-feedback --strict
- openspec validate frontend-ux --strict
- ./restart OK

Closes #109