### PR TITLE
docs: registrar release documental concluída

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -75,4 +75,8 @@
 
 **Documentos revisados:** `docs/project-hub.md`, `docs/mvp-scope.md`, `docs/beta-validation.md`, `docs/backlog-operating-model.md` e `docs/decision-log.md`.
 
+**Evidencia:** PR `#175` mergeado em `main` com merge commit `9ecbf88`; Google Docs/Drive sincronizados; `openspec validate --all` passou; CI do PR passou.
+
+**Resultado:** cards `#156`, `#136`, `#146`, `#138`, `#145`, `#137`, `#160` e `#159` movidos de `Homologado / Validate` para `Pronto / Done`.
+
 **Regra:** release documental concluída com evidência permite avançar os cards incluídos de `Homologado` para `Pronto`.

--- a/docs/project-hub.md
+++ b/docs/project-hub.md
@@ -32,7 +32,7 @@ Aqui deve ficar:
 - Fase atual: fechamento do beta fechado.
 - Fonte operacional: GitHub Project `MVP Cripto - Beta Fechado`.
 - Status consolidado em 2026-05-08: Alan homologou definicoes de marca, beta, metricas, captacao, copy, divulgacao e feedback.
-- Release documental 2026-05-09: cards homologados `#156`, `#136`, `#146`, `#138`, `#145`, `#137`, `#160` e `#159` consolidados neste hub e nos documentos tematicos.
+- Release documental 2026-05-09 concluida: cards `#156`, `#136`, `#146`, `#138`, `#145`, `#137`, `#160` e `#159` consolidados na documentacao, publicados em `main` pelo PR `#175` e movidos para `Pronto / Done` no GitHub Project.
 - Ambiente do beta: VPS atual, frontend como entrada, backend restrito, cadastro publico desabilitado.
 - Redis runtime: correcao aplicada localmente e card `#170` em `Pronto / Validate`.
 - Nome, marca e dominio: decidido como **Cripto Farol** / `criptofarol.com.br`; registro do dominio em andamento com Alan no `#154`.
@@ -70,9 +70,9 @@ Alan homologou os seguintes cards e estas definicoes passam a ser base do produt
 - `#160` canal de captacao: formulario simples com triagem manual; lista manual como contingencia.
 - `#159` copy/CTA: headline "Enxergue melhor antes de decidir em cripto" e CTA "Entrar na lista do beta fechado".
 
-## Itens em Revisao
+## Itens Publicados na Release 2026-05-09
 
-Cards com definicoes homologadas/concluidas e consolidadas neste hub:
+Cards com definicoes homologadas por Alan, consolidadas na documentacao e movidas para `Pronto / Done`:
 
 - `#136` ambiente de publicacao do beta fechado.
 - `#137` checklist de validacao com 3 a 5 usuarios.


### PR DESCRIPTION
## Resumo\n- Atualiza o hub e decision-log com a evidência final da release documental de 2026-05-09.\n- Registra que os cards #156, #136, #146, #138, #145, #137, #160 e #159 foram movidos para Pronto/Done.\n- Google Docs sincronizados no Drive.\n\n## Validação\n- git diff --check OK\n- project item-list confirmou os 8 cards em Pronto/Done\n