### PR TITLE
Docs: registrar tópico Crypto dos alertas Monitor

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -122,3 +122,11 @@
 **Requisitos minimos:** allowlist do grupo interno, deduplicacao, rate limit, auditoria, texto padronizado, opcao de desligar e separacao entre alerta automatico interno e resposta externa.
 
 **Evidencia:** card `#174`; documento operacional `docs/monitor-telegram-alerts.md`.
+
+## 2026-05-11 - Topico interno dos sinais do Monitor
+
+**Decisao:** Alan pediu que os sinais sejam enviados no topico `Crypto` do grupo interno `Grupo Crypto` (`telegram:-1003891182144`, `threadId=5`).
+
+**Escopo:** vale para sinais/rascunhos internos do Monitor. O grupo externo do beta continua fora do envio direto da Clara sem nova aprovacao explicita.
+
+**Guardrail:** enviar somente evento real derivado do Monitor, sem inventar sinal manual e sem linguagem de recomendacao financeira.

--- a/docs/monitor-telegram-alerts.md
+++ b/docs/monitor-telegram-alerts.md
@@ -56,13 +56,13 @@ Nao consigo executar esse tipo de acao por aqui. Posso registrar como feedback d
 
 ## Destino dos Alertas
 
-Destino aprovado para o MVP: grupo interno `Grupo Crypto`, no topico operacional do projeto.
+Destino aprovado para o MVP: grupo interno `Grupo Crypto`, topico `Crypto` (`telegram:-1003891182144`, `threadId=5`).
 
 Destino externo: grupo privado do beta, apenas por encaminhamento/manual de Alan.
 
 Regras:
 
-- o chat interno precisa estar cadastrado explicitamente em allowlist;
+- o chat interno precisa estar cadastrado explicitamente em allowlist: `telegram:-1003891182144`, `threadId=5`;
 - Clara nao precisa estar no grupo externo dos beta testers neste momento;
 - mensagens automaticas so podem ir para o grupo interno allowlistado;
 - o envio precisa poder ser desligado;
@@ -197,7 +197,7 @@ Card tecnico criado: `#183` - `P1: Implementar alertas Telegram internos do Moni
 
 Escopo da implementacao:
 
-- configurar allowlist do grupo interno Telegram;
+- configurar allowlist do grupo interno Telegram: `telegram:-1003891182144`, `threadId=5`;
 - criar job/polling dos status do Monitor;
 - persistir historico de alertas enviados;
 - aplicar deduplicacao e rate limit;

--- a/docs/project-hub.md
+++ b/docs/project-hub.md
@@ -36,7 +36,7 @@ Aqui deve ficar:
 - Entregaveis da Clara em 2026-05-09 para revisao: `#143` com brand system, wordmark, mark e ativos minimos; `#140` com landing page estatica para captacao e documento de copy/estrutura.
 - Ambiente do beta: VPS atual, frontend como entrada, backend restrito, cadastro publico desabilitado.
 - Canal de feedback do beta: definido no `#144` como grupo privado separado de Telegram, com Alan responsavel pela criacao e Clara responsavel por descricao, mensagem fixada, roteiro e consolidacao dos feedbacks.
-- Alertas do Monitor no beta: definido no `#174` que Clara envia alertas/rascunhos no grupo interno `Grupo Crypto`; Alan revisa e encaminha/adapta para o grupo privado do beta. Envio direto por Clara ao grupo externo fica fora do MVP atual.
+- Alertas do Monitor no beta: definido no `#174` que Clara envia alertas/rascunhos no grupo interno `Grupo Crypto`, topico `Crypto` (`telegram:-1003891182144`, `threadId=5`); Alan revisa e encaminha/adapta para o grupo privado do beta. Envio direto por Clara ao grupo externo fica fora do MVP atual.
 - Implementacao tecnica dos alertas: criada no card `#183`, com envio apenas ao grupo interno allowlistado, deduplicacao, rate limit, auditoria e opcao de desligar.
 - Redis runtime: correcao aplicada localmente e card `#170` em `Pronto / Validate`.
 - Nome, marca e dominio: decidido como **Cripto Farol** / `criptofarol.com.br`; registro do dominio em andamento com Alan no `#154`.


### PR DESCRIPTION
## Resumo
Sincroniza documentação do destino aprovado para alertas do Monitor.

Atualizações:
- Registra grupo interno `Grupo Crypto` e tópico `Crypto` (`threadId=5`).
- Atualiza decisão no decision log.
- Atualiza docs operacionais e project hub.

Validação:
- git diff --check origin/main..HEAD