### PR TITLE
fix: ajustar campos de alterar senha

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -30,7 +30,7 @@ export function Input({
             )}
             <div className="relative">
                 {icon && (
-                    <div className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
+                    <div aria-hidden="true" className="input-icon pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
                         {icon}
                     </div>
                 )}
@@ -38,7 +38,7 @@ export function Input({
                     id={inputId}
                     aria-invalid={error ? true : undefined}
                     aria-describedby={describedBy}
-                    className={`input ${icon ? 'pl-12' : ''} ${error ? 'border-red-500 ring-2 ring-red-500/20 focus:border-red-500 focus:ring-red-500/20' : ''} ${className}`}
+                    className={`input ${className} ${icon ? 'input-with-icon' : ''} ${error ? 'border-red-500 ring-2 ring-red-500/20 focus:border-red-500 focus:ring-red-500/20' : ''}`}
                     {...props}
                 />
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -732,6 +732,10 @@ textarea {
   box-shadow: var(--shadow-sm);
 }
 
+.input.input-with-icon {
+  padding-left: 48px;
+}
+
 .input:focus {
   background: var(--bg-input);
   border-color: var(--accent-primary);

--- a/frontend/tests/e2e/change-password-field-icons.spec.ts
+++ b/frontend/tests/e2e/change-password-field-icons.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test'
+
+type TestUser = {
+  id: string
+  email: string
+  name: string
+  isAdmin: boolean
+}
+
+const user: TestUser = {
+  id: 'change-password-user',
+  email: 'change-password@example.com',
+  name: 'Change Password User',
+  isAdmin: false,
+}
+
+async function setupAuthenticatedUser(page: any) {
+  await page.addInitScript((authUser: TestUser) => {
+    window.localStorage.setItem('auth_access_token', 'test-access-token')
+    window.localStorage.setItem('auth_refresh_token', 'test-refresh-token')
+    window.localStorage.setItem('auth_user', JSON.stringify(authUser))
+  }, user)
+
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/auth/me', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(user),
+    })
+  )
+}
+
+test('change password fields keep icons clear of input text', async ({ page }) => {
+  await setupAuthenticatedUser(page)
+
+  await page.goto('/change-password')
+  await expect(page.getByRole('heading', { name: 'Alterar Senha' })).toBeVisible()
+
+  const inputs = page.locator('.input-with-icon')
+  await expect(inputs).toHaveCount(3)
+
+  const spacings = await inputs.evaluateAll((elements) =>
+    elements.map((element) => {
+      const inputElement = element as HTMLInputElement
+      const wrapper = inputElement.parentElement
+      const icon = wrapper?.querySelector('.input-icon')
+      const inputBox = inputElement.getBoundingClientRect()
+      const iconBox = icon?.getBoundingClientRect()
+      const paddingLeft = Number.parseFloat(window.getComputedStyle(inputElement).paddingLeft)
+
+      inputElement.value = 'SenhaForte123!'
+
+      return {
+        iconRight: iconBox?.right ?? 0,
+        textStart: inputBox.left + paddingLeft,
+        paddingLeft,
+      }
+    }),
+  )
+
+  for (const spacing of spacings) {
+    expect(spacing.paddingLeft).toBeGreaterThanOrEqual(48)
+    expect(spacing.iconRight).toBeLessThanOrEqual(spacing.textStart - 8)
+  }
+})

--- a/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/design.md
+++ b/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/design.md
@@ -1,0 +1,30 @@
+## Context
+
+A tela `/change-password` usa o componente compartilhado `Input` com icones `lucide-react` nos tres campos de senha. O componente adiciona `pl-12` quando existe icone, mas a classe global `.input` define `padding: 0 var(--space-md)`, podendo sobrescrever o utilitario Tailwind dependendo da ordem final do CSS. O resultado visivel e o icone ocupando a mesma area do texto/placeholder.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Garantir espacamento estavel entre icone e texto nos inputs com icone.
+- Corrigir a tela de alterar senha sem criar um padrao alternativo de formulario.
+- Cobrir a regressao com um teste E2E focado em layout.
+
+**Non-Goals:**
+
+- Alterar fluxo de autenticacao, endpoint de troca de senha ou mensagens de toast.
+- Redesenhar a pagina de seguranca.
+- Adicionar dependencia visual ou biblioteca nova.
+
+## Decisions
+
+- Corrigir no componente compartilhado `Input`, usando padding inline calculado quando houver `icon`. Isso ataca a causa da colisao e preserva telas que ja usam `Input`.
+- Manter a API do componente igual (`icon`, `label`, `error`), evitando mudanca em chamadas existentes.
+- Validar a tela com Playwright por medicao de bounding boxes entre icone e input, alem do build frontend.
+
+## Risks / Trade-offs
+
+- [Risk] Inputs com `className` customizado podem tentar sobrescrever padding esquerdo.
+  Mitigation: aplicar a classe de espacamento depois de `className`, mantendo prioridade para o caso com icone.
+- [Risk] O teste visual pode ficar fragil se o tema mudar dimensoes.
+  Mitigation: validar relacao espacial minima entre icone e inicio do campo, nao cor exata ou screenshot pixel-perfect.

--- a/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/proposal.md
+++ b/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+O formulario de alterar senha exibe icones sobrepostos ao texto dos campos, prejudicando leitura e preenchimento. O bug bloqueia uma acao de seguranca basica e deve ser corrigido antes da homologacao do fluxo de acesso.
+
+## What Changes
+
+- Ajustar o componente de input com icone para manter padding interno suficiente no lado esquerdo.
+- Garantir que os campos de senha da tela `/change-password` mantenham texto e placeholder sem colisao com o icone.
+- Adicionar cobertura E2E focada na tela de alterar senha para validar o espacamento visual por bounding boxes.
+
+## Capabilities
+
+### New Capabilities
+
+- `change-password-form-layout`: Contrato visual dos campos do formulario de alterar senha.
+
+### Modified Capabilities
+
+- Nenhuma.
+
+## Impact
+
+- Frontend: `frontend/src/components/ui/Input.tsx` e teste E2E focado.
+- Sem mudanca de API, banco, dependencias ou regra de negocio.

--- a/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/specs/change-password-form-layout/spec.md
+++ b/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/specs/change-password-form-layout/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Password fields preserve icon spacing
+The change password form SHALL render password field icons without overlapping the field text or placeholder.
+
+#### Scenario: User views change password form
+- **WHEN** an authenticated user opens `/change-password`
+- **THEN** each password input with a leading icon has enough left padding for the icon and text to remain visually separated
+
+#### Scenario: User enters password text
+- **WHEN** the user types into any change password field with a leading icon
+- **THEN** the typed text remains readable and does not collide with the icon

--- a/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/tasks.md
+++ b/openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/tasks.md
@@ -1,0 +1,13 @@
+## 1. Frontend Fix
+
+- [x] 1.1 Ajustar `Input` para aplicar espacamento proprio quando houver icone.
+- [x] 1.2 Garantir que a tela `/change-password` continue usando o padrao compartilhado sem markup duplicado.
+
+## 2. Validation
+
+- [x] 2.1 Adicionar teste E2E focado validando que icones nao sobrepoem os campos de alterar senha.
+- [x] 2.2 Rodar validacoes: teste E2E focado, build frontend, OpenSpec verify e `./restart`.
+
+## Notes
+
+- Usar `$crypto-frontend` para manter padrao visual e validacao responsiva.

--- a/openspec/specs/change-password-form-layout/spec.md
+++ b/openspec/specs/change-password-form-layout/spec.md
@@ -1,0 +1,16 @@
+# change-password-form-layout Specification
+
+## Purpose
+Define visual layout requirements for the change password form fields.
+
+## Requirements
+### Requirement: Password fields preserve icon spacing
+The change password form SHALL render password field icons without overlapping the field text or placeholder.
+
+#### Scenario: User views change password form
+- **WHEN** an authenticated user opens `/change-password`
+- **THEN** each password input with a leading icon has enough left padding for the icon and text to remain visually separated
+
+#### Scenario: User enters password text
+- **WHEN** the user types into any change password field with a leading icon
+- **THEN** the typed text remains readable and does not collide with the icon


### PR DESCRIPTION
Fecha #110.\n\nEvidencias locais:\n- OpenSpec issue-110-change-password-field-icons arquivado em openspec/changes/archive/2026-05-02-issue-110-change-password-field-icons/\n- openspec validate issue-110-change-password-field-icons --strict: OK antes do archive\n- openspec validate change-password-form-layout --strict: OK\n- npm --prefix frontend run build: OK\n- npx --prefix frontend playwright test --config frontend/playwright.config.ts frontend/tests/e2e/change-password-field-icons.spec.ts: 1/1 OK\n\nObservacao: openspec validate --all --strict ainda aponta 5 falhas preexistentes em outras changes, fora do escopo do #110.