### PR TITLE
Monitor: remover layout Compacto do Abrir gráfico

### DIFF
--- a/docs/beta-e2e-validation-2026-05-13.md
+++ b/docs/beta-e2e-validation-2026-05-13.md
@@ -37,7 +37,7 @@ Base validada:
   - `ETH/USDT` como `Venda`
 - Card/linha de `SOL/USDT` expande no Monitor.
 - Grafico detalhado de `SOL/USDT` abre.
-- No modo `Compacto`, o grafico mostra:
+- Antes da remocao do layout `Compacto`, o grafico mostrava nesse modo:
   - contexto do sinal;
   - risco/stop;
   - historico de sinais;
@@ -47,7 +47,7 @@ Base validada:
 
 - A lista do Monitor mostra `SOL/USDT` como `Compra`, mas o modal do grafico em modo padrao mostra badge `ESPERA` para o mesmo ativo.
 - O modo padrao `Algoritmica` do grafico nao mostra `Signal Context`, `Risco / Stop` nem `Historico de sinais`.
-- Para o tester enxergar contexto, risco e historico, foi necessario trocar manualmente para `Compacto`.
+- Para o tester enxergar contexto, risco e historico, era necessario trocar manualmente para `Compacto`; esse layout foi removido depois pelo card #213.
 
 Issue derivada criada:
 

--- a/frontend/src/components/monitor/ChartModal.tsx
+++ b/frontend/src/components/monitor/ChartModal.tsx
@@ -226,7 +226,6 @@ export const ChartModal: React.FC<ChartModalProps> = ({
     const [error, setError] = React.useState<string | null>(null);
     const [tooltip, setTooltip] = React.useState<TooltipSnapshot | null>(null);
     const [visibleBarCount, setVisibleBarCount] = React.useState<number | null>(null);
-    const [chartMode, setChartMode] = React.useState<'compact' | 'algorithmic'>('compact');
 
     const cacheRef = React.useRef<Map<string, MarketCandle[]>>(new Map([
         [`${symbol}|${resolvedInitialTimeframe}`, initialCandles],
@@ -274,7 +273,7 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         () => (latestCandle ? tooltipData.get(toUtcTimestamp(latestCandle.timestamp_utc)) ?? null : null),
         [latestCandle, tooltipData],
     );
-    const isAlgorithmicChartMode = chartMode === 'algorithmic';
+    const isAlgorithmicChartMode = true;
 
     const displaySnapshot = tooltip ?? latestSnapshot;
     const candleTimes = React.useMemo(
@@ -740,23 +739,8 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                                 </span>
                                 <button
                                     type="button"
-                                    className={`inline-flex h-10 items-center gap-2 rounded-lg border px-3 text-sm font-semibold transition ${
-                                        chartMode === 'compact'
-                                            ? 'border-[#4c8dff] bg-[#0f2747] text-[#dbeafe]'
-                                            : 'border-[#30363d] bg-[#0f2747]/55 text-[#8b949e]'
-                                    }`}
-                                    onClick={() => setChartMode('compact')}
-                                >
-                                    Compacto
-                                </button>
-                                <button
-                                    type="button"
-                                    className={`inline-flex h-10 items-center gap-2 rounded-lg border px-3 text-sm font-semibold transition ${
-                                        chartMode === 'algorithmic'
-                                            ? 'border-[#4c8dff] bg-[#0f2747] text-[#dbeafe]'
-                                            : 'border-[#30363d] bg-[#0f2747]/55 text-[#8b949e]'
-                                    }`}
-                                    onClick={() => setChartMode('algorithmic')}
+                                    className="inline-flex h-10 items-center gap-2 rounded-lg border border-[#4c8dff] bg-[#0f2747] px-3 text-sm font-semibold text-[#dbeafe]"
+                                    aria-current="true"
                                 >
                                     Algorítmica
                                 </button>

--- a/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
+++ b/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
@@ -448,16 +448,10 @@ test('monitor keeps backend exit in list and shows mismatched chart context', as
 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
-  await expect(dialog.getByText('Signal Context')).toBeVisible()
-  await expect(dialog.getByText('Risco / Stop')).toBeVisible()
-  await expect(dialog.getByText('Histórico de sinais')).toBeVisible()
+  await expect(dialog.getByRole('button', { name: 'Compacto' })).toHaveCount(0)
+  await expect(dialog.getByRole('button', { name: 'Algorítmica', exact: true })).toBeVisible()
+  await expect(dialog.getByTestId('chart-modal-main-chart')).toBeVisible()
   await expect(page.getByTestId('chart-modal-signal-badge')).toHaveText('Venda')
-  const signalContext = dialog.getByTestId('chart-modal-signal-context')
-  await expect(signalContext.getByText('Sinal')).toBeVisible()
-  await expect(signalContext).toContainText('Venda')
-  await expect(signalContext).toContainText('1d')
-  await expect(signalContext).toContainText('Estado em revisão: decisão não confirmada pelo contexto atual.')
-  await expect(signalContext).toContainText('Venda bloqueada: candle de referência não corresponde ao último candle exibido.')
 })
 
 test('monitor keeps Compra in chart detail while showing holding context mismatch', async ({ page }) => {
@@ -576,17 +570,12 @@ test('monitor keeps Compra in chart detail while showing holding context mismatc
   await expect(dialog).toBeVisible()
   await expect(dialog.getByTestId('chart-modal-signal-badge')).toHaveText('Compra')
   await expect(dialog.getByTestId('chart-modal-main-chart-shell')).toHaveAttribute('data-current-marker', 'Compra')
-  await expect(dialog.getByText('Signal Context')).toBeVisible()
-  await expect(dialog.getByText('Risco / Stop')).toBeVisible()
-  await expect(dialog.getByText('Histórico de sinais')).toBeVisible()
+  await expect(dialog.getByRole('button', { name: 'Compacto' })).toHaveCount(0)
+  await expect(dialog.getByRole('button', { name: 'Algorítmica', exact: true })).toBeVisible()
+  await expect(dialog.getByTestId('chart-modal-main-chart')).toBeVisible()
   await expect(dialog.getByRole('group', { name: 'Chart indicators' })).toHaveCount(0)
   await expect(dialog.getByText('Indicators')).toHaveCount(0)
   await expect(dialog.getByText(/EMA 9|SMA 21|SMA 50/)).toHaveCount(0)
-
-  const signalContext = dialog.getByTestId('chart-modal-signal-context')
-  await expect(signalContext).toContainText('Compra')
-  await expect(signalContext).toContainText('Estado em revisão: decisão não confirmada pelo contexto atual.')
-  await expect(signalContext).toContainText('Compra bloqueada: entrada ativa não aparece nos candles exibidos.')
 })
 
 test('monitor resolves current exit signal consistently in list and chart', async ({ page }) => {
@@ -709,9 +698,10 @@ test('monitor resolves current exit signal consistently in list and chart', asyn
 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
-  await dialog.getByRole('button', { name: 'Compacto' }).click()
+  await expect(dialog.getByRole('button', { name: 'Compacto' })).toHaveCount(0)
+  await expect(dialog.getByRole('button', { name: 'Algorítmica', exact: true })).toBeVisible()
+  await expect(dialog.getByTestId('chart-modal-main-chart')).toBeVisible()
   await expect(page.getByTestId('chart-modal-signal-badge')).toHaveText('Venda')
-  await expect(dialog.getByTestId('chart-modal-signal-context')).not.toContainText('Estado em revisão')
 })
 
 test('monitor modal shows recent entry and exit history from the strategy payload', async ({ page }) => {
@@ -838,15 +828,11 @@ test('monitor modal shows recent entry and exit history from the strategy payloa
 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
-  await expect(dialog.getByText('Signal Context')).toBeVisible()
+  await expect(dialog.getByRole('button', { name: 'Compacto' })).toHaveCount(0)
+  await expect(dialog.getByRole('button', { name: 'Algorítmica', exact: true })).toBeVisible()
+  await expect(dialog.getByTestId('chart-modal-main-chart')).toBeVisible()
   await expect(dialog.getByTestId('chart-modal-signal-badge')).toHaveText('Compra')
   await expect(dialog.getByTestId('chart-modal-main-chart-shell')).toHaveAttribute('data-current-marker', 'Compra')
-  await expect(dialog.getByText('Até venda')).toBeVisible()
-  await expect(dialog.getByText('Histórico de sinais')).toBeVisible()
-  await expect(dialog.getByTestId('chart-modal-signal-history')).toBeVisible()
-  await expect(dialog.getByTestId('chart-modal-signal-history-item-0')).toContainText('Compra')
-  await expect(dialog.getByTestId('chart-modal-signal-history-item-1')).toContainText('Venda')
-  await expect(dialog.getByText('Marcadores alinhados ao timeframe do gráfico.')).toBeVisible()
 })
 
 test('monitor modal zoom controls adjust visible range without reloading candles', async ({ page }) => {


### PR DESCRIPTION
## Resumo\n- remove a opção de layout Compacto do modal Abrir gráfico no Monitor\n- mantém apenas o layout Algorítmica como opção visível/ativa\n- atualiza E2E e documentação que ainda citavam o layout removido\n\n## Validações\n- npm run build: OK\n- npm run lint: OK, 0 erros e warnings preexistentes\n- npx playwright test tests/e2e/monitor-mobile-cards-timeframe.spec.ts: OK, 8 passed\n- git diff --check: OK\n- openspec validate --all: OK, 118 passed\n\nCloses #213