### PR TITLE
fix: hide entry and stop on exit for monitor views

### DIFF
--- a/frontend/src/components/monitor/ChartModal.tsx
+++ b/frontend/src/components/monitor/ChartModal.tsx
@@ -21,7 +21,7 @@ import {
     type OpportunitySignalHistoryItem,
 } from './types';
 import { CHART_TIMEFRAMES, fetchMarketCandles, toChartTimeframe, type ChartTimeframe } from './chartData';
-import { resolveOpportunitySignal } from './signalResolution';
+import { hasExitedOpportunity, resolveOpportunitySignal } from './signalResolution';
 
 interface ChartModalProps {
     symbol: string;
@@ -436,6 +436,7 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         }),
         [latestCandle?.timestamp_utc, opportunity, timeframe],
     );
+    const showEntryStopRows = resolvedSignal.section !== 'exit' && !hasExitedOpportunity(opportunity);
     const signalLabel = resolvedSignal.visual.markerLabel;
     const canRenderSignalHistoryMarkers = React.useMemo(
         () => String(opportunity.timeframe || '').trim().toLowerCase() === timeframe,
@@ -685,7 +686,11 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         smaMediumSeries.setData(strategyProtected ? [] : smaMediumData);
         smaLongSeries.setData(strategyProtected ? [] : smaLongData);
 
-        if (opportunity.entry_price !== null && opportunity.entry_price !== undefined) {
+        if (
+            showEntryStopRows
+            && opportunity.entry_price !== null
+            && opportunity.entry_price !== undefined
+        ) {
             candleSeries.createPriceLine({
                 price: opportunity.entry_price,
                 color: '#388bfd',
@@ -695,7 +700,11 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                 title: 'ENTRY',
             });
         }
-        if (opportunity.stop_price !== null && opportunity.stop_price !== undefined) {
+        if (
+            showEntryStopRows
+            && opportunity.stop_price !== null
+            && opportunity.stop_price !== undefined
+        ) {
             candleSeries.createPriceLine({
                 price: opportunity.stop_price,
                 color: '#f85149',
@@ -756,6 +765,7 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         smaMediumData,
         strategyProtected,
         tooltipData,
+        showEntryStopRows,
         visibleIndicators.emaShort,
         visibleIndicators.smaLong,
         visibleIndicators.smaMedium,
@@ -1103,14 +1113,18 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                                             <section>
                                                 <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#8b949e]">Risk / Stop</p>
                                                 <div className="mt-2 space-y-2 rounded-xl border border-[#30363d] bg-[#0d1117] p-3">
-                                                    <div className="flex justify-between gap-3">
-                                                        <span className="text-[#8b949e]">Entry</span>
-                                                        <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.entry_price)}</span>
-                                                    </div>
-                                                    <div className="flex justify-between gap-3">
-                                                        <span className="text-[#8b949e]">Stop</span>
-                                                        <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.stop_price)}</span>
-                                                    </div>
+                                                    {showEntryStopRows ? (
+                                                        <>
+                                                            <div className="flex justify-between gap-3">
+                                                                <span className="text-[#8b949e]">Entry</span>
+                                                                <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.entry_price)}</span>
+                                                            </div>
+                                                            <div className="flex justify-between gap-3">
+                                                                <span className="text-[#8b949e]">Stop</span>
+                                                                <span className="font-mono text-[#e6edf3]">{formatPrice(opportunity.stop_price)}</span>
+                                                            </div>
+                                                        </>
+                                                    ) : null}
                                                     <div className="flex justify-between gap-3">
                                                         <span className="text-[#8b949e]">Risk</span>
                                                         <span className="font-mono text-[#f85149]">{formatPercent(opportunity.distance_to_stop_pct)}</span>

--- a/frontend/src/components/monitor/OpportunityCard.tsx
+++ b/frontend/src/components/monitor/OpportunityCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Download, LineChart, RefreshCw, ShieldCheck } from 'lucide-react';
 import { API_BASE_URL } from '../../lib/apiBase';
 import { authFetch } from '@/lib/authFetch';
-import { resolveOpportunitySignal } from './signalResolution';
+import { hasExitedOpportunity, resolveOpportunitySignal } from './signalResolution';
 import {
     getOpportunityAssetType,
     getStrategyDisplayName,
@@ -111,6 +111,7 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
         : '-';
     const batchInfo = opportunity.timestamp ? new Date(opportunity.timestamp).toLocaleString('en-US') : '-';
     const symbolTestKey = symbolKey(symbol);
+    const showEntryStopRows = resolvedSignal.section !== 'exit' && !hasExitedOpportunity(opportunity);
     const portfolioStatusClass = portfolioStatusTone === 'success'
         ? 'text-emerald-300'
         : portfolioStatusTone === 'warning'
@@ -363,21 +364,25 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
                     <div style={{ height: '14px' }} />
                     <h5 className="h5-notes">
                         <span className="swatch" />
-                        Entry / Stop
+                        {showEntryStopRows ? 'Entry / Stop' : 'Execução'}
                     </h5>
                     <dl className="kv">
-                        <dt>entry</dt>
-                        <dd>
-                            {opportunity.entry_price !== null && opportunity.entry_price !== undefined
-                                ? `$${toDisplayValue(opportunity.entry_price, 8)}`
-                                : '-'}
-                        </dd>
-                        <dt>stop</dt>
-                        <dd>
-                            {opportunity.stop_price !== null && opportunity.stop_price !== undefined
-                                ? `$${toDisplayValue(opportunity.stop_price, 8)}`
-                                : '-'}
-                        </dd>
+                        {showEntryStopRows ? (
+                            <React.Fragment>
+                                <dt>entry</dt>
+                                <dd>
+                                    {opportunity.entry_price !== null && opportunity.entry_price !== undefined
+                                        ? `$${toDisplayValue(opportunity.entry_price, 8)}`
+                                        : '-'}
+                                </dd>
+                                <dt>stop</dt>
+                                <dd>
+                                    {opportunity.stop_price !== null && opportunity.stop_price !== undefined
+                                        ? `$${toDisplayValue(opportunity.stop_price, 8)}`
+                                        : '-'}
+                                </dd>
+                            </React.Fragment>
+                        ) : null}
                         <dt>preço atual</dt>
                         <dd>{priceString}</dd>
                         <dt>distância stop</dt>

--- a/frontend/src/components/monitor/signalResolution.ts
+++ b/frontend/src/components/monitor/signalResolution.ts
@@ -198,3 +198,13 @@ export const resolveOpportunitySignal = (
         },
     };
 };
+
+export const hasExitedOpportunity = (opportunity: Opportunity): boolean => {
+    const rawStatus = asStatus(opportunity.status);
+    const isHolding = Boolean(opportunity.is_holding);
+
+    return (
+        !isHolding
+        && (rawStatus === 'EXITED' || rawStatus === 'STOPPED_OUT' || rawStatus === 'MISSED_ENTRY' || rawStatus === 'MISSED')
+    );
+};

--- a/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/design.md
+++ b/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/design.md
@@ -1,0 +1,22 @@
+## Context
+
+`resolvedSignal.section` already classifies opportunities as `hold`, `wait`, or `exit` in `resolveOpportunitySignal`.
+
+`OpportunityCard` and `ChartModal` currently always render operational `entry` and `stop` values, independent of status.
+
+## Decisions
+
+1. Use a single status check in the UI layer:
+   - `const showEntryStopRows = resolvedSignal.section !== 'exit'`.
+
+2. Keep the rest of risk/detail information in place for `EXIT` rows.
+
+3. When `showEntryStopRows` is false:
+   - hide the two lines (`entry`, `stop`) in `OpportunityCard`'s operational block.
+   - hide the two lines (`Entry`, `Stop`) in `ChartModal` "Risk / Stop" block.
+   - keep `current price` and `risk` metrics visible.
+
+## Validation
+
+- Visual/manual check in `develop` for an `exit`-classified row.
+- Keep OpenSpec validation/traces in line with project flow at lote/release.

--- a/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/proposal.md
+++ b/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/proposal.md
@@ -1,0 +1,13 @@
+## Why
+
+When an opportunity is already in `exit`, old `entry` and `stop` prices from the previous operation are no longer actionable. Keeping them in the monitor detail views creates noise and can suggest an active setup when the position is already closed.
+
+## What Changes
+
+- Hide `entry` and `stop` rows in `OpportunityCard` when the resolved section is `EXIT`.
+- Hide `entry` and `stop` rows in `ChartModal` risk block when the resolved section is `EXIT`.
+- Keep current price, distance-to-stop and distance-to-next-status context visible so users can still evaluate the post-exit state.
+
+## Impact
+
+- Frontend: monitor detail panel (`OpportunityCard`) and chart modal (`ChartModal`) conditional rendering behavior.

--- a/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/specs/opportunity-monitor/spec.md
+++ b/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/specs/opportunity-monitor/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Simplified Hold Status Display
+**Description:** The system SHALL display a clear binary indicator: HOLD (active position) or WAIT (no position). When holding, show distance to exit; when not holding, show distance to entry.
+When the resolved state is EXIT, the monitor SHALL hide entry/stop operational lines from both card and chart views, because those values are no longer actionable.
+
+#### Scenario: Opportunity in HOLD state
+- **WHEN** the strategy is in HOLD status
+- **THEN** the UI displays distance to exit
+
+#### Scenario: Opportunity in WAIT state
+- **WHEN** the strategy is in WAIT status
+- **THEN** the UI displays distance to entry
+
+#### Scenario: Opportunity in EXIT state
+- **WHEN** an opportunity resolves to EXIT
+- **THEN** card and chart entries for Entry/Stop are hidden and no new entry/stop price guidance is shown.

--- a/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/tasks.md
+++ b/openspec/changes/archive/2026-05-03-issue-118-remover-entrada-stop/tasks.md
@@ -1,0 +1,12 @@
+## 1. Monitor Card UI
+
+- [x] 1.1 Remove `entry` and `stop` rows from `OpportunityCard` when section is `exit`.
+
+## 2. Chart Modal UI
+
+- [x] 2.1 Remove `Entry` and `Stop` rows from `ChartModal` risk block when section is `exit`.
+
+## 3. Validation
+
+- [x] 3.1 Run `openspec validate --changes` and confirm no failures.
+- [x] 3.2 Run affected frontend build validation (`npm --prefix frontend run build`).

--- a/openspec/specs/opportunity-monitor/spec.md
+++ b/openspec/specs/opportunity-monitor/spec.md
@@ -5,14 +5,19 @@ TBD - created by syncing delta from change improve-opportunity-monitor. Dashboar
 ## Requirements
 ### Requirement: Simplified Hold Status Display
 **Description:** The system SHALL display a clear binary indicator: HOLD (active position) or WAIT (no position). When holding, show distance to exit; when not holding, show distance to entry.
+When the resolved state is EXIT, the monitor SHALL hide entry/stop operational lines from both card and chart views, because those values are no longer actionable.
 
-#### Scenario: HOLD distance shown
+#### Scenario: Opportunity in HOLD state
 - **WHEN** the strategy is in HOLD status
 - **THEN** the UI displays distance to exit
 
-#### Scenario: WAIT distance shown
+#### Scenario: Opportunity in WAIT state
 - **WHEN** the strategy is in WAIT status
 - **THEN** the UI displays distance to entry
+
+#### Scenario: Opportunity in EXIT state
+- **WHEN** an opportunity resolves to EXIT
+- **THEN** card and chart entries for Entry/Stop are hidden and no new entry/stop price guidance is shown.
 
 ### Requirement: Distance to Next Status
 **Description:** The system SHALL always display percentage distance to the next relevant status change, with progress bar and color coding (Green < 0.5%, Yellow 0.5–1%, Gray > 1%). When the status is WAIT (no position), the system SHALL compute the distance to entry using the entry rule: entry is valid only when (crossover(short, long) OR crossover(short, medium)) AND trend up (short > long). If trend up is false, the system SHALL measure distance using the short-to-long pair (red → blue). If trend up is true, the system SHALL measure distance using the short-to-medium pair (red → orange).
@@ -94,3 +99,4 @@ The opportunity monitor SHALL use a configured admin-curated favorite set as a f
 - **WHEN** the opportunity monitor loads favorites for a requesting user
 - **AND** the requesting user's filtered favorite set has at least one crypto Monitor candidate
 - **THEN** the monitor computes opportunities only from the requesting user's favorites
+


### PR DESCRIPTION
Implemented card 118: hides entry/stop in monitor card and chart when opportunity resolves to exit, with OpenSpec update (issue-118) and archive + specs sync.