### PR TITLE
docs: consolidar regras e status do projeto

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
 - **Regra de implementação por card:** ao receber pedido com número de card (ex.: `#99`), localizar o card no board `github.com/users/oalansilva/projects/1`, criar/usar branch própria da change a partir de `develop`, mover para `In Progress`, executar usando OpenSpec e subagents conforme o escopo, rodar `/opsx:verify`, integrar em `develop`, executar `./restart`, e só então mover o card para `Done`. Não arquivar nem publicar em `main` nesta etapa.
 - **Regra de homologação direta por card (solicitação do cliente):** quando Alan disser que um card está homologado, mova o card de `Done` para `Homologado` sem abrir PR, sem merge em `main` e sem arquivar OpenSpec automaticamente. Homologação aqui significa aprovação funcional em `develop`.
 - **Guardrail anti-release acidental:** as frases `card homologado`, `cards homologados`, `está homologado`, `homologuei`, `aprovado em develop` ou equivalentes significam somente atualizar status para `Homologado`. Elas **não autorizam** commit, PR, merge, archive, release ou qualquer ação em `main`.
-- **Regra de release/lote:** quando Alan pedir `subir lote`, `fechar lote`, `fechar release` ou equivalente, selecione os cards `Homologado`, confirme commits/branches incluídos, rode validação final completa, arquive as changes OpenSpec correspondentes, push, PR para `main`, merge manual, atualize `develop` e mova os cards incluídos para `Pronto`.
+- **Regra de release/lote:** quando Alan pedir `subir lote`, `fechar lote`, `fechar release`, `criar release`, `gerar release` ou equivalente, selecione apenas os cards `Homologado` cujo responsavel seja `Codex`; ignore cards de outros responsaveis, pois nao sao de codigo. Depois confirme commits/branches incluídos, rode validação final completa, arquive as changes OpenSpec correspondentes, push, PR para `main`, merge manual, atualize `develop` e mova os cards incluídos para `Pronto`.
+- **Regra documental de release:** quando Alan pedir `gerar release`, `criar release`, `fechar release`, `subir lote` ou equivalente, antes de publicar/encerrar o pacote, pegue todos os cards `Homologado` por Alan incluídos na release e revise se as decisões, status e entregáveis desses cards estão refletidos na documentação do projeto/produto. A seleção de cards da release continua limitada aos cards com responsavel `Codex`; cards de outros responsaveis ficam fora do pacote. A documentação precisa ficar atualizada tanto nos Markdown locais quanto nos Google Docs/Drive correspondentes. Depois da release publicada/encerrada com evidência, mova os cards incluídos de `Homologado` para `Pronto`.
 - **Regra de não regressão de status:** depois que um card estiver em `Done`, nunca mova de volta para `In Progress` durante homologação, archive, commit, PR ou merge. Se aparecer falha, ajuste necessário ou reteste, corrija e reteste mantendo o status atual. O card só avança: `Done` -> `Homologado` -> `Pronto`.
 - **Regra de confiabilidade por testes:** em qualquer etapa, se surgir erro de testes (locais ou CI), corrija, revalide e só então siga para próxima etapa de encerramento.
 - **Regra de validação OpenSpec global:** `openspec validate --all` verde é critério padrão de fechamento. Se falhar por changes antigas fora do card, valide os specs afetados pelo card como evidência parcial, mas resolva a sujeira global antes do encerramento: corrija ou arquive as changes antigas, inclusive por archive manual quando a CLI/skill não conseguir concluir.
@@ -36,6 +37,7 @@ Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
 - **Subagents:** use subagents sempre que houver ganho claro de paralelismo, investigação independente, validação especializada ou aceleração sem duplicar trabalho.
 - OpenSpec é a camada de especificação técnica (artifacts).
 - Workflow DB e OpenSpec são fontes de operação e evidência.
+- **Regra de documentação produto/Drive:** documentos de produto/projeto que existem no Google Drive e em `docs/*.md` devem ser mantidos sincronizados. Drive é a fonte de consulta/revisão para Alan; Markdown local/GitHub é espelho versionado e backup técnico. Não editar manualmente nos dois lugares de forma divergente. Ao atualizar definição aprovada, atualize o `.md` local e sincronize o Google Doc correspondente, ou atualize o Drive e depois espelhe localmente. Para código e documentação técnica de implementação, GitHub continua mandando.
 
 ## De-para OpenSpec/OPSX no Codex
 
@@ -179,7 +181,7 @@ Status final: pronto.
 ### Release em lote
 
 - Vários cards podem ficar em `Homologado` aguardando publicação conjunta.
-- Quando Alan pedir `subir lote`, `fechar lote`, `fechar release` ou equivalente, liste cards homologados e commits/branches que entram no pacote.
+- Quando Alan pedir `subir lote`, `fechar lote`, `fechar release`, `criar release`, `gerar release` ou equivalente, liste apenas cards `Homologado` com responsavel `Codex` e os commits/branches que entram no pacote. Ignore cards de outros responsaveis.
 - Se `develop` contiver só conteúdo homologado do pacote, use PR `develop -> main`.
 - Se `develop` contiver mudança não homologada, não faça merge direto `develop -> main`; crie `release-*` a partir de `main` e inclua somente commits/branches aprovados, ou peça decisão de Alan.
 - Antes de mover cards para `Pronto`, confirme que cada card realmente entrou no merge para `main`.
@@ -262,7 +264,7 @@ Padrão de commit recomendado:
   - status atual
   - decisões de escopo
   - evidências de teste/PR
-- Para promover produção, junte os cards `Homologado` no lote/release pedido por Alan, confirme commits/branches incluídos, abra PR para `main`, resolva checks/políticas bloqueantes quando forem corrigíveis por código/configuração do repo, realize o merge manual do PR e então mova os cards incluídos para `Pronto`.
+- Para promover produção, junte apenas os cards `Homologado` com responsavel `Codex` no lote/release pedido por Alan, ignore cards de outros responsaveis, confirme commits/branches incluídos, abra PR para `main`, resolva checks/políticas bloqueantes quando forem corrigíveis por código/configuração do repo, realize o merge manual do PR e então mova os cards incluídos para `Pronto`.
 - Política adicional: quando houver falha recorrente de unit tests de DB, aplique isolamento por teste (reset de tabelas/fixtures) antes de alterar regras de negócio.
 - Ao registrar bloqueios de CI, incluir evidência e impacto de `Unit tests` e `Backend format` no comentário do PR, e manter esta orientação em `AGENTS.md` para repetição.
 - Em workflows com `push` e `pull_request`, a `concurrency.group` deve diferenciar `github.event_name`; caso contrário, o run de `pull_request` pode cancelar o run de `push` do mesmo SHA em `develop`, deixando checks obrigatórios como `cancelled` e bloqueando o merge em `main`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: redis:7-alpine
     command: ["redis-server", "--appendonly", "yes", "--maxmemory-policy", "noeviction"]
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_BIND_HOST:-127.0.0.1}:${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
     healthcheck:

--- a/docs/backlog-operating-model.md
+++ b/docs/backlog-operating-model.md
@@ -6,6 +6,7 @@ Este projeto usa dois artefatos complementares:
 
 - **GitHub Projects + Issues**: fonte operacional de execucao, ligada a issue, PR, commit, teste e evidencia.
 - **SharePoint Excel `crypto_backlog_po.xlsx`**: visao executiva de produto, roadmap, decisao de negocio e evidencia consolidada.
+- **`docs/project-hub.md`**: ponto unico de consulta rapida para objetivo, status atual, bloqueios, decisoes e proximos passos.
 
 Telegram e chat servem para alinhamento rapido. Nao sao fonte da verdade.
 
@@ -41,6 +42,27 @@ Exemplos de evidencia:
 - `Blocked`: depende de decisao, acesso, dado ou correcao anterior.
 - `Validate`: precisa de teste, revisao ou evidencia.
 - `Done`: concluido com evidencia.
+
+## Regra de Revisao da Clara
+
+Quando Clara concluir um entregavel de produto, operacao, validacao, metrica ou copy:
+
+- mover `Status` para `Done`;
+- mover `Fluxo` para `Validate`;
+- registrar evidencia no issue;
+- aguardar revisao/homologacao de Alan.
+
+Clara nao deve usar `Pronto` como estado de revisao. Se ainda faltar execucao real, o card deve ficar em `In progress`.
+
+## Regra de Release
+
+Quando Alan pedir `gerar release`, `criar release`, `fechar release`, `subir lote` ou equivalente:
+
+- levantar os cards `Homologado` incluídos no pacote;
+- revisar se decisões, status e entregáveis estão refletidos na documentação do projeto/produto;
+- sincronizar Markdown local e Google Docs/Drive correspondentes;
+- publicar/encerrar a release com evidência;
+- mover os cards incluídos de `Homologado` para `Pronto`.
 
 ## Campos Recomendados
 

--- a/docs/beta-validation.md
+++ b/docs/beta-validation.md
@@ -19,25 +19,50 @@ Esse tamanho permite suporte manual, conversa direta e aprendizado rapido sem tr
 
 ## Canal
 
-Usar Telegram como canal manual de feedback no inicio.
+Usar grupo privado de Telegram como canal manual de feedback no inicio.
 
-Decisao pendente: usar grupo atual ou criar grupo separado para beta testers.
+Recomendacao homologada: criar/usar um espaco privado para beta testers, com mensagem fixada, disclaimer e controle manual de entrada/saida.
+
+## Captacao
+
+Canal principal: formulario simples com triagem manual.
+
+Campos minimos:
+
+- nome;
+- email ou Telegram/WhatsApp;
+- nivel com cripto: iniciante, intermediario, ativo/trader;
+- principal dificuldade hoje: excesso de informacao, timing, venda, risco ou outro;
+- disponibilidade para testar e responder feedback.
+
+Alternativa de contingencia: lista manual controlada por Alan/Clara, com os mesmos campos.
 
 ## Roteiro de Convite
 
 Texto base:
 
-> Estou testando um beta fechado de uma plataforma cripto focada em apoiar decisao de swing trade. A ideia nao e prometer lucro nem mandar sinal milagroso. Quero validar se o Monitor ajuda a entender oportunidades, risco e contexto de forma mais clara. Posso te colocar no beta por alguns dias e depois te pedir um feedback direto?
+> Estou testando o beta fechado do Cripto Farol, uma ferramenta educacional para ajudar investidores a enxergar melhor contexto, status e oportunidades em cripto. A ideia nao e prometer lucro nem mandar sinal milagroso. Quero validar se o Monitor ajuda voce a decidir com mais clareza. Posso te colocar no beta por alguns dias e depois te pedir um feedback direto?
+
+## Roteiro de Uso do Tester
+
+1. Acessar o beta.
+2. Entrar no Monitor.
+3. Abrir pelo menos 2 ativos.
+4. Ver status/contexto do ativo.
+5. Abrir grafico ou detalhe quando existir.
+6. Explicar com as proprias palavras o que entendeu.
+7. Responder o feedback estruturado.
 
 ## Perguntas de Feedback
 
-1. Voce entendeu rapidamente o que o Monitor mostra?
-2. O que ficou confuso?
-3. O grafico ajudou ou atrapalhou?
-4. Voce confiaria em usar isso como apoio de decisao?
-5. O que teria que existir para voce pagar?
-6. Voce pagaria R$29 ou R$49 por mes por isso se funcionasse bem?
-7. Indicaria para alguem?
+1. Voce entendeu o que fazer em ate 3 minutos?
+2. Que informacao gerou mais confianca?
+3. Onde voce travou ou desconfiou?
+4. O status do ativo ficou claro?
+5. O grafico/contexto ajudou ou confundiu?
+6. Isso ajudaria voce a decidir melhor ou ainda faltou algo critico?
+7. Voce usaria de novo? Por que?
+8. De 0 a 10, quanto isso ajudou sua decisao?
 
 ## Metricas Minimas
 
@@ -52,6 +77,21 @@ Registrar por usuario:
 - indicaria para alguem;
 - principal dor percebida;
 - principal bloqueio.
+
+## Metricas de Sucesso Homologadas
+
+- 10 a 20 interessados qualificados.
+- 3 a 5 beta testers ativos.
+- Pelo menos 3 feedbacks completos.
+- Pelo menos 2 usuarios sinalizando valor: usariam de novo, pagariam, continuariam acompanhando ou indicariam.
+- Usuario entende em ate 3 minutos o que o produto ajuda a decidir.
+
+## Sinais de Alerta
+
+- Usuario nao entende o que fazer no Monitor.
+- Usuario interpreta o produto como promessa de lucro ou call de compra/venda.
+- Feedback gira mais em falta de confianca/explicacao do que em valor percebido.
+- Ninguem demonstra vontade de usar novamente.
 
 ## Evidencia
 
@@ -68,4 +108,4 @@ Nao vender promessa de lucro.
 
 O posicionamento correto e:
 
-> apoio a decisao com dados, contexto e backtests.
+> ferramenta educacional de apoio a decisao com dados, contexto e backtests.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -23,3 +23,56 @@
 **Evidencias aceitas:** PR, commit, resultado de teste, print, log, feedback real de usuario, link de arquivo ou decisao registrada.
 
 **Motivo:** evitar status inventado e separar intencao de efeito confirmado.
+
+## 2026-05-07 - Hub unico de consulta rapida do projeto
+
+**Decisao:** manter `docs/project-hub.md` como documento central de consulta rapida do projeto, sem substituir o GitHub Project como fonte operacional.
+
+**Motivo:** Alan pediu um local unico para consultar definicoes, status atual e organizacao do produto/projeto sem depender apenas dos cards.
+
+**Regra:** cards continuam sendo execucao; o hub consolida objetivo, estado atual, bloqueios, decisoes e links para os documentos detalhados.
+
+## 2026-05-08 - Nome e dominio do produto
+
+**Decisao:** usar **Cripto Farol** como nome do produto e `criptofarol.com.br` como dominio principal.
+
+**Motivo:** decisao explicita de Alan apos rodadas de naming. O nome comunica orientacao e apoio a decisao sem prometer lucro.
+
+**Evidencia:** whois retornou sem match para `criptofarol.com.br` e `criptofarol.com` no momento da checagem. Busca web rapida encontrou ruido para a expressao `Cripto Farol` ligado a curso/reclamacao; isso fica registrado como ponto de atencao, nao bloqueio.
+
+**Proximo passo:** Alan registrar o dominio no card `#154`; depois atualizar DNS, landing, copy e identidade visual.
+
+## 2026-05-08 - Definicoes homologadas para beta fechado
+
+**Decisao:** consolidar como base do produto as definicoes homologadas por Alan nos cards `#156`, `#136`, `#146`, `#138`, `#145`, `#137`, `#160` e `#159`.
+
+**Definicoes consolidadas:**
+
+- Direcao visual: clareza, criterio e vigilancia tranquila.
+- Ambiente: VPS atual, frontend como entrada, backend interno e cadastro publico desabilitado.
+- Divulgacao: rede quente e abordagem direta antes de canal amplo.
+- Feedback: roteiro estruturado via Telegram.
+- Metricas: 10 a 20 interessados, 3 a 5 testers ativos, 3 feedbacks completos e 2 sinais de valor.
+- Validacao: checklist com tarefas reais no Monitor.
+- Captacao: formulario simples com triagem manual.
+- Landing: headline "Enxergue melhor antes de decidir em cripto" e CTA "Entrar na lista do beta fechado".
+
+**Regra:** essas definicoes devem sobreviver aos cards e orientar landing, onboarding, comunicacao e validacao.
+
+## 2026-05-08 - Fluxo de revisao dos cards da Clara
+
+**Decisao:** quando Clara concluir um entregavel, deve mover o card para `Status=Done` e `Fluxo=Validate`, nunca para `Pronto`.
+
+**Motivo:** Alan corrigiu o fluxo para que `Done` seja o estado usado para revisao/homologacao dele.
+
+**Regra:** se ainda falta execucao real, manter em `In Progress`; se o entregavel esta produzido e precisa de revisao de Alan, mover para `Done / Validate`.
+
+## 2026-05-09 - Release documental dos cards homologados
+
+**Decisao:** quando Alan pedir uma release, os cards `Homologado` incluídos no pacote devem ter suas decisões e entregáveis consolidados na documentação local e no Google Drive antes de serem movidos para `Pronto`.
+
+**Cards incluídos nesta release documental:** `#156`, `#136`, `#146`, `#138`, `#145`, `#137`, `#160` e `#159`.
+
+**Documentos revisados:** `docs/project-hub.md`, `docs/mvp-scope.md`, `docs/beta-validation.md`, `docs/backlog-operating-model.md` e `docs/decision-log.md`.
+
+**Regra:** release documental concluída com evidência permite avançar os cards incluídos de `Homologado` para `Pronto`.

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -8,6 +8,22 @@ Se oferecermos um Monitor de estrategias de swing trade, alimentado por backtest
 
 Dar ao investidor uma leitura simples de oportunidade e risco para acompanhar estrategias, sem prometer lucro e sem vender sinal milagroso.
 
+## Marca e Posicionamento
+
+- Nome do produto: **Cripto Farol**.
+- Dominio definido: `criptofarol.com.br`.
+- Promessa de produto: enxergar melhor antes de decidir em cripto.
+- Headline base: **Enxergue melhor antes de decidir em cripto.**
+- CTA base: **Entrar na lista do beta fechado**.
+- Posicionamento: ferramenta educacional de apoio a decisao, nao recomendacao financeira.
+
+## Direcao Visual Minima
+
+- Atributos: clareza, criterio e vigilancia tranquila.
+- Conceito: farol tecnico que orienta, alerta e da referencia sem prometer resultado.
+- Paleta: azul petroleo/navy como base, verde/teal como cor secundaria e amarelo-farol como acento controlado.
+- Tom visual: limpo, tecnico, sobrio e sem estetica de guru, foguete, luxo financeiro ou hype.
+
 ## Must-have para Beta Fechado
 
 1. Login e acesso controlado.
@@ -29,6 +45,7 @@ Dar ao investidor uma leitura simples de oportunidade e risco para acompanhar es
 4. Registro de metricas.
 5. Suporte no Telegram.
 6. Pergunta de disposicao de pagar.
+7. Triagem de interessados via formulario simples ou lista manual.
 
 ## Fora do MVP Agora
 
@@ -66,5 +83,5 @@ Nao liberar beta se:
 - 3 a 5 usuarios beta convidados.
 - Pelo menos 3 usando o fluxo principal.
 - Pelo menos 3 conversas reais de feedback.
-- Pelo menos 1 sinal claro de disposicao de pagar ou indicacao para outro usuario.
+- Pelo menos 2 sinais claros de valor: uso recorrente, disposicao de pagar, indicacao ou vontade de continuar acompanhando.
 - Lista objetiva do que precisa mudar antes de cobrar.

--- a/docs/project-hub.md
+++ b/docs/project-hub.md
@@ -1,0 +1,130 @@
+# Hub do Projeto Cripto
+
+## Objetivo
+
+Este documento e o ponto unico de consulta rapida do projeto.
+
+Aqui deve ficar:
+
+- o objetivo do produto;
+- o status atual;
+- as decisoes principais;
+- os bloqueios e proximos passos;
+- o mapa para os documentos detalhados.
+
+## Regra de Uso
+
+- GitHub Project continua sendo a fonte operacional de execucao.
+- Este hub e a fonte rapida de contexto e status consolidado.
+- Documentos detalhados ficam nos arquivos tematicos de `docs/`.
+- Telegram e chat nao sao fonte da verdade.
+
+## Produto
+
+- Nome do projeto: **Cripto Farol**.
+- Dominio definido por Alan: `criptofarol.com.br`.
+- Objetivo do produto: ajudar investidores em cripto com clareza, contexto e apoio a decisao.
+- Proposta do MVP: usar o Monitor como tela principal do beta fechado.
+- Guardrail comercial: sem promessa de lucro, sem sinal milagroso, sem hype vazio.
+
+## Status Atual
+
+- Fase atual: fechamento do beta fechado.
+- Fonte operacional: GitHub Project `MVP Cripto - Beta Fechado`.
+- Status consolidado em 2026-05-08: Alan homologou definicoes de marca, beta, metricas, captacao, copy, divulgacao e feedback.
+- Release documental 2026-05-09: cards homologados `#156`, `#136`, `#146`, `#138`, `#145`, `#137`, `#160` e `#159` consolidados neste hub e nos documentos tematicos.
+- Ambiente do beta: VPS atual, frontend como entrada, backend restrito, cadastro publico desabilitado.
+- Redis runtime: correcao aplicada localmente e card `#170` em `Pronto / Validate`.
+- Nome, marca e dominio: decidido como **Cripto Farol** / `criptofarol.com.br`; registro do dominio em andamento com Alan no `#154`.
+
+## Gates Atuais
+
+Antes de liberar usuarios beta reais:
+
+1. Alan confirmar registro de `criptofarol.com.br`.
+2. Fechar publicacao controlada da VPS.
+3. Validar fluxo ponta a ponta.
+4. Validar os documentos e definicoes homologadas no Drive.
+
+## Decisoes Ja Tomadas
+
+- GitHub Project = execucao.
+- SharePoint Excel = visao executiva/produto.
+- Monitor = home operacional do MVP.
+- Beta fechado com 3 a 5 usuarios.
+- Acesso manual e controlado no inicio.
+- Feedback inicial via grupo privado de Telegram.
+- Captacao inicial por formulario simples com triagem manual.
+- Posicionamento do Cripto Farol: ferramenta educacional de apoio a decisao, nao recomendacao financeira.
+
+## Definicoes Homologadas em 2026-05-08
+
+Alan homologou os seguintes cards e estas definicoes passam a ser base do produto:
+
+- `#156` direcao visual minima: clareza, criterio e vigilancia tranquila; paleta com azul petroleo/navy, verde/teal e acento amarelo-farol.
+- `#136` ambiente de publicacao: VPS atual, frontend como entrada, backend interno, cadastro publico desabilitado e usuarios beta autorizados manualmente.
+- `#146` estrategia de divulgacao: rede quente e abordagem direta primeiro; LinkedIn controlado depois; Instagram como apoio; grupos/comunidades somente apos validar fluxo e mensagem.
+- `#138` roteiro de feedback: mensagem inicial, perguntas apos primeiro acesso, perguntas apos uso real do Monitor e nota final por tester.
+- `#145` metricas do beta: 10 a 20 interessados, 3 a 5 testers ativos, ativacao do Monitor, minimo de 3 feedbacks completos e pelo menos 2 sinais de valor.
+- `#137` checklist de validacao: 3 a 5 perfis reais, roteiro minimo de uso e registro de travas/valor percebido.
+- `#160` canal de captacao: formulario simples com triagem manual; lista manual como contingencia.
+- `#159` copy/CTA: headline "Enxergue melhor antes de decidir em cripto" e CTA "Entrar na lista do beta fechado".
+
+## Itens em Revisao
+
+Cards com definicoes homologadas/concluidas e consolidadas neste hub:
+
+- `#136` ambiente de publicacao do beta fechado.
+- `#137` checklist de validacao com 3 a 5 usuarios.
+- `#145` metricas de sucesso do beta e divulgacao.
+- `#159` copy e CTA da landing.
+- `#160` formulario ou canal de captacao.
+- `#146` estrategia de divulgacao e canais.
+- `#138` roteiro de feedback no Telegram.
+- `#156` direcao visual minima.
+
+## Itens Ainda em Execucao Real
+
+Estes cards ainda nao sao apenas planejamento:
+
+- `#154` registrar dominio aprovado `criptofarol.com.br`.
+- `#171` configurar publicacao beta na VPS atual com acesso controlado.
+- `#75` validar fluxo ponta a ponta do beta fechado.
+- `#140` criar landing page para captacao de beta testers.
+- `#143` identidade visual minima do beta.
+- `#157` criar logo ou wordmark inicial da marca aprovada.
+- `#158` exportar assets de marca para landing e produto.
+- `#155` preparar DNS inicial do dominio aprovado.
+- `#151` gerar pacote inicial de conteudo.
+
+## Proximos Passos Recomendados
+
+1. Alan concluir o registro de `criptofarol.com.br` no `#154`.
+2. Clara preparar o plano DNS no `#155` apos confirmacao do registro.
+3. Codex executar `#171` para publicacao controlada na VPS atual.
+4. Clara/Codex avancarem landing e identidade com base em `#156`, `#159` e `#160`.
+5. Rodar validacao interna ponta a ponta no `#75`.
+6. Abrir beta controlado com 3 a 5 usuarios usando `#137`, `#138` e `#145`.
+
+## Mapa de Documentos
+
+- Pasta do projeto no Google Drive: `https://drive.google.com/drive/folders/1OE0D_nsb7BAMQ_ntZXUonnsfX9MtXhT9`
+- Escopo do MVP: [mvp-scope.md](/root/.openclaw/workspace/crypto/docs/mvp-scope.md)
+- Validacao do beta: [beta-validation.md](/root/.openclaw/workspace/crypto/docs/beta-validation.md)
+- Modelo operacional do backlog: [backlog-operating-model.md](/root/.openclaw/workspace/crypto/docs/backlog-operating-model.md)
+- Log de decisoes: [decision-log.md](/root/.openclaw/workspace/crypto/docs/decision-log.md)
+
+## Regra de Atualizacao
+
+Atualizar este hub quando houver mudanca em pelo menos um destes pontos:
+
+- decisao de produto;
+- mudanca de status do beta;
+- novo bloqueio relevante;
+- mudanca de ambiente/publicacao;
+- definicao de marca/dominio;
+- alteracao do proximo passo principal.
+
+## Regra de Release
+
+Quando Alan pedir uma release, levantar os cards `Homologado` incluídos no pacote, revisar se as decisões e entregáveis estão refletidos nos Markdown locais e nos Google Docs/Drive correspondentes, publicar/encerrar a release com evidência e então mover os cards incluídos para `Pronto`.

--- a/start.sh
+++ b/start.sh
@@ -13,6 +13,7 @@ BACKEND_PORT="${CRYPTO_BACKEND_PORT:-8003}"
 FRONTEND_PORT="${CRYPTO_FRONTEND_PORT:-5173}"
 REDIS_HOST="${CRYPTO_REDIS_HOST:-127.0.0.1}"
 REDIS_PORT="${CRYPTO_REDIS_PORT:-6379}"
+REDIS_BIND_HOST="${CRYPTO_REDIS_BIND_HOST:-127.0.0.1}"
 BACKEND_LOG="/tmp/crypto-uvicorn-${BACKEND_PORT}.log"
 FRONTEND_LOG="/tmp/crypto-vite-${FRONTEND_PORT}.log"
 RUNTIME_WORKER_LOG="/tmp/crypto-runtime-worker.log"
@@ -229,6 +230,22 @@ run_alembic_migrations() {
 
 start_redis_runtime() {
   if wait_for_tcp_open "$REDIS_HOST" "$REDIS_PORT" 2 1; then
+    if command -v docker >/dev/null 2>&1 && docker inspect "$REDIS_CONTAINER_NAME" >/dev/null 2>&1; then
+      local redis_bind
+      redis_bind="$(docker inspect -f '{{range $p, $conf := .NetworkSettings.Ports}}{{if eq $p "6379/tcp"}}{{range $conf}}{{.HostIp}}:{{.HostPort}} {{end}}{{end}}{{end}}' "$REDIS_CONTAINER_NAME" 2>/dev/null || true)"
+      if [[ "$redis_bind" == *"0.0.0.0:${REDIS_PORT}"* || "$redis_bind" == *":::${REDIS_PORT}"* ]]; then
+        echo "Redis runtime is bound publicly (${redis_bind}); recreating with ${REDIS_BIND_HOST}:${REDIS_PORT}."
+        docker stop "$REDIS_CONTAINER_NAME" >/dev/null
+        docker rm "$REDIS_CONTAINER_NAME" >/dev/null
+      else
+        return 0
+      fi
+    else
+      return 0
+    fi
+  fi
+
+  if wait_for_tcp_open "$REDIS_HOST" "$REDIS_PORT" 2 1; then
     return 0
   fi
 
@@ -238,7 +255,7 @@ start_redis_runtime() {
     else
       docker run -d \
         --name "$REDIS_CONTAINER_NAME" \
-        -p "${REDIS_PORT}:6379" \
+        -p "${REDIS_BIND_HOST}:${REDIS_PORT}:6379" \
         -v "${REDIS_VOLUME_NAME}:/data" \
         redis:7-alpine \
         redis-server --appendonly yes --maxmemory-policy noeviction >/dev/null


### PR DESCRIPTION
Publica em main o pacote já salvo em develop.

Resumo:
- consolida regra de release limitada a cards com responsável Codex;
- adiciona hub do projeto e decisões do beta fechado;
- atualiza docs de MVP, validação beta e modelo operacional;
- ajusta Redis para bind local por padrão.

Validação:
- git status limpo antes da publicação;
- comparação origin/main..origin/develop revisada.