### PR TITLE
Release: publicar cards homologados #220 #237 #238

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,14 @@ backend_log.txt
 # .codex/  (commented to allow versioning of skills)
 .codex/antigravity-skills/
 
+# OpenClaw local agent workspace/persona state
+.openclaw/
+/HEARTBEAT.md
+/IDENTITY.md
+/SOUL.md
+/TOOLS.md
+/USER.md
+
 # Backend data (checkpoints, jobs, storage)
 backend/data/
 backend/backend/data/

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ backend_log.txt
 .codex/antigravity-skills/
 
 # OpenClaw local agent workspace/persona state
-.openclaw/
+/.openclaw/workspace-state.json
 /HEARTBEAT.md
 /IDENTITY.md
 /SOUL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,36 +8,44 @@ Este arquivo existe para reduzir retrabalho e evitar mudanças fora de escopo.
 - `AGENTS.md` define como executar essas regras na pratica: comandos, status, evidencias, OpenSpec/OPSX, GitHub Project, Git e responsabilidades dos agentes.
 - Use os dois arquivos. Em conflito real, aplique a regra mais restritiva e registre a ambiguidade antes de alterar codigo, card ou Git.
 
+## Processo global do Alan
+
+- Regras gerais de processo ficam na skill global `alan-workflow`: `/root/.codex/skills/alan-workflow/SKILL.md`.
+- Use essa skill para comunicacao curta, evidencias antes de concluir, OpenSpec no card antes de implementar, higiene Git/worktree/release, classificacao de pendencias, status `Todo`/`In Progress`/`Done`/`Homologado`/`Pronto`/`Cancelado`, seguranca de output e fechamento sem pendencia.
+- Este `AGENTS.md` deve manter apenas regras especificas do cripto: branches `develop/main`, Project 1, release guard, PostgreSQL, Drive/docs, comandos de backend/frontend, workflow DB e papeis dos agentes.
+- Se uma regra geral precisar mudar para todos os projetos, atualize `alan-workflow`; nao duplique a regra aqui.
+
 ## TL;DR
 
 - **Branch padrão:** cada card/change usa branch própria a partir de `develop` (`change-<id>-<slug>` ou `card-<id>-<slug>`). `develop` é integração/homologação; `main` é produção.
 - **Comunicação padrão com Alan:** usar sempre a skill `caveman` em modo `lite`: curto, direto, sem filler, mantendo clareza técnica. Só desligar se Alan pedir explicitamente `stop caveman` ou `normal mode`.
-- **Fluxo de status:** `In Progress` = em execução; `Done` = codificado e validado tecnicamente em `develop`; `Homologado` = Alan testou e aprovou em `develop`; `Pronto` = já subiu para `main`/produção.
+- **Colunas/Status:** seguir `alan-workflow`; no cripto, o campo `Status` e a fonte principal das colunas visuais. `Done` = Done tecnico: codificado, validado e integrado em `develop`, aguardando teste/aprovacao do Alan; `Homologado` = Alan testou e aprovou em `develop`; `Pronto` = já subiu para `main`/produção com evidencia.
 - **Fluxo de produção:** implemente em branch da change, integre em `develop` para homologação, acumule cards homologados quando fizer sentido; para liberar produção, abra PR `develop -> main` quando `develop` contiver só conteúdo homologado do pacote, ou use `release-*` quando precisar congelar apenas parte aprovada. Resolva checks/políticas bloqueantes quando possível e realize o merge manual quando permitido, sem auto-merge.
 - **Regra de fluxo:** não implemente diretamente em `main`; não implemente diretamente em `develop` salvo ajuste mínimo autorizado por Alan. Branch por change é o padrão.
 - **Regra de merge de release/lote:** após abrir um PR para `main` dentro de um fechamento de lote/release solicitado por Alan, execute o merge manualmente quando os checks estiverem verdes e não houver bloqueios.
 - **Regra de autonomia operacional:** dentro de fechamento de lote/release solicitado por Alan, após validação e evidência, o agente tem autonomia para repetir tentativas manuais de merge até resolução de bloqueios resolvíveis no repositório, sem pedir nova autorização.
-- **Regra de implementação por card:** ao receber pedido com número de card (ex.: `#99`), localizar o card no board `github.com/users/oalansilva/projects/1`, criar/usar branch própria da change a partir de `develop`, mover para `In Progress`, executar usando OpenSpec e subagents conforme o escopo, rodar `/opsx:verify`, integrar em `develop`, executar `./restart`, e só então mover o card para `Done`. Não arquivar nem publicar em `main` nesta etapa.
+- **Regra de implementação por card:** seguir `alan-workflow`; no cripto, usar o board `github.com/users/oalansilva/projects/1`, criar/usar branch propria da change a partir de `develop`, integrar em `develop`, executar `./restart`, e so entao mover o card para `Status=Done` como Done tecnico. Nao arquivar nem publicar em `main` nesta etapa.
 - **Regra de conclusão de correção:** para qualquer correção de bug ou ajuste solicitado por Alan, só diga `concluído` depois de validar, fazer merge/integração da branch de trabalho em `develop`, executar `./restart` e confirmar que a URL do sistema está servindo o bundle/resultado novo. Antes disso, reporte como `corrigido na branch`, `validado localmente` ou `aguardando integração`, conforme o estado real.
-- **Regra de homologação direta por card (solicitação do cliente):** quando Alan disser que um card está homologado, mova o card de `Done` para `Homologado` sem abrir PR, sem merge em `main` e sem arquivar OpenSpec automaticamente. Homologação aqui significa aprovação funcional em `develop`.
-- **Guardrail anti-release acidental:** as frases `card homologado`, `cards homologados`, `está homologado`, `homologuei`, `aprovado em develop` ou equivalentes significam somente atualizar status para `Homologado`. Elas **não autorizam** commit, PR, merge, archive, release ou qualquer ação em `main`.
-- **Regra de release/lote:** quando Alan pedir `subir lote`, `fechar lote`, `fechar release`, `criar release`, `gerar release` ou equivalente, selecione todos os cards `Homologado` incluídos no pacote, independente do responsavel. Para cards de `Codex`, confirme commits/branches incluídos, rode validação final completa, arquive as changes OpenSpec correspondentes, push, PR para `main`, merge manual, atualize `develop` e mova os cards incluídos para `Pronto`. Para cards de `Clara` ou `Alan`, revise a documentação do projeto antes de fechar, atualizando Markdown local e Drive quando aplicável.
+- **Regra de homologação direta por card (solicitação do cliente):** seguir `alan-workflow`; no cripto, homologacao significa aprovacao funcional em `develop`.
+- **Guardrail anti-release acidental:** seguir `alan-workflow`; no cripto, homologacao nao autoriza `main`, PR, merge, archive ou release.
+- **Regra de release/lote:** seguir `alan-workflow`; no cripto, selecione todos os cards `Homologado` incluídos no pacote, confirme commits/branches, rode validação final completa, arquive OpenSpec, push, PR para `main`, merge manual, atualize `develop` e mova os cards incluídos para `Pronto`.
 - **Regra documental de release da Clara/Alan:** quando Alan pedir `gerar release`, `criar release`, `fechar release`, `subir lote` ou equivalente para cards no nome da Clara ou do Alan, antes de publicar/encerrar o pacote, pegue todos os cards `Homologado` por Alan e com `Responsavel=Clara` ou `Responsavel=Alan` incluídos na release e revise se as decisões, status e entregáveis desses cards estão refletidos na documentação do projeto/produto. A documentação precisa ficar atualizada tanto nos Markdown locais quanto nos Google Docs/Drive correspondentes. Depois da release publicada/encerrada com evidência, mova esses cards de `Homologado` para `Pronto`. Cards de `Codex` seguem o fluxo técnico próprio do Codex no mesmo pacote.
 - **Regra de não regressão de status:** depois que um card estiver em `Done`, nunca mova de volta para `In Progress` durante homologação, archive, commit, PR ou merge. Se aparecer falha, ajuste necessário ou reteste, corrija e reteste mantendo o status atual. O card só avança: `Done` -> `Homologado` -> `Pronto`.
 - **Regra de confiabilidade por testes:** em qualquer etapa, se surgir erro de testes (locais ou CI), corrija, revalide e só então siga para próxima etapa de encerramento.
 - **Regra de validação OpenSpec global:** `openspec validate --all` verde é critério padrão de fechamento. Se falhar por changes antigas fora do card, valide os specs afetados pelo card como evidência parcial, mas resolva a sujeira global antes do encerramento: corrija ou arquive as changes antigas, inclusive por archive manual quando a CLI/skill não conseguir concluir.
-- **Regra de checks em execução:** teste, build ou CI iniciado precisa ser acompanhado até terminar. Status como "build está rodando" é atualização intermediária, não evidência final para `Done`, release/lote, commit, PR ou merge.
+- **Regra de checks em execução:** seguir `alan-workflow`; no cripto, isso vale para testes locais, `openspec validate`, build e CI antes de `Done`, release/lote, commit, PR ou merge.
 - **Regra de commits e testes:** commits locais na branch da change são permitidos e não exigem suíte completa a cada commit. Durante o card, rode testes proporcionais/focados; testes completos ficam para fechamento de lote/release.
-- **Regra de worktree limpo no fechamento:** antes de iniciar nova change, antes de `Done`, release/lote, commit, PR ou merge, rode `git status --short` e não deixe nenhum arquivo modificado solto sem classificação. Trabalho de outra change deve ir para branch/worktree própria. Stash é só proteção temporária, sempre nomeado com hash, arquivos, motivo e comando de recuperação.
-- **Regra de varredura da release:** quando Alan pedir `suba a release`, `subir release`, `salvar tudo`, `subir para develop/main`, `limpar branches`, `limpar worktrees` ou equivalente, trate como fechamento completo de release: primeiro faça inventário de todos os worktrees e branches (`git worktree list`, `git status -sb` em cada diretório e commits `ahead`). Classifique cada item como `integrar`, `já integrado`, `preservar` ou `descartar somente com autorização explícita`. Integre o que deve entrar, valide, envie para `develop`, publique em `main` via PR/merge manual quando permitido e só então limpe branches/worktrees. Antes de remover branch ou diretório temporário, prove que o commit/patch entrou em `main` ou registre por que deve ser preservado. Nunca apague worktree/branch com arquivo modificado, não rastreado ou commit `ahead` sem commit/merge/cherry-pick confirmado.
+- **Regra de worktree limpo no fechamento:** seguir `alan-workflow`; no cripto, trabalho de outra change deve ir para branch/worktree própria e a integração padrão acontece em `develop` antes de produção.
+- **Regra de varredura da release:** seguir o inventario/classificacao de `alan-workflow`; no cripto, integre o que deve entrar em `develop`, publique em `main` via PR/merge manual quando permitido e só então limpe branches/worktrees.
 - **Regra de guard automatizado de release:** antes de abrir/mesclar PR de release, rode `scripts/release-guard pre`; depois do merge/publicação e antes de reportar limpeza final, rode `scripts/release-guard post`. Se qualquer modo estrito falhar, pare e classifique/corrija todos os bloqueios antes de seguir. Use `scripts/release-guard audit` para diagnostico sem bloqueio durante desenvolvimento.
 - **Regra de comparação oficial:** estado publicado deve ser comparado contra `origin/develop` e `origin/main` depois de `git fetch --prune origin`. `main` local ou `develop` local atrasados servem apenas como alerta, nunca como prova final de merge ou falta de merge.
-- **Regra anti-stash órfão:** stash não é armazenamento de trabalho. Nenhuma release/lote pode terminar com stash novo ou antigo sem classificação explícita: `integrar`, `preservar em branch/card`, ou `descartar somente com autorização explícita`.
+- **Regra anti-stash órfão:** seguir `alan-workflow`; nenhuma release/lote pode terminar com stash novo ou antigo sem classificacao explicita.
 - **Banco padrão:** PostgreSQL é obrigatório em runtime, QA e scripts operacionais (`DATABASE_URL` e `WORKFLOW_DATABASE_URL` em formato PostgreSQL).
 - **Não usar SQLite** como banco de operação. Em runtime/QA/Homologação, use apenas PostgreSQL (`DATABASE_URL` e `WORKFLOW_DATABASE_URL`).
 - **Funcionalidades novas:** siga OpenSpec por padrão antes de implementar (`openspec/changes/<change>/` com proposal/spec/design/tasks quando aplicável).
 - **Regra obrigatória de criação via OpenSpec:** ao iniciar uma mudança por card, execute o fluxo ` /opsx:new ──► /opsx:ff ──► /opsx:apply ──► /opsx:verify ` antes de mover para `Done`; execute `/opsx:archive` somente no fechamento de lote/release para produção.
   - Se o projeto ainda não estiver inicializado com OpenSpec, rode `openspec init` e então comece o fluxo.
+- **OpenSpec no card antes de implementar:** seguir `alan-workflow`; neste repo, preferir Gist secreto descrito como `crypto openspec <change>` e comentario no issue/card.
 - **Observação de fluxo OpenSpec:** use os comandos nesta ordem para mudanças novas; ajuste a cadência apenas com justificativa explícita.
 - **Subagents:** use subagents sempre que houver ganho claro de paralelismo, investigação independente, validação especializada ou aceleração sem duplicar trabalho.
 - OpenSpec é a camada de especificação técnica (artifacts).
@@ -70,6 +78,8 @@ De-para principal:
 | `/opsx:verify <change>` | `$openspec-verify-change` | `openspec list --json` quando a change estiver ambígua; `openspec status --change "<change>" --json`; `openspec instructions apply --change "<change>" --json` | Verifica completude, corretude e coerência entre artifacts, specs, tasks, design, testes e implementação real. |
 | `/opsx:archive <change>` | `$openspec-archive-change` | `openspec status --change "<change>" --json`; avaliar sync de specs; mover para `openspec/changes/archive/YYYY-MM-DD-<change>/` | Arquiva somente no fechamento de lote/release após homologação, checando artifacts, tasks, delta specs e registrando warnings se algo ficar incompleto. |
 
+Antes de executar `/opsx:apply` em qualquer change vinculada a card/issue, siga `alan-workflow` e publique os artefatos OpenSpec no card. Convencao local do Gist: descricao `crypto openspec <change>` e comentario no card do Project 1.
+
 De-para complementar:
 
 | Intenção / comando | Skill Codex obrigatória | Uso correto |
@@ -89,6 +99,10 @@ Fluxo canônico para implementação por card:
 /opsx:ff <change>
   -> usar $openspec-ff-change
   -> gerar artifacts até apply-ready
+
+publicar artifacts OpenSpec no card
+  -> seguir alan-workflow; no cripto, usar Gist `crypto openspec <change>` ou links permanentes
+  -> comentar o card com change, arquivos e comandos gh gist view
 
 /opsx:apply <change>
   -> usar $openspec-apply-change
@@ -141,19 +155,23 @@ Este projeto usa branches por change para isolar trabalho, `develop` para integr
 
 1. Atualizar `develop`.
 2. Criar branch `change-<id>-<slug>` ou `card-<id>-<slug>`.
-3. Mover card para `In Progress`.
-4. Executar OpenSpec (`/opsx:new`, `/opsx:ff`, `/opsx:apply`, `/opsx:verify`) e implementar.
+3. Mover card para `Status=In Progress`.
+4. Executar OpenSpec (`/opsx:new`, `/opsx:ff`), publicar os artifacts OpenSpec no card, então executar `/opsx:apply` e `/opsx:verify` para implementar e validar.
 5. Fazer commits locais na branch quando útil. Não rodar suíte completa a cada commit.
 6. Rodar testes proporcionais/focados e validação OpenSpec da change.
 7. Integrar em `develop` quando pronto para teste integrado, preferencialmente com squash/commit único por card referenciando o card.
 8. Executar `./restart`.
-9. Mover para `Done` com comentário de evidência.
+9. Mover para `Status=Done` com comentário de evidência tecnica.
 
 ### Colunas Kanban
 
-- `Done`: implementação técnica concluída, validada proporcionalmente e integrada em `develop`.
+- O campo `Status` e a fonte principal das colunas. O campo `Fluxo`, quando existir, e substatus/legado; se houver divergencia, `Status` prevalece.
+- `Todo`: backlog ou pronto para comecar.
+- `In Progress`: Codex/Clara esta trabalhando ou validando tecnicamente.
+- `Done`: Done tecnico; implementação técnica concluída, validada proporcionalmente e integrada em `develop`, aguardando teste/aprovacao do Alan.
 - `Homologado`: Alan testou/aprovou funcionalmente em `develop`.
-- `Pronto`: conteúdo do card entrou em `main`/produção.
+- `Pronto`: conteúdo do card entrou em `main`/produção com evidencia; este e o fechamento final.
+- `Cancelado`: nao sera feito ou foi substituido.
 
 Nunca mover para `Homologado` sem aprovação explícita de Alan. Nunca mover para `Pronto` sem confirmar merge/publicação em `main`.
 
@@ -437,6 +455,6 @@ O agente principal continua responsável por consolidar decisões, evitar trabal
 
 ## Engenharia de prompt
 
-Reforço de fluxo de fechamento: `Done` conclui implementação validada em `develop`; `Homologado` conclui aprovação funcional de Alan em `develop`; `Pronto` conclui produção após merge manual em `main` (via PR `develop -> main`) com validação e evidências registradas.
+Reforço de fluxo de fechamento: `Done` conclui somente a implementação validada em `develop` (Done tecnico); `Homologado` conclui aprovação funcional de Alan em `develop`; `Pronto` conclui produção após merge manual em `main` (via PR `develop -> main`) com validação e evidências registradas.
 
 Se for necessário mudar o tom de um agente (ex: deixar o design mais exploratório ou o DEV mais cauteloso), primeiro atualiza este arquivo com o novo prompt/personalidade e registra no `openspec/changes/<change>/` do fluxo ativo. Nunca altere agentes apenas via jobs sem documentar aqui.

--- a/backend/app/services/strategy_descriptions.py
+++ b/backend/app/services/strategy_descriptions.py
@@ -6,20 +6,22 @@ import re
 from typing import Any
 
 PUBLIC_STRATEGY_DISPLAY_NAMES: dict[str, str] = {
-    "multi_ma_crossover": "Virada de Tendência",
+    "multi_ma_crossover": "Tendência em Virada",
     "multi_ma_crossoverv2": "Tendência Confirmada",
-    "ema_rsi": "Pulso de Momentum",
-    "ema_macd_volume": "Força com Volume",
+    "ema_rsi": "Retomada com Força",
+    "ema_macd_volume": "Movimento com Confirmação",
     "bollinger_rsi_adx": "Retorno ao Equilíbrio",
-    "volume_atr_breakout": "Rompimento com Volatilidade",
-    "ema_rsi_fibonacci": "Pullback de Retomada",
-    "short_ema200_pullback": "Repique em Tendência de Baixa",
+    "volume_atr_breakout": "Rompimento com Pressão",
+    "ema_rsi_fibonacci": "Recuo de Retomada",
+    "short_ema200_pullback": "Repique de Baixa",
     "bollinger_breakout": "Expansão de Volatilidade",
-    "macd_cross": "Mudança de Momentum",
-    "rsi_ema_scalping": "Leitura Rápida de Movimento",
-    "example: breakout with volume": "Rompimento com Volume",
-    "example: scalping ema 5/13": "Leitura Ágil de Curto Prazo",
-    "example: swing rsi divergence": "Reversão de Swing",
+    "macd_cross": "Mudança de Ritmo",
+    "rsi_ema_scalping": "Movimento Curto",
+    "example_breakout_with_volume": "Rompimento com Volume",
+    "example_scalping_ema_5_13": "Leitura Ágil",
+    "example_swing_rsi_divergence": "Virada de Swing",
+    "quant_btc_1d_roc_ema_momentum_guard_long_v3": "Momentum BTC Protegido",
+    "quant_btc_roc_ema_momentum_guard_long_v3": "Momentum BTC Protegido",
 }
 
 PUBLIC_STRATEGY_DESCRIPTIONS: dict[str, str] = {
@@ -65,6 +67,12 @@ PUBLIC_STRATEGY_DESCRIPTIONS: dict[str, str] = {
     "example: swing rsi divergence": (
         "Observa sinais de enfraquecimento do movimento para estudar possíveis reversões em operações de swing."
     ),
+    "quant_btc_1d_roc_ema_momentum_guard_long_v3": (
+        "Acompanha a força direcional do BTC com filtros de proteção para evitar entradas em contexto fraco. Use como apoio para avaliar continuidade, sempre conferindo risco e histórico."
+    ),
+    "quant_btc_roc_ema_momentum_guard_long_v3": (
+        "Acompanha a força direcional do BTC com filtros de proteção para evitar entradas em contexto fraco. Use como apoio para avaliar continuidade, sempre conferindo risco e histórico."
+    ),
 }
 
 SENSITIVE_NAME_PATTERN = re.compile(
@@ -74,7 +82,8 @@ SENSITIVE_NAME_PATTERN = re.compile(
 
 
 def normalize_strategy_key(name: Any) -> str:
-    return str(name or "").strip().lower().replace("-", "_")
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(name or "").strip().lower())
+    return normalized.strip("_")
 
 
 def public_strategy_display_name(name: Any) -> str:
@@ -84,15 +93,7 @@ def public_strategy_display_name(name: Any) -> str:
     if key in PUBLIC_STRATEGY_DISPLAY_NAMES:
         return PUBLIC_STRATEGY_DISPLAY_NAMES[key]
 
-    raw = str(name or "").strip()
-    if not raw:
-        return "Estratégia Protegida"
-    if SENSITIVE_NAME_PATTERN.search(raw):
-        return "Estratégia Protegida"
-
-    parts = raw.replace("-", "_").split("_")
-    normalized = [part[:1].upper() + part[1:] for part in parts if part.strip()]
-    return " ".join(normalized) or "Estratégia Protegida"
+    return "Estratégia Cripto Farol"
 
 
 def public_strategy_description(name: Any, raw_description: Any = None) -> str:

--- a/backend/app/services/strategy_descriptions.py
+++ b/backend/app/services/strategy_descriptions.py
@@ -6,22 +6,22 @@ import re
 from typing import Any
 
 PUBLIC_STRATEGY_DISPLAY_NAMES: dict[str, str] = {
-    "multi_ma_crossover": "Tendência em Virada",
-    "multi_ma_crossoverv2": "Tendência Confirmada",
-    "ema_rsi": "Retomada com Força",
-    "ema_macd_volume": "Movimento com Confirmação",
-    "bollinger_rsi_adx": "Retorno ao Equilíbrio",
-    "volume_atr_breakout": "Rompimento com Pressão",
-    "ema_rsi_fibonacci": "Recuo de Retomada",
-    "short_ema200_pullback": "Repique de Baixa",
-    "bollinger_breakout": "Expansão de Volatilidade",
-    "macd_cross": "Mudança de Ritmo",
-    "rsi_ema_scalping": "Movimento Curto",
-    "example_breakout_with_volume": "Rompimento com Volume",
-    "example_scalping_ema_5_13": "Leitura Ágil",
-    "example_swing_rsi_divergence": "Virada de Swing",
-    "quant_btc_1d_roc_ema_momentum_guard_long_v3": "Momentum BTC Protegido",
-    "quant_btc_roc_ema_momentum_guard_long_v3": "Momentum BTC Protegido",
+    "multi_ma_crossover": "Médias Móveis: Tendência em Virada",
+    "multi_ma_crossoverv2": "Médias Móveis: Tendência Confirmada",
+    "ema_rsi": "RSI: Retomada com Força",
+    "ema_macd_volume": "MACD + Volume: Movimento com Confirmação",
+    "bollinger_rsi_adx": "Bandas + RSI: Retorno ao Equilíbrio",
+    "volume_atr_breakout": "Volume + Volatilidade: Rompimento com Pressão",
+    "ema_rsi_fibonacci": "Fibonacci: Recuo de Retomada",
+    "short_ema200_pullback": "Médias Móveis: Repique de Baixa",
+    "bollinger_breakout": "Bandas: Expansão de Volatilidade",
+    "macd_cross": "MACD: Mudança de Ritmo",
+    "rsi_ema_scalping": "RSI: Movimento Curto",
+    "example_breakout_with_volume": "Volume: Rompimento com Pressão",
+    "example_scalping_ema_5_13": "Médias Móveis: Leitura Ágil",
+    "example_swing_rsi_divergence": "RSI: Virada de Swing",
+    "quant_btc_1d_roc_ema_momentum_guard_long_v3": "Momentum BTC: Continuidade Protegida",
+    "quant_btc_roc_ema_momentum_guard_long_v3": "Momentum BTC: Continuidade Protegida",
 }
 
 PUBLIC_STRATEGY_DESCRIPTIONS: dict[str, str] = {

--- a/backend/app/services/strategy_descriptions.py
+++ b/backend/app/services/strategy_descriptions.py
@@ -1,55 +1,98 @@
-"""Public trader-facing strategy descriptions."""
+"""Public trader-facing strategy names and descriptions."""
 
 from __future__ import annotations
 
+import re
 from typing import Any
+
+PUBLIC_STRATEGY_DISPLAY_NAMES: dict[str, str] = {
+    "multi_ma_crossover": "Virada de Tendência",
+    "multi_ma_crossoverv2": "Tendência Confirmada",
+    "ema_rsi": "Pulso de Momentum",
+    "ema_macd_volume": "Força com Volume",
+    "bollinger_rsi_adx": "Retorno ao Equilíbrio",
+    "volume_atr_breakout": "Rompimento com Volatilidade",
+    "ema_rsi_fibonacci": "Pullback de Retomada",
+    "short_ema200_pullback": "Repique em Tendência de Baixa",
+    "bollinger_breakout": "Expansão de Volatilidade",
+    "macd_cross": "Mudança de Momentum",
+    "rsi_ema_scalping": "Leitura Rápida de Movimento",
+    "example: breakout with volume": "Rompimento com Volume",
+    "example: scalping ema 5/13": "Leitura Ágil de Curto Prazo",
+    "example: swing rsi divergence": "Reversão de Swing",
+}
 
 PUBLIC_STRATEGY_DESCRIPTIONS: dict[str, str] = {
     "multi_ma_crossover": (
-        "Segue a tendência usando médias móveis para indicar quando a força de compra ou venda muda."
+        "Acompanha mudanças de direção para apoiar decisões quando o mercado mostra virada de tendência. Use como sinal de contexto, sempre conferindo risco e histórico antes de agir."
     ),
     "multi_ma_crossoverv2": (
-        "Busca movimentos de tendência com médias móveis e filtro de direção antes de sinalizar entrada ou saída."
+        "Filtra movimentos direcionais e procura momentos em que a tendência parece ganhar confirmação. Ajuda a comparar oportunidades sem prometer continuidade do movimento."
     ),
     "ema_rsi": (
-        "Combina tendência e força do movimento para procurar entradas com confirmação de momentum."
+        "Observa força e fôlego do movimento para indicar quando uma retomada pode estar se formando. Serve como apoio para avaliar entrada, não como recomendação automática."
     ),
     "ema_macd_volume": (
-        "Procura movimentos de tendência confirmados por momentum e aumento de volume."
+        "Prioriza movimentos em que direção, força e participação do mercado parecem convergir. Útil para acompanhar tendências com confirmação ampla, sem garantia de resultado."
     ),
     "bollinger_rsi_adx": (
-        "Busca oportunidades de retorno ao preço médio quando o ativo estica demais dentro do contexto de tendência."
+        "Busca leituras de possível retorno ao equilíbrio depois de movimentos esticados. Ajuda a separar exagero de mercado de tendência persistente."
     ),
     "volume_atr_breakout": (
-        "Observa rompimentos com volume e volatilidade para capturar movimentos mais fortes."
+        "Acompanha rompimentos quando preço, volume e volatilidade sugerem aceleração. Deve ser validada junto ao risco, pois rompimentos podem falhar."
     ),
     "ema_rsi_fibonacci": (
-        "Procura pullbacks em tendência usando força do movimento e regiões prováveis de retomada."
+        "Observa recuos dentro de uma direção principal para identificar possíveis retomadas. Ajuda a estudar continuidade, sem expor a receita técnica da leitura."
     ),
     "short_ema200_pullback": (
-        "Busca vendas em repiques contra uma tendência principal de baixa, com gestão por stop."
+        "Acompanha repiques contra uma direção principal de baixa para apoiar decisões de venda. Use apenas como leitura de contexto e com atenção ao risco."
     ),
     "bollinger_breakout": (
-        "Observa expansão de volatilidade nas Bandas de Bollinger para identificar rompimentos."
+        "Observa momentos em que a volatilidade começa a expandir e pode abrir espaço para rompimento. Não substitui avaliação de risco e confirmação."
     ),
-    "macd_cross": ("Usa cruzamentos de MACD para acompanhar mudanças de momentum na tendência."),
+    "macd_cross": (
+        "Acompanha mudanças de momentum para indicar quando a força do movimento pode estar mudando de lado."
+    ),
     "rsi_ema_scalping": (
-        "Combina RSI e médias curtas para leituras rápidas em movimentos de curto prazo."
+        "Foca leituras rápidas de curto prazo para apoiar decisões em movimentos mais ágeis. Exige acompanhamento próximo e controle de risco."
     ),
     "example: breakout with volume": (
-        "Procura rompimentos de preço que ganham confirmação pelo aumento de volume."
+        "Procura rompimentos que ganham participação do mercado. Deve ser usada como apoio para comparar cenários, não como promessa de acerto."
     ),
     "example: scalping ema 5/13": (
-        "Usa médias rápidas para capturar movimentos curtos com resposta ágil."
+        "Apoia leituras curtas e rápidas para quem acompanha o movimento de perto. Não revela a configuração técnica usada."
     ),
     "example: swing rsi divergence": (
-        "Procura divergências de RSI para antecipar possíveis viradas em operações de swing."
+        "Observa sinais de enfraquecimento do movimento para estudar possíveis reversões em operações de swing."
     ),
 }
+
+SENSITIVE_NAME_PATTERN = re.compile(
+    r"(\d|ema|sma|rsi|macd|adx|atr|bollinger|fibonacci|entry|exit|threshold|logic)",
+    re.IGNORECASE,
+)
 
 
 def normalize_strategy_key(name: Any) -> str:
     return str(name or "").strip().lower().replace("-", "_")
+
+
+def public_strategy_display_name(name: Any) -> str:
+    """Return a safe product name for visible strategy identity."""
+
+    key = normalize_strategy_key(name)
+    if key in PUBLIC_STRATEGY_DISPLAY_NAMES:
+        return PUBLIC_STRATEGY_DISPLAY_NAMES[key]
+
+    raw = str(name or "").strip()
+    if not raw:
+        return "Estratégia Protegida"
+    if SENSITIVE_NAME_PATTERN.search(raw):
+        return "Estratégia Protegida"
+
+    parts = raw.replace("-", "_").split("_")
+    normalized = [part[:1].upper() + part[1:] for part in parts if part.strip()]
+    return " ".join(normalized) or "Estratégia Protegida"
 
 
 def public_strategy_description(name: Any, raw_description: Any = None) -> str:
@@ -59,14 +102,7 @@ def public_strategy_description(name: Any, raw_description: Any = None) -> str:
     if key in PUBLIC_STRATEGY_DESCRIPTIONS:
         return PUBLIC_STRATEGY_DESCRIPTIONS[key]
 
-    raw = str(raw_description or "").strip()
-    if not raw:
-        return "Estratégia configurada para avaliar entradas e saídas com regras salvas no sistema."
-
-    first_sentence = raw.split(".")[0].strip()
-    if not first_sentence:
-        return "Estratégia configurada para avaliar entradas e saídas com regras salvas no sistema."
-
-    if len(first_sentence) > 180:
-        first_sentence = first_sentence[:177].rstrip() + "..."
-    return first_sentence
+    return (
+        "Estratégia configurada para apoiar decisões de entrada e saída com regras protegidas "
+        "no sistema. Avalie junto ao histórico, ao contexto do ativo e ao seu controle de risco."
+    )

--- a/backend/app/services/strategy_secret_visibility.py
+++ b/backend/app/services/strategy_secret_visibility.py
@@ -51,12 +51,12 @@ def redact_favorite_strategy_payload(
     *,
     include_secrets: bool,
 ) -> dict[str, Any]:
+    public_display_name = _public_strategy_display_name(payload)
     if include_secrets:
         payload["is_strategy_protected"] = False
-        payload.setdefault("strategy_display_name", _display_name(payload))
+        payload["strategy_display_name"] = public_display_name
         return payload
 
-    public_display_name = _public_strategy_display_name(payload)
     payload["strategy_name"] = PROTECTED_STRATEGY_LABEL
     payload["parameters"] = {}
     payload["is_strategy_protected"] = True
@@ -101,12 +101,12 @@ def redact_opportunity_payload(
     *,
     include_secrets: bool,
 ) -> dict[str, Any]:
+    public_display_name = _public_strategy_display_name(payload)
     if include_secrets:
         payload["is_strategy_protected"] = False
-        payload.setdefault("strategy_display_name", _display_name(payload))
+        payload["strategy_display_name"] = public_display_name
         return payload
 
-    public_display_name = _public_strategy_display_name(payload)
     payload["template_name"] = PROTECTED_STRATEGY_LABEL
     if payload.get("is_curated_fallback"):
         payload["name"] = PROTECTED_STRATEGY_LABEL

--- a/backend/app/services/strategy_secret_visibility.py
+++ b/backend/app/services/strategy_secret_visibility.py
@@ -7,18 +7,10 @@ from sqlalchemy.orm import Session
 
 from app.middleware.authMiddleware import is_admin_email
 from app.models import User
+from app.services.strategy_descriptions import public_strategy_display_name
 
 PROTECTED_STRATEGY_LABEL = "Estratégia protegida"
 PROTECTED_STRATEGY_CODE = "estrategia_protegida"
-PUBLIC_STRATEGY_ACRONYMS = {
-    "atr": "ATR",
-    "ema": "EMA",
-    "macd": "MACD",
-    "ma": "MA",
-    "rsi": "RSI",
-    "sma": "SMA",
-    "vwap": "VWAP",
-}
 
 
 def can_view_strategy_secrets(db: Session, user_id: str | None) -> bool:
@@ -51,16 +43,7 @@ def _public_strategy_display_name(payload: dict[str, Any]) -> str:
     if not raw or raw == PROTECTED_STRATEGY_LABEL:
         return PROTECTED_STRATEGY_LABEL
 
-    parts = raw.replace("-", "_").split("_")
-    normalized = []
-    for part in parts:
-        token = part.strip()
-        if not token:
-            continue
-        lower = token.lower()
-        normalized.append(PUBLIC_STRATEGY_ACRONYMS.get(lower, token[:1].upper() + token[1:]))
-
-    return " ".join(normalized) or PROTECTED_STRATEGY_LABEL
+    return public_strategy_display_name(raw)
 
 
 def redact_favorite_strategy_payload(

--- a/backend/tests/integration/test_favorites_user_scoping.py
+++ b/backend/tests/integration/test_favorites_user_scoping.py
@@ -117,7 +117,7 @@ def test_favorites_list_only_returns_current_user_rows(tmp_path: Path):
     assert [item.name for item in listed_b] == ["B favorite"]
     assert [item.name for item in listed_a] == ["A favorite"]
     assert listed_a[0].strategy_name == "Estratégia protegida"
-    assert listed_a[0].strategy_display_name == "Tendência em Virada"
+    assert listed_a[0].strategy_display_name == "Médias Móveis: Tendência em Virada"
     assert listed_a[0].parameters == {}
     assert listed_a[0].is_strategy_protected is True
     assert "tendência" in (listed_a[0].strategy_description or "").lower()
@@ -312,9 +312,9 @@ def test_common_user_lists_admin_catalog_and_saves_own_star_tier(tmp_path: Path,
     assert [item.id for item in common_list] == [admin_favorite.id, admin_second_favorite.id]
     assert common_list[0].tier is None
     assert common_list[0].strategy_name == "Estratégia protegida"
-    assert common_list[0].strategy_display_name == "Tendência em Virada"
+    assert common_list[0].strategy_display_name == "Médias Móveis: Tendência em Virada"
     assert common_list[1].strategy_name == "Estratégia protegida"
-    assert common_list[1].strategy_display_name == "Retomada com Força"
+    assert common_list[1].strategy_display_name == "RSI: Retomada com Força"
     assert common_list[0].parameters == {}
     assert common_list[1].parameters == {}
     assert updated.tier == 1

--- a/backend/tests/integration/test_favorites_user_scoping.py
+++ b/backend/tests/integration/test_favorites_user_scoping.py
@@ -117,7 +117,7 @@ def test_favorites_list_only_returns_current_user_rows(tmp_path: Path):
     assert [item.name for item in listed_b] == ["B favorite"]
     assert [item.name for item in listed_a] == ["A favorite"]
     assert listed_a[0].strategy_name == "Estratégia protegida"
-    assert listed_a[0].strategy_display_name == "Virada de Tendência"
+    assert listed_a[0].strategy_display_name == "Tendência em Virada"
     assert listed_a[0].parameters == {}
     assert listed_a[0].is_strategy_protected is True
     assert "tendência" in (listed_a[0].strategy_description or "").lower()
@@ -312,9 +312,9 @@ def test_common_user_lists_admin_catalog_and_saves_own_star_tier(tmp_path: Path,
     assert [item.id for item in common_list] == [admin_favorite.id, admin_second_favorite.id]
     assert common_list[0].tier is None
     assert common_list[0].strategy_name == "Estratégia protegida"
-    assert common_list[0].strategy_display_name == "Virada de Tendência"
+    assert common_list[0].strategy_display_name == "Tendência em Virada"
     assert common_list[1].strategy_name == "Estratégia protegida"
-    assert common_list[1].strategy_display_name == "Pulso de Momentum"
+    assert common_list[1].strategy_display_name == "Retomada com Força"
     assert common_list[0].parameters == {}
     assert common_list[1].parameters == {}
     assert updated.tier == 1

--- a/backend/tests/integration/test_favorites_user_scoping.py
+++ b/backend/tests/integration/test_favorites_user_scoping.py
@@ -117,7 +117,7 @@ def test_favorites_list_only_returns_current_user_rows(tmp_path: Path):
     assert [item.name for item in listed_b] == ["B favorite"]
     assert [item.name for item in listed_a] == ["A favorite"]
     assert listed_a[0].strategy_name == "Estratégia protegida"
-    assert listed_a[0].strategy_display_name == "Multi MA Crossover"
+    assert listed_a[0].strategy_display_name == "Virada de Tendência"
     assert listed_a[0].parameters == {}
     assert listed_a[0].is_strategy_protected is True
     assert "tendência" in (listed_a[0].strategy_description or "").lower()
@@ -312,9 +312,9 @@ def test_common_user_lists_admin_catalog_and_saves_own_star_tier(tmp_path: Path,
     assert [item.id for item in common_list] == [admin_favorite.id, admin_second_favorite.id]
     assert common_list[0].tier is None
     assert common_list[0].strategy_name == "Estratégia protegida"
-    assert common_list[0].strategy_display_name == "Multi MA Crossover"
+    assert common_list[0].strategy_display_name == "Virada de Tendência"
     assert common_list[1].strategy_name == "Estratégia protegida"
-    assert common_list[1].strategy_display_name == "EMA RSI"
+    assert common_list[1].strategy_display_name == "Pulso de Momentum"
     assert common_list[0].parameters == {}
     assert common_list[1].parameters == {}
     assert updated.tier == 1

--- a/backend/tests/integration/test_opportunities_smoke.py
+++ b/backend/tests/integration/test_opportunities_smoke.py
@@ -126,7 +126,7 @@ async def test_opportunities_route_keeps_signal_history_in_payload(monkeypatch):
     assert len(response) == 1
     assert response[0]["asset_type"] == "crypto"
     assert response[0]["template_name"] == "Estratégia protegida"
-    assert response[0]["strategy_display_name"] == "Virada de Tendência"
+    assert response[0]["strategy_display_name"] == "Tendência em Virada"
     assert response[0]["parameters"] == {}
     assert response[0]["indicator_values"] is None
     assert response[0]["details"] == {}
@@ -186,6 +186,7 @@ async def test_opportunities_route_keeps_admin_strategy_details(monkeypatch):
     response = await opportunity_routes.get_opportunities(tier="all", current_user_id="admin-user")
 
     assert response[0]["template_name"] == "multi_ma_crossover"
+    assert response[0]["strategy_display_name"] == "Tendência em Virada"
     assert response[0]["parameters"] == {"ema_short": 9, "sma_long": 50}
     assert response[0]["indicator_values"] == {"short": 71346.57}
     assert response[0]["details"] == {"exit_analysis": {"distance": 0.88}}
@@ -237,7 +238,7 @@ async def test_opportunities_route_redacts_curated_fallback_for_common_user(monk
 
     assert captured["user_id"] == "common-user"
     assert response[0]["template_name"] == "Estratégia protegida"
-    assert response[0]["strategy_display_name"] == "Secret Admin Strategy"
+    assert response[0]["strategy_display_name"] == "Estratégia Cripto Farol"
     assert response[0]["name"] == "Estratégia protegida"
     assert response[0]["notes"] is None
     assert response[0]["parameters"] == {}

--- a/backend/tests/integration/test_opportunities_smoke.py
+++ b/backend/tests/integration/test_opportunities_smoke.py
@@ -126,7 +126,7 @@ async def test_opportunities_route_keeps_signal_history_in_payload(monkeypatch):
     assert len(response) == 1
     assert response[0]["asset_type"] == "crypto"
     assert response[0]["template_name"] == "Estratégia protegida"
-    assert response[0]["strategy_display_name"] == "Tendência em Virada"
+    assert response[0]["strategy_display_name"] == "Médias Móveis: Tendência em Virada"
     assert response[0]["parameters"] == {}
     assert response[0]["indicator_values"] is None
     assert response[0]["details"] == {}
@@ -186,7 +186,7 @@ async def test_opportunities_route_keeps_admin_strategy_details(monkeypatch):
     response = await opportunity_routes.get_opportunities(tier="all", current_user_id="admin-user")
 
     assert response[0]["template_name"] == "multi_ma_crossover"
-    assert response[0]["strategy_display_name"] == "Tendência em Virada"
+    assert response[0]["strategy_display_name"] == "Médias Móveis: Tendência em Virada"
     assert response[0]["parameters"] == {"ema_short": 9, "sma_long": 50}
     assert response[0]["indicator_values"] == {"short": 71346.57}
     assert response[0]["details"] == {"exit_analysis": {"distance": 0.88}}

--- a/backend/tests/integration/test_opportunities_smoke.py
+++ b/backend/tests/integration/test_opportunities_smoke.py
@@ -126,7 +126,7 @@ async def test_opportunities_route_keeps_signal_history_in_payload(monkeypatch):
     assert len(response) == 1
     assert response[0]["asset_type"] == "crypto"
     assert response[0]["template_name"] == "Estratégia protegida"
-    assert response[0]["strategy_display_name"] == "Multi MA Crossover"
+    assert response[0]["strategy_display_name"] == "Virada de Tendência"
     assert response[0]["parameters"] == {}
     assert response[0]["indicator_values"] is None
     assert response[0]["details"] == {}

--- a/backend/tests/unit/test_strategy_descriptions.py
+++ b/backend/tests/unit/test_strategy_descriptions.py
@@ -1,4 +1,18 @@
-from app.services.strategy_descriptions import public_strategy_description
+from app.services.strategy_descriptions import (
+    public_strategy_description,
+    public_strategy_display_name,
+)
+
+SENSITIVE_COPY_TOKENS = (
+    "ema200",
+    "ema21",
+    "ema50",
+    "rsi 45",
+    "45-70",
+    "0.618",
+    "entry_logic",
+    "exit_logic",
+)
 
 
 def test_known_strategy_description_is_public_and_high_level():
@@ -7,11 +21,24 @@ def test_known_strategy_description_is_public_and_high_level():
         "Short-only: bearish trend with EMA200, EMA21, EMA50, RSI 45-70.",
     )
 
-    assert "vendas" in description.lower()
-    assert "rsi 45" not in description.lower()
+    assert "venda" in description.lower()
+    assert all(token not in description.lower() for token in SENSITIVE_COPY_TOKENS)
+
+
+def test_known_strategy_display_name_is_product_copy():
+    assert public_strategy_display_name("short_ema200_pullback") == "Repique em Tendência de Baixa"
+    assert public_strategy_display_name("ema_rsi") == "Pulso de Momentum"
+
+
+def test_unknown_sensitive_strategy_display_name_is_protected():
+    assert public_strategy_display_name("ema_9_sma_50_rsi_30_70") == "Estratégia Protegida"
 
 
 def test_unknown_strategy_description_uses_safe_fallback():
-    description = public_strategy_description("custom_template", "")
+    description = public_strategy_description(
+        "custom_template",
+        "Uses EMA 9, SMA 50, RSI 30-70 and entry_logic to recreate the strategy.",
+    )
 
-    assert "regras salvas" in description
+    assert "regras protegidas" in description
+    assert all(token not in description.lower() for token in SENSITIVE_COPY_TOKENS)

--- a/backend/tests/unit/test_strategy_descriptions.py
+++ b/backend/tests/unit/test_strategy_descriptions.py
@@ -26,12 +26,22 @@ def test_known_strategy_description_is_public_and_high_level():
 
 
 def test_known_strategy_display_name_is_product_copy():
-    assert public_strategy_display_name("short_ema200_pullback") == "Repique em Tendência de Baixa"
-    assert public_strategy_display_name("ema_rsi") == "Pulso de Momentum"
+    assert public_strategy_display_name("short_ema200_pullback") == "Repique de Baixa"
+    assert public_strategy_display_name("ema_rsi") == "Retomada com Força"
+    assert public_strategy_display_name("multi_ma_crossover") == "Tendência em Virada"
+
+
+def test_generated_quant_strategy_has_safe_product_copy():
+    raw_name = "Quant BTC ROC+EMA Momentum Guard Long v3"
+    description = public_strategy_description(raw_name)
+
+    assert public_strategy_display_name(raw_name) == "Momentum BTC Protegido"
+    assert "força direcional do btc" in description.lower()
+    assert all(token not in description.lower() for token in SENSITIVE_COPY_TOKENS)
 
 
 def test_unknown_sensitive_strategy_display_name_is_protected():
-    assert public_strategy_display_name("ema_9_sma_50_rsi_30_70") == "Estratégia Protegida"
+    assert public_strategy_display_name("ema_9_sma_50_rsi_30_70") == "Estratégia Cripto Farol"
 
 
 def test_unknown_strategy_description_uses_safe_fallback():

--- a/backend/tests/unit/test_strategy_descriptions.py
+++ b/backend/tests/unit/test_strategy_descriptions.py
@@ -26,16 +26,20 @@ def test_known_strategy_description_is_public_and_high_level():
 
 
 def test_known_strategy_display_name_is_product_copy():
-    assert public_strategy_display_name("short_ema200_pullback") == "Repique de Baixa"
-    assert public_strategy_display_name("ema_rsi") == "Retomada com Força"
-    assert public_strategy_display_name("multi_ma_crossover") == "Tendência em Virada"
+    assert (
+        public_strategy_display_name("short_ema200_pullback") == "Médias Móveis: Repique de Baixa"
+    )
+    assert public_strategy_display_name("ema_rsi") == "RSI: Retomada com Força"
+    assert (
+        public_strategy_display_name("multi_ma_crossover") == "Médias Móveis: Tendência em Virada"
+    )
 
 
 def test_generated_quant_strategy_has_safe_product_copy():
     raw_name = "Quant BTC ROC+EMA Momentum Guard Long v3"
     description = public_strategy_description(raw_name)
 
-    assert public_strategy_display_name(raw_name) == "Momentum BTC Protegido"
+    assert public_strategy_display_name(raw_name) == "Momentum BTC: Continuidade Protegida"
     assert "força direcional do btc" in description.lower()
     assert all(token not in description.lower() for token in SENSITIVE_COPY_TOKENS)
 

--- a/frontend/src/components/monitor/ChartModal.tsx
+++ b/frontend/src/components/monitor/ChartModal.tsx
@@ -5,7 +5,7 @@ import type { MarketCandle } from './MiniCandlesChart';
 import { API_BASE_URL } from '../../lib/apiBase';
 import { authFetch } from '@/lib/authFetch';
 import { formatStrategyParameterLabel, formatStrategyParameterValue } from '@/lib/strategyParameters';
-import { buildTradeMarkers } from '@/lib/tradeMarkers';
+import { buildTradeMarkers, collapseSameCandleOppositeMarkers, sameDisplayedCandle } from '@/lib/tradeMarkers';
 import {
     StrategyChartSurface,
     toStrategyChartTimestamp,
@@ -222,6 +222,15 @@ function hasEquivalentMarker(markers: StrategyChartMarker[], marker: StrategyCha
         && existing.shape === marker.shape
         && existing.position === marker.position
     ));
+}
+
+function markerTextCovers(existing: StrategyChartMarker, marker: StrategyChartMarker): boolean {
+    const existingText = existing.text.toUpperCase();
+    const markerText = marker.text.toUpperCase();
+    return (
+        (markerText.includes('COMPRA') && existingText.includes('COMPRA'))
+        || (markerText.includes('VENDA') && existingText.includes('VENDA'))
+    );
 }
 
 export const ChartModal: React.FC<ChartModalProps> = ({
@@ -503,13 +512,21 @@ export const ChartModal: React.FC<ChartModalProps> = ({
             ? tradeSignalMarkers
             : historicalSignalMarkers as StrategyChartMarker[];
 
-        return baseMarkers.length > 0
+        const mergedMarkers = baseMarkers.length > 0
             ? [
                 ...baseMarkers,
-                ...fallbackMarker.filter((marker) => !hasEquivalentMarker(baseMarkers, marker)),
+                ...fallbackMarker.filter((marker) => (
+                    !hasEquivalentMarker(baseMarkers, marker)
+                    && !baseMarkers.some((existing) => (
+                        sameDisplayedCandle(existing.time, marker.time, timeframe)
+                        && markerTextCovers(existing, marker)
+                    ))
+                )),
             ]
             : fallbackMarker;
-    }, [fallbackMarker, historicalSignalMarkers, tradeSignalMarkers]);
+
+        return collapseSameCandleOppositeMarkers(mergedMarkers, timeframe);
+    }, [fallbackMarker, historicalSignalMarkers, timeframe, tradeSignalMarkers]);
     const priceLines = React.useMemo<StrategyChartPriceLine[]>(() => [
         ...(showEntryStopRows && opportunity.entry_price !== null && opportunity.entry_price !== undefined
             ? [{ price: opportunity.entry_price, color: '#fcd535', title: 'Compra' }]

--- a/frontend/src/components/monitor/ChartModal.tsx
+++ b/frontend/src/components/monitor/ChartModal.tsx
@@ -5,6 +5,7 @@ import type { MarketCandle } from './MiniCandlesChart';
 import { API_BASE_URL } from '../../lib/apiBase';
 import { authFetch } from '@/lib/authFetch';
 import { formatStrategyParameterLabel, formatStrategyParameterValue } from '@/lib/strategyParameters';
+import { buildTradeMarkers } from '@/lib/tradeMarkers';
 import {
     StrategyChartSurface,
     toStrategyChartTimestamp,
@@ -207,34 +208,6 @@ function buildTradesFromSignalHistory(history: OpportunitySignalHistoryItem[] | 
     });
 
     return trades;
-}
-
-function buildTradeMarkers(trades: StrategyTrade[], direction: string): StrategyChartMarker[] {
-    const isShort = direction.toLowerCase() === 'short';
-    return trades.flatMap((trade) => {
-        const markers: StrategyChartMarker[] = [];
-        if (trade.entry_time) {
-            markers.push({
-                time: trade.entry_time,
-                position: isShort ? 'aboveBar' : 'belowBar',
-                color: isShort ? '#f97316' : '#10b981',
-                shape: isShort ? 'arrowDown' : 'arrowUp',
-                text: isShort ? 'VENDA' : 'COMPRA',
-            });
-        }
-        if (trade.exit_time) {
-            const profit = Number(trade.profit);
-            const profitText = Number.isFinite(profit) ? ` (${(profit * 100).toFixed(2)}%)` : '';
-            markers.push({
-                time: trade.exit_time,
-                position: isShort ? 'belowBar' : 'aboveBar',
-                color: isShort ? '#10b981' : '#ef4444',
-                shape: isShort ? 'arrowUp' : 'arrowDown',
-                text: isShort ? `COMPRA${profitText}` : `VENDA${profitText}`,
-            });
-        }
-        return markers;
-    });
 }
 
 function markerTimesMatch(left: StrategyChartMarker['time'], right: StrategyChartMarker['time']): boolean {
@@ -521,8 +494,10 @@ export const ChartModal: React.FC<ChartModalProps> = ({
         signalLabel,
     ]);
     const tradeSignalMarkers = React.useMemo<StrategyChartMarker[]>(() => (
-        canRenderSignalHistoryMarkers ? buildTradeMarkers(analysisTrades, opportunityDirection) : []
-    ), [analysisTrades, canRenderSignalHistoryMarkers, opportunityDirection]);
+        canRenderSignalHistoryMarkers
+            ? buildTradeMarkers(analysisTrades, { direction: opportunityDirection, timeframe })
+            : []
+    ), [analysisTrades, canRenderSignalHistoryMarkers, opportunityDirection, timeframe]);
     const chartMarkers = React.useMemo<StrategyChartMarker[]>(() => {
         const baseMarkers = tradeSignalMarkers.length > 0
             ? tradeSignalMarkers

--- a/frontend/src/components/monitor/ChartModal.tsx
+++ b/frontend/src/components/monitor/ChartModal.tsx
@@ -224,15 +224,6 @@ function hasEquivalentMarker(markers: StrategyChartMarker[], marker: StrategyCha
     ));
 }
 
-function markerTextCovers(existing: StrategyChartMarker, marker: StrategyChartMarker): boolean {
-    const existingText = existing.text.toUpperCase();
-    const markerText = marker.text.toUpperCase();
-    return (
-        (markerText.includes('COMPRA') && existingText.includes('COMPRA'))
-        || (markerText.includes('VENDA') && existingText.includes('VENDA'))
-    );
-}
-
 export const ChartModal: React.FC<ChartModalProps> = ({
     symbol,
     opportunity,
@@ -517,10 +508,7 @@ export const ChartModal: React.FC<ChartModalProps> = ({
                 ...baseMarkers,
                 ...fallbackMarker.filter((marker) => (
                     !hasEquivalentMarker(baseMarkers, marker)
-                    && !baseMarkers.some((existing) => (
-                        sameDisplayedCandle(existing.time, marker.time, timeframe)
-                        && markerTextCovers(existing, marker)
-                    ))
+                    && !baseMarkers.some((existing) => sameDisplayedCandle(existing.time, marker.time, timeframe))
                 )),
             ]
             : fallbackMarker;

--- a/frontend/src/components/onboarding/OnboardingGuide.tsx
+++ b/frontend/src/components/onboarding/OnboardingGuide.tsx
@@ -1,26 +1,26 @@
 import { Link } from 'react-router-dom'
-import { Activity, BarChart3, Bookmark, HelpCircle, ShieldCheck, Wallet } from 'lucide-react'
+import { Activity, Bookmark, HelpCircle, ShieldCheck, Wallet } from 'lucide-react'
 
 const journeySteps = [
   {
-    title: 'Carteira',
-    description: 'Confirme o contexto dos ativos que voce acompanha. Isso ajuda a leitura do Monitor.',
-    icon: Wallet,
+    title: 'Favoritos',
+    description: 'Comece por aqui: compare estrategias, veja graficos, revise trades e separe as melhores opcoes.',
+    icon: Bookmark,
   },
   {
-    title: 'Favoritos',
-    description: 'Escolha as estrategias que merecem acompanhamento e use estrelas para priorizar.',
+    title: 'Selecionar estrategias',
+    description: 'Use as estrelas para priorizar o que merece acompanhamento e levar apenas o essencial ao Monitor.',
     icon: Bookmark,
   },
   {
     title: 'Monitor',
-    description: 'Veja sinais, contexto e distancia para a proxima decisao sem depender de suporte manual.',
+    description: 'Acompanhe as estrategias selecionadas com status, contexto e distancia para a proxima decisao.',
     icon: Activity,
   },
   {
-    title: 'Grafico e Trades',
-    description: 'Abra o grafico para leitura visual ou Ver Trades para entender o historico da estrategia.',
-    icon: BarChart3,
+    title: 'Carteira Binance opcional',
+    description: 'Configure a carteira depois, se quiser complementar a leitura. Ela nao e requisito para comecar.',
+    icon: Wallet,
   },
 ]
 
@@ -54,8 +54,8 @@ export function OnboardingGuide({ compact = false, onDismiss }: OnboardingGuideP
       </div>
 
       <p className="onboarding-guide-copy">
-        O Cripto Farol organiza informacao para apoiar sua decisao. Ele nao promete resultado, nao substitui sua analise
-        e nao incentiva alavancagem.
+        O Cripto Farol comeca pelos Favoritos: avalie graficos e trades, selecione as melhores estrategias e acompanhe
+        no Monitor. A Binance e opcional e entra depois, como complemento.
       </p>
 
       <div className="onboarding-steps">
@@ -75,8 +75,8 @@ export function OnboardingGuide({ compact = false, onDismiss }: OnboardingGuideP
         <Link to="/help" className="onboarding-primary-action">
           Ver guia completo
         </Link>
-        <Link to="/monitor" className="onboarding-secondary-action">
-          Ir para Monitor
+        <Link to="/favorites" className="onboarding-secondary-action">
+          Ir para Favoritos
         </Link>
       </div>
 

--- a/frontend/src/lib/tradeMarkers.ts
+++ b/frontend/src/lib/tradeMarkers.ts
@@ -1,0 +1,107 @@
+import type { StrategyChartMarker } from '../components/charts/StrategyChartSurface'
+
+export interface TradeMarkerTrade {
+    entry_time?: string | number | null
+    entry_price?: number | null
+    exit_time?: string | number | null
+    exit_price?: number | null
+    profit?: number | null
+}
+
+export interface BuildTradeMarkersOptions {
+    direction?: string | null
+    timeframe?: string | null
+}
+
+const TIMEFRAME_MS: Record<string, number> = {
+    '1m': 60_000,
+    '5m': 5 * 60_000,
+    '15m': 15 * 60_000,
+    '30m': 30 * 60_000,
+    '1h': 60 * 60_000,
+    '4h': 4 * 60 * 60_000,
+    '1d': 24 * 60 * 60_000,
+}
+
+function parseTime(value?: string | number | null): number | null {
+    if (value === null || value === undefined || value === '') return null
+    if (typeof value === 'number') {
+        const milliseconds = value > 10_000_000_000 ? value : value * 1000
+        return Number.isFinite(milliseconds) ? milliseconds : null
+    }
+    const parsed = Date.parse(String(value))
+    return Number.isFinite(parsed) ? parsed : null
+}
+
+function displayedCandleKey(value?: string | number | null, timeframe?: string | null): string {
+    const parsed = parseTime(value)
+    if (parsed === null) return ''
+    const normalizedTimeframe = String(timeframe || '').trim().toLowerCase()
+    const interval = TIMEFRAME_MS[normalizedTimeframe]
+    if (!interval) return String(Math.floor(parsed / 1000))
+    return String(Math.floor(parsed / interval))
+}
+
+function formatProfit(profit?: number | null): string {
+    const value = Number(profit)
+    return Number.isFinite(value) ? ` (${(value * 100).toFixed(2)}%)` : ''
+}
+
+function isSameDisplayedCandle(
+    entryTime?: string | number | null,
+    exitTime?: string | number | null,
+    timeframe?: string | null,
+): boolean {
+    const entryKey = displayedCandleKey(entryTime, timeframe)
+    const exitKey = displayedCandleKey(exitTime, timeframe)
+    return entryKey !== '' && entryKey === exitKey
+}
+
+export function buildTradeMarkers(
+    trades: TradeMarkerTrade[] | undefined | null,
+    options: BuildTradeMarkersOptions = {},
+): StrategyChartMarker[] {
+    const isShort = String(options.direction || 'long').toLowerCase() === 'short'
+    const timeframe = options.timeframe
+
+    return (trades || []).flatMap((trade) => {
+        const entryTime = trade.entry_time
+        const exitTime = trade.exit_time
+        if (!entryTime) return []
+
+        const entryLabel = isShort ? 'VENDA' : 'COMPRA'
+        const exitLabel = isShort ? 'COMPRA' : 'VENDA'
+        const entryMarker: StrategyChartMarker = {
+            time: entryTime,
+            position: isShort ? 'aboveBar' : 'belowBar',
+            color: isShort ? '#f97316' : '#10b981',
+            shape: isShort ? 'arrowDown' : 'arrowUp',
+            text: entryLabel,
+        }
+
+        if (!exitTime) {
+            return [entryMarker]
+        }
+
+        if (isSameDisplayedCandle(entryTime, exitTime, timeframe)) {
+            return [{
+                time: entryTime,
+                position: 'aboveBar',
+                color: '#fcd535',
+                shape: 'circle',
+                text: `${entryLabel}/${exitLabel}${formatProfit(trade.profit)}`,
+            }]
+        }
+
+        return [
+            entryMarker,
+            {
+                time: exitTime,
+                position: isShort ? 'belowBar' : 'aboveBar',
+                color: isShort ? '#10b981' : '#ef4444',
+                shape: isShort ? 'arrowUp' : 'arrowDown',
+                text: `${exitLabel}${formatProfit(trade.profit)}`,
+            },
+        ]
+    })
+}

--- a/frontend/src/lib/tradeMarkers.ts
+++ b/frontend/src/lib/tradeMarkers.ts
@@ -42,19 +42,70 @@ function displayedCandleKey(value?: string | number | null, timeframe?: string |
     return String(Math.floor(parsed / interval))
 }
 
+export function sameDisplayedCandle(
+    left?: string | number | null,
+    right?: string | number | null,
+    timeframe?: string | null,
+): boolean {
+    const leftKey = displayedCandleKey(left, timeframe)
+    const rightKey = displayedCandleKey(right, timeframe)
+    return leftKey !== '' && leftKey === rightKey
+}
+
 function formatProfit(profit?: number | null): string {
     const value = Number(profit)
     return Number.isFinite(value) ? ` (${(value * 100).toFixed(2)}%)` : ''
 }
 
-function isSameDisplayedCandle(
-    entryTime?: string | number | null,
-    exitTime?: string | number | null,
+function markerAction(marker: StrategyChartMarker): 'COMPRA' | 'VENDA' | null {
+    const text = marker.text.toUpperCase()
+    if (text.includes('COMPRA')) return 'COMPRA'
+    if (text.includes('VENDA')) return 'VENDA'
+    return null
+}
+
+function markerProfitText(marker: StrategyChartMarker): string {
+    return marker.text.match(/\([+-]?\d+(?:\.\d+)?%\)/)?.[0] || ''
+}
+
+export function collapseSameCandleOppositeMarkers(
+    markers: StrategyChartMarker[],
     timeframe?: string | null,
-): boolean {
-    const entryKey = displayedCandleKey(entryTime, timeframe)
-    const exitKey = displayedCandleKey(exitTime, timeframe)
-    return entryKey !== '' && entryKey === exitKey
+): StrategyChartMarker[] {
+    const groups = new Map<string, StrategyChartMarker[]>()
+    const passthrough: StrategyChartMarker[] = []
+
+    markers.forEach((marker) => {
+        const key = displayedCandleKey(marker.time, timeframe)
+        if (!key) {
+            passthrough.push(marker)
+            return
+        }
+        groups.set(key, [...(groups.get(key) || []), marker])
+    })
+
+    return [
+        ...passthrough,
+        ...Array.from(groups.values()).flatMap((group) => {
+            const actions = group
+                .map(markerAction)
+                .filter((action): action is 'COMPRA' | 'VENDA' => action !== null)
+            const uniqueActions = actions.filter((action, index) => actions.indexOf(action) === index)
+
+            if (uniqueActions.length < 2) return group
+
+            const first = group[0]
+            const profitText = group.map(markerProfitText).find(Boolean) || ''
+            const combinedMarker: StrategyChartMarker = {
+                time: first.time,
+                position: 'aboveBar',
+                color: '#fcd535',
+                shape: 'circle',
+                text: `${uniqueActions.join('/')}${profitText ? ` ${profitText}` : ''}`,
+            }
+            return [combinedMarker]
+        }),
+    ]
 }
 
 export function buildTradeMarkers(
@@ -64,7 +115,7 @@ export function buildTradeMarkers(
     const isShort = String(options.direction || 'long').toLowerCase() === 'short'
     const timeframe = options.timeframe
 
-    return (trades || []).flatMap((trade) => {
+    const markers: StrategyChartMarker[] = (trades || []).flatMap((trade): StrategyChartMarker[] => {
         const entryTime = trade.entry_time
         const exitTime = trade.exit_time
         if (!entryTime) return []
@@ -83,7 +134,7 @@ export function buildTradeMarkers(
             return [entryMarker]
         }
 
-        if (isSameDisplayedCandle(entryTime, exitTime, timeframe)) {
+        if (sameDisplayedCandle(entryTime, exitTime, timeframe)) {
             return [{
                 time: entryTime,
                 position: 'aboveBar',
@@ -104,4 +155,6 @@ export function buildTradeMarkers(
             },
         ]
     })
+
+    return collapseSameCandleOppositeMarkers(markers, timeframe)
 }

--- a/frontend/src/lib/tradeMarkers.ts
+++ b/frontend/src/lib/tradeMarkers.ts
@@ -68,44 +68,55 @@ function markerProfitText(marker: StrategyChartMarker): string {
     return marker.text.match(/\([+-]?\d+(?:\.\d+)?%\)/)?.[0] || ''
 }
 
+function markerForAction(group: StrategyChartMarker[], action: 'COMPRA' | 'VENDA'): StrategyChartMarker {
+    const selected = group.find((marker) => markerAction(marker) === action) ?? group[0]
+    return {
+        ...selected,
+        text: `${action}${markerProfitText(selected) ? ` ${markerProfitText(selected)}` : ''}`,
+    }
+}
+
 export function collapseSameCandleOppositeMarkers(
     markers: StrategyChartMarker[],
     timeframe?: string | null,
 ): StrategyChartMarker[] {
-    const groups = new Map<string, StrategyChartMarker[]>()
-    const passthrough: StrategyChartMarker[] = []
+    const groups = new Map<string, { marker: StrategyChartMarker; index: number }[]>()
+    const passthrough: { marker: StrategyChartMarker; index: number }[] = []
 
-    markers.forEach((marker) => {
+    markers.forEach((marker, index) => {
         const key = displayedCandleKey(marker.time, timeframe)
         if (!key) {
-            passthrough.push(marker)
+            passthrough.push({ marker, index })
             return
         }
-        groups.set(key, [...(groups.get(key) || []), marker])
+        groups.set(key, [...(groups.get(key) || []), { marker, index }])
     })
 
-    return [
-        ...passthrough,
-        ...Array.from(groups.values()).flatMap((group) => {
+    let lastAction: 'COMPRA' | 'VENDA' | null = null
+
+    return [...passthrough.map((entry) => [entry]), ...Array.from(groups.values())]
+        .sort((left, right) => left[0].index - right[0].index)
+        .flatMap((entries) => {
+            const group = entries.map((entry) => entry.marker)
             const actions = group
                 .map(markerAction)
                 .filter((action): action is 'COMPRA' | 'VENDA' => action !== null)
             const uniqueActions = actions.filter((action, index) => actions.indexOf(action) === index)
 
-            if (uniqueActions.length < 2) return group
-
-            const first = group[0]
-            const profitText = group.map(markerProfitText).find(Boolean) || ''
-            const combinedMarker: StrategyChartMarker = {
-                time: first.time,
-                position: 'aboveBar',
-                color: '#fcd535',
-                shape: 'circle',
-                text: `${uniqueActions.join('/')}${profitText ? ` ${profitText}` : ''}`,
+            if (uniqueActions.length < 2) {
+                if (uniqueActions[0]) lastAction = uniqueActions[0]
+                return group
             }
-            return [combinedMarker]
-        }),
-    ]
+
+            const targetAction = lastAction === 'COMPRA'
+                ? 'VENDA'
+                : lastAction === 'VENDA'
+                    ? 'COMPRA'
+                    : actions[actions.length - 1]
+
+            lastAction = targetAction
+            return [markerForAction(group, targetAction)]
+        })
 }
 
 export function buildTradeMarkers(
@@ -132,16 +143,6 @@ export function buildTradeMarkers(
 
         if (!exitTime) {
             return [entryMarker]
-        }
-
-        if (sameDisplayedCandle(entryTime, exitTime, timeframe)) {
-            return [{
-                time: entryTime,
-                position: 'aboveBar',
-                color: '#fcd535',
-                shape: 'circle',
-                text: `${entryLabel}/${exitLabel}${formatProfit(trade.profit)}`,
-            }]
         }
 
         return [

--- a/frontend/src/pages/ComboResultsPage.tsx
+++ b/frontend/src/pages/ComboResultsPage.tsx
@@ -7,6 +7,7 @@ import { StrategyTradesTable } from '../components/charts/StrategyTradesTable'
 import { API_BASE_URL } from '../lib/apiBase'
 import { authFetch } from '@/lib/authFetch'
 import { formatStrategyParameterLabel, formatStrategyParameterValue } from '@/lib/strategyParameters'
+import { buildTradeMarkers } from '@/lib/tradeMarkers'
 
 interface BacktestResult {
     template_name: string
@@ -236,46 +237,7 @@ export function ComboResultsPage() {
         ? { ...baseMetrics, ...derivedMetrics }
         : baseMetrics
 
-    // Prepare Chart Data (entry/exit invertidos para short: entrada = venda, saída = compra)
-    const markers = result.trades.flatMap(curr => {
-        const list = []
-        if (isShort) {
-            list.push({
-                time: curr.entry_time,
-                position: 'aboveBar',
-                color: '#f97316',
-                shape: 'arrowDown',
-                text: 'VENDA'
-            })
-            if (curr.exit_time) {
-                list.push({
-                    time: curr.exit_time,
-                    position: 'belowBar',
-                    color: '#10b981',
-                    shape: 'arrowUp',
-                    text: `COMPRA (${(curr.profit! * 100).toFixed(2)}%)`
-                })
-            }
-        } else {
-            list.push({
-                time: curr.entry_time,
-                position: 'belowBar',
-                color: '#10b981',
-                shape: 'arrowUp',
-                text: 'COMPRA'
-            })
-            if (curr.exit_time) {
-                list.push({
-                    time: curr.exit_time,
-                    position: 'aboveBar',
-                    color: '#ef4444',
-                    shape: 'arrowDown',
-                    text: `VENDA (${(curr.profit! * 100).toFixed(2)}%)`
-                })
-            }
-        }
-        return list
-    })
+    const markers = buildTradeMarkers(result.trades, { direction, timeframe: result.timeframe })
 
     return (
         <div className="app-page combo-page relative overflow-hidden">

--- a/frontend/src/pages/FavoritesDashboard.tsx
+++ b/frontend/src/pages/FavoritesDashboard.tsx
@@ -401,7 +401,10 @@ const FavoritesDashboard: React.FC = () => {
             .trim();
     };
 
-    const getFavoriteName = (fav: FavoriteStrategy): string => fav.name || fav.symbol || 'Estratégia';
+    const getFavoriteName = (fav: FavoriteStrategy): string => {
+        const label = getFavoriteStrategyLabel(fav).trim();
+        return label || fav.name || fav.symbol || 'Estratégia';
+    };
 
     const getFavoriteStrategyName = (fav: FavoriteStrategy): string => {
         let name = getFavoriteName(fav).trim();
@@ -424,7 +427,7 @@ const FavoritesDashboard: React.FC = () => {
         )) {
             return label;
         }
-        return readableName || label;
+        return label || readableName;
     };
 
     const getGridStrategyDetail = (fav: FavoriteStrategy): string | null => {

--- a/frontend/src/pages/FavoritesDashboard.tsx
+++ b/frontend/src/pages/FavoritesDashboard.tsx
@@ -387,9 +387,9 @@ const FavoritesDashboard: React.FC = () => {
     };
 
     const getFavoriteStrategyLabel = (fav: FavoriteStrategy): string => {
-        return fav.is_strategy_protected
-            ? (fav.strategy_display_name || 'Estratégia protegida')
-            : fav.strategy_name.replace(/_/g, ' ');
+        return fav.strategy_display_name || (fav.is_strategy_protected
+            ? 'Estratégia protegida'
+            : fav.strategy_name.replace(/_/g, ' '));
     };
 
     const normalizeStrategyComparison = (value: string): string => {

--- a/frontend/src/pages/FavoritesDashboard.tsx
+++ b/frontend/src/pages/FavoritesDashboard.tsx
@@ -994,7 +994,7 @@ const FavoritesDashboard: React.FC = () => {
         <div className="app-page favorites-page favorites-workbench">
             <div className="max-w-[1920px] mx-auto page-stack">
                 <ScreenHelpPanel title="Como usar Favoritos">
-                    Escolha as estrategias que merecem acompanhamento, marque estrelas para priorizar e depois use o Monitor para acompanhar contexto e sinais.
+                    Comece por aqui: compare estrategias, abra graficos, revise trades, marque estrelas nas melhores opcoes e depois acompanhe no Monitor.
                 </ScreenHelpPanel>
                 <section className="fav-header">
                     <div className="fav-title-row">

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -3,9 +3,9 @@ import { Activity, ArrowRight, Bookmark, ShieldCheck, Wallet } from 'lucide-reac
 import { OnboardingGuide } from '@/components/onboarding/OnboardingGuide'
 
 const quickActions = [
-  { to: '/external/balances', label: 'Abrir Carteira', icon: Wallet },
   { to: '/favorites', label: 'Abrir Favoritos', icon: Bookmark },
   { to: '/monitor', label: 'Abrir Monitor', icon: Activity },
+  { to: '/external/balances', label: 'Configurar Carteira', icon: Wallet },
 ]
 
 export default function HelpPage() {
@@ -16,7 +16,8 @@ export default function HelpPage() {
           <p className="eyebrow">Guia do beta</p>
           <h1>Como usar o Cripto Farol no primeiro acesso</h1>
           <p>
-            Use este fluxo para sair do primeiro login ate uma leitura util no Monitor, sem depender de explicacao manual.
+            Comece pelos Favoritos, escolha as estrategias que merecem acompanhamento e depois use o Monitor. A carteira
+            Binance e opcional e pode ficar para depois.
           </p>
         </div>
         <div className="help-page-guardrail">
@@ -31,22 +32,22 @@ export default function HelpPage() {
         <article>
           <h2>Favoritos</h2>
           <p>
-            E o catalogo de estrategias que voce decidiu acompanhar. As estrelas ajudam a separar prioridade antes de
-            levar a leitura para o Monitor.
+            E o ponto de partida. Compare estrategias, abra graficos, revise trades e use estrelas para separar o que
+            realmente merece acompanhamento.
           </p>
         </article>
         <article>
           <h2>Monitor</h2>
           <p>
-            E a tela de acompanhamento diario. Ela mostra Compra, Venda, contexto e distancia para decisao, sempre como
-            informacao para sua propria analise.
+            E a tela de acompanhamento das estrategias selecionadas. Ela mostra Compra, Venda, contexto e distancia para
+            decisao, sempre como informacao para sua propria analise.
           </p>
         </article>
         <article>
-          <h2>Grafico e Trades</h2>
+          <h2>Carteira Binance opcional</h2>
           <p>
-            Use Abrir Grafico para leitura visual da estrategia. Use Ver Trades quando precisar entender o historico e
-            a consistencia do setup.
+            Configure a carteira apenas se quiser complementar o acompanhamento com saldos read-only. Ela nao e
+            pre-requisito para usar Favoritos ou Monitor.
           </p>
         </article>
       </section>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -17,6 +17,8 @@ type FavoriteStrategy = {
   symbol: string
   timeframe: string
   strategy_name: string
+  is_strategy_protected?: boolean
+  strategy_display_name?: string | null
   metrics?: Record<string, unknown> | null
   created_at: string
 }
@@ -424,7 +426,7 @@ export default function HomePage() {
             ) : (
               <>
                 <div className="mt-3 text-2xl font-semibold text-[var(--text-primary)]">
-                  {bestFavorite.strategy_name || bestFavorite.name}
+                  {bestFavorite.strategy_display_name || bestFavorite.strategy_name || bestFavorite.name}
                 </div>
                 <div className="mt-1 text-[12px] text-[var(--text-tertiary)]">
                   {bestFavorite.symbol} · {bestFavorite.timeframe}

--- a/frontend/src/pages/MonitorPage.tsx
+++ b/frontend/src/pages/MonitorPage.tsx
@@ -6,7 +6,7 @@ export function MonitorPage() {
   return (
     <div className="app-page monitor-page">
       <ScreenHelpPanel title="Como usar o Monitor">
-        Acompanhe Compra, Venda e contexto das estrategias priorizadas. Use Abrir Grafico para leitura visual e Ver Trades para revisar historico, sempre como apoio a decisao.
+        Acompanhe as estrategias que voce selecionou em Favoritos. Use Compra, Venda, contexto, Abrir Grafico e Ver Trades sempre como apoio a decisao.
       </ScreenHelpPanel>
       <MonitorDisclaimer />
       <MonitorStatusTab />

--- a/frontend/tests/e2e/card-222-onboarding.spec.ts
+++ b/frontend/tests/e2e/card-222-onboarding.spec.ts
@@ -34,6 +34,7 @@ test('first-use onboarding prompt appears and can be dismissed', async ({ page }
 
   await expect(page.getByTestId('onboarding-prompt')).toBeVisible()
   await expect(page.getByText('Comece pelo fluxo certo')).toBeVisible()
+  await expect(page.getByText('O Cripto Farol comeca pelos Favoritos')).toBeVisible()
   await expect(page.getByText('Apoio a decisao, com leitura de contexto e disciplina.')).toBeVisible()
 
   await page.getByRole('button', { name: 'Dispensar' }).click()
@@ -51,10 +52,11 @@ test('help route explains journey and is available in navigation', async ({ page
   await expect(page.getByTestId('help-page')).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Como usar o Cripto Farol no primeiro acesso' })).toBeVisible()
   const guide = page.getByTestId('onboarding-guide')
-  await expect(guide.getByRole('heading', { name: 'Carteira' })).toBeVisible()
-  await expect(guide.getByRole('heading', { name: 'Favoritos' })).toBeVisible()
-  await expect(guide.getByRole('heading', { name: 'Monitor' })).toBeVisible()
-  await expect(guide.getByRole('heading', { name: 'Grafico e Trades' })).toBeVisible()
+  await expect(guide.locator('.onboarding-step').nth(0).getByRole('heading', { name: 'Favoritos' })).toBeVisible()
+  await expect(guide.locator('.onboarding-step').nth(1).getByRole('heading', { name: 'Selecionar estrategias' })).toBeVisible()
+  await expect(guide.locator('.onboarding-step').nth(2).getByRole('heading', { name: 'Monitor' })).toBeVisible()
+  await expect(guide.locator('.onboarding-step').nth(3).getByRole('heading', { name: 'Carteira Binance opcional' })).toBeVisible()
+  await expect(guide).toContainText('nao e requisito para comecar')
   await expect(page.getByText('Sem promessa de lucro')).toBeVisible()
 
   const navigation = page.getByRole('navigation', { name: 'Navegacao principal' })
@@ -67,9 +69,10 @@ test('Monitor and Favorites show contextual help panels', async ({ page }) => {
 
   await page.goto('/monitor')
   await expect(page.getByTestId('screen-help-panel')).toContainText('Como usar o Monitor')
+  await expect(page.getByTestId('screen-help-panel')).toContainText('estrategias que voce selecionou em Favoritos')
   await expect(page.getByText('sempre como apoio a decisao')).toBeVisible()
 
   await page.goto('/favorites')
   await expect(page.getByTestId('screen-help-panel')).toContainText('Como usar Favoritos')
-  await expect(page.getByText('marque estrelas para priorizar')).toBeVisible()
+  await expect(page.getByTestId('screen-help-panel')).toContainText('Comece por aqui: compare estrategias')
 })

--- a/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
+++ b/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
@@ -920,7 +920,7 @@ test('monitor uses favorite trade markers without duplicating the current sell m
   await expect(dialog.locator('header p').first()).toContainText('4 velas')
 })
 
-test('monitor collapses same-day Compra and Venda favorite trade into one marker', async ({ page }) => {
+test('monitor resolves same-day Compra and Venda trade to the opposite signal', async ({ page }) => {
   await mockAuthenticatedSession(page)
 
   await page.route('**/*', (route: any) => {
@@ -1050,11 +1050,11 @@ test('monitor collapses same-day Compra and Venda favorite trade into one marker
 
   const surface = page.getByTestId('chart-modal-surface')
   await expect(surface).toHaveAttribute('data-marker-count', '1')
-  await expect(surface).toHaveAttribute('data-marker-labels', /COMPRA\/VENDA/)
-  await expect(surface).not.toHaveAttribute('data-marker-labels', /^COMPRA\|VENDA$/)
+  await expect(surface).toHaveAttribute('data-marker-labels', /^VENDA/)
+  await expect(surface).not.toHaveAttribute('data-marker-labels', /COMPRA/)
 })
 
-test('monitor collapses exit and next entry from different trades on the same day', async ({ page }) => {
+test('monitor resolves exit and next entry on the same day to the opposite of the previous signal', async ({ page }) => {
   await mockAuthenticatedSession(page)
 
   await page.route('**/*', (route: any) => {
@@ -1190,7 +1190,7 @@ test('monitor collapses exit and next entry from different trades on the same da
 
   const surface = page.getByTestId('chart-modal-surface')
   await expect(surface).toHaveAttribute('data-marker-count', '2')
-  await expect(surface).toHaveAttribute('data-marker-labels', /COMPRA\|VENDA\/COMPRA/)
+  await expect(surface).toHaveAttribute('data-marker-labels', /^COMPRA\|VENDA/)
   await expect(surface).not.toHaveAttribute('data-marker-labels', /COMPRA\|VENDA\|COMPRA/)
 })
 

--- a/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
+++ b/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
@@ -920,6 +920,140 @@ test('monitor uses favorite trade markers without duplicating the current sell m
   await expect(dialog.locator('header p').first()).toContainText('4 velas')
 })
 
+test('monitor collapses same-day Compra and Venda favorite trade into one marker', async ({ page }) => {
+  await mockAuthenticatedSession(page)
+
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/auth/me', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(AUTH_USER),
+    })
+  )
+
+  await page.route('**/api/favorites/', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 238,
+          name: 'ADA Compra Médias Móveis',
+          symbol: 'ADA/USDT',
+          timeframe: '1d',
+          strategy_name: 'Compra Médias Móveis: Tendência Confirmada',
+          parameters: {},
+          metrics: {},
+          created_at: '2026-05-21T00:00:00Z',
+          tier: 1,
+        },
+      ]),
+    })
+  )
+
+  await page.route('**/api/opportunities/**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 238,
+          symbol: 'ADA/USDT',
+          timeframe: '1d',
+          template_name: 'Compra Médias Móveis: Tendência Confirmada',
+          name: 'ADA Compra Médias Móveis',
+          notes: '',
+          tier: 1,
+          parameters: { direction: 'long' },
+          is_holding: false,
+          distance_to_next_status: 0,
+          next_status_label: 'exit',
+          status: 'EXIT',
+          message: 'Venda no candle atual.',
+          last_price: 0.78,
+          timestamp: '2026-05-21T00:00:00Z',
+          signal_history: [],
+          details: {},
+        },
+      ]),
+    })
+  )
+
+  await page.route('**/api/favorites/238/trades', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        favorite_id: 238,
+        trades: [
+          {
+            entry_time: '2026-05-21T00:00:00+00:00',
+            entry_price: 0.77,
+            exit_time: '2026-05-21T16:00:00+00:00',
+            exit_price: 0.78,
+            profit: 0.012987,
+            type: 'long',
+          },
+        ],
+        metrics: { total_trades: 1 },
+        candles: [
+          { timestamp_utc: '2026-05-21T00:00:00Z', open: 0.77, high: 0.79, low: 0.76, close: 0.78, volume: 1000 },
+        ],
+      }),
+    })
+  )
+
+  await page.route('**/api/monitor/preferences', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        __global__: { in_portfolio: false, card_mode: 'strategy', price_timeframe: '1d', theme: 'dark-green' },
+        'ADA/USDT': { in_portfolio: true, card_mode: 'strategy', price_timeframe: '1d', theme: 'dark-green' },
+      }),
+    })
+  )
+
+  await page.route('**/api/user/binance-credentials', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configured: false, api_key_masked: null }),
+    })
+  )
+
+  await page.route('**/api/market/candles**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        candles: [
+          { timestamp_utc: '2026-05-21T00:00:00Z', open: 0.77, high: 0.79, low: 0.76, close: 0.78, volume: 1000 },
+        ],
+      }),
+    })
+  )
+
+  await page.goto('/monitor')
+
+  const card = page.getByTestId('monitor-card-ada-usdt')
+  await expect(card).toBeVisible()
+  await card.getByRole('button', { name: 'Abrir Gráfico' }).click()
+
+  const surface = page.getByTestId('chart-modal-surface')
+  await expect(surface).toHaveAttribute('data-marker-count', '1')
+  await expect(surface).toHaveAttribute('data-marker-labels', /COMPRA\/VENDA/)
+  await expect(surface).not.toHaveAttribute('data-marker-labels', /^COMPRA\|VENDA$/)
+})
+
 test('monitor modal shows recent entry and exit history from the strategy payload', async ({ page }) => {
   await mockAuthenticatedSession(page)
 

--- a/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
+++ b/frontend/tests/e2e/monitor-mobile-cards-timeframe.spec.ts
@@ -1054,6 +1054,146 @@ test('monitor collapses same-day Compra and Venda favorite trade into one marker
   await expect(surface).not.toHaveAttribute('data-marker-labels', /^COMPRA\|VENDA$/)
 })
 
+test('monitor collapses exit and next entry from different trades on the same day', async ({ page }) => {
+  await mockAuthenticatedSession(page)
+
+  await page.route('**/*', (route: any) => {
+    const url = new URL(route.request().url())
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      return route.continue()
+    }
+    return route.abort('blockedbyclient')
+  })
+
+  await page.route('**/api/auth/me', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(AUTH_USER),
+    })
+  )
+
+  await page.route('**/api/favorites/', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 239,
+          name: 'ADA Reentrada',
+          symbol: 'ADA/USDT',
+          timeframe: '1d',
+          strategy_name: 'Compra Médias Móveis: Tendência Confirmada',
+          parameters: {},
+          metrics: {},
+          created_at: '2026-05-21T00:00:00Z',
+          tier: 1,
+        },
+      ]),
+    })
+  )
+
+  await page.route('**/api/opportunities/**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 239,
+          symbol: 'ADA/USDT',
+          timeframe: '1d',
+          template_name: 'Compra Médias Móveis: Tendência Confirmada',
+          name: 'ADA Reentrada',
+          notes: '',
+          tier: 1,
+          parameters: { direction: 'long' },
+          is_holding: true,
+          distance_to_next_status: 0.4,
+          next_status_label: 'exit',
+          status: 'HOLDING',
+          message: 'Compra ativa.',
+          last_price: 0.79,
+          timestamp: '2026-05-21T00:00:00Z',
+          signal_history: [],
+          details: {},
+        },
+      ]),
+    })
+  )
+
+  await page.route('**/api/favorites/239/trades', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        favorite_id: 239,
+        trades: [
+          {
+            entry_time: '2026-05-18T00:00:00+00:00',
+            entry_price: 0.74,
+            exit_time: '2026-05-21T00:00:00+00:00',
+            exit_price: 0.78,
+            profit: 0.054,
+            type: 'long',
+          },
+          {
+            entry_time: '2026-05-21T00:00:00+00:00',
+            entry_price: 0.78,
+            type: 'long',
+          },
+        ],
+        metrics: { total_trades: 2 },
+        candles: [
+          { timestamp_utc: '2026-05-18T00:00:00Z', open: 0.74, high: 0.75, low: 0.73, close: 0.745, volume: 1000 },
+          { timestamp_utc: '2026-05-21T00:00:00Z', open: 0.78, high: 0.80, low: 0.77, close: 0.79, volume: 1000 },
+        ],
+      }),
+    })
+  )
+
+  await page.route('**/api/monitor/preferences', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        __global__: { in_portfolio: false, card_mode: 'strategy', price_timeframe: '1d', theme: 'dark-green' },
+        'ADA/USDT': { in_portfolio: true, card_mode: 'strategy', price_timeframe: '1d', theme: 'dark-green' },
+      }),
+    })
+  )
+
+  await page.route('**/api/user/binance-credentials', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configured: false, api_key_masked: null }),
+    })
+  )
+
+  await page.route('**/api/market/candles**', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        candles: [
+          { timestamp_utc: '2026-05-21T00:00:00Z', open: 0.78, high: 0.80, low: 0.77, close: 0.79, volume: 1000 },
+        ],
+      }),
+    })
+  )
+
+  await page.goto('/monitor')
+
+  const card = page.getByTestId('monitor-card-ada-usdt')
+  await expect(card).toBeVisible()
+  await card.getByRole('button', { name: 'Abrir Gráfico' }).click()
+
+  const surface = page.getByTestId('chart-modal-surface')
+  await expect(surface).toHaveAttribute('data-marker-count', '2')
+  await expect(surface).toHaveAttribute('data-marker-labels', /COMPRA\|VENDA\/COMPRA/)
+  await expect(surface).not.toHaveAttribute('data-marker-labels', /COMPRA\|VENDA\|COMPRA/)
+})
+
 test('monitor modal shows recent entry and exit history from the strategy payload', async ({ page }) => {
   await mockAuthenticatedSession(page)
 

--- a/openspec/changes/card-220-strategy-descriptions/.openspec.yaml
+++ b/openspec/changes/card-220-strategy-descriptions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/card-220-strategy-descriptions/design.md
+++ b/openspec/changes/card-220-strategy-descriptions/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The product already separates common-user and admin visibility for strategy details. Common users receive redacted Favorites and Monitor payloads, while admin/internal flows can still inspect template names, parameters, indicator values, and raw strategy metadata.
+
+The current public label formatter converts technical identifiers into title-cased names, and public descriptions are keyed by template name. Card #220 narrows the product requirement: generated strategies need useful, distinguishable product names and descriptions, but the public copy cannot reveal a technical recipe.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide curated public strategy names and descriptions for generated strategy templates.
+- Reuse the existing redaction boundary so common-user payloads get safe product copy.
+- Keep admin/internal payloads unchanged for audit and operation.
+- Add focused tests proving common-user copy does not expose sensitive fields and admin copy remains technical.
+
+**Non-Goals:**
+
+- Change strategy parameters, template data, entry/exit rules, ranking, or backtest behavior.
+- Add AI-generated copy.
+- Add database schema or migration work.
+- Remove existing admin/internal access to strategy secrets.
+
+## Decisions
+
+- Store public display names beside public descriptions in `strategy_descriptions.py`.
+  - Rationale: names and descriptions are a product-copy catalog, not strategy execution data.
+  - Alternative considered: rename `combo_templates.name` in the database. Rejected because template names are runtime identifiers used by execution and audit paths.
+- Apply curated public names only inside the existing redaction layer.
+  - Rationale: common-user surfaces already depend on `strategy_display_name`; admin payloads should keep raw technical identifiers.
+  - Alternative considered: format names in frontend components. Rejected because Monitor, Favorites, exports, and future clients need the same visibility boundary.
+- Keep unknown strategies conservative.
+  - Rationale: unknown templates should get readable formatting when necessary, but descriptions must fall back to non-replicable generic copy if raw text looks technical.
+
+## Risks / Trade-offs
+
+- Public copy can become stale when new templates are added -> Mitigation: unknown-template fallback stays safe, and tests cover current generated templates.
+- Names mention broad indicator categories such as momentum or volatility -> Mitigation: descriptions avoid parameter values, thresholds, formulas, and full entry/exit recipes.
+- Existing database descriptions remain technical -> Mitigation: public payloads call the safe catalog; admin/internal surfaces may keep the raw database copy.

--- a/openspec/changes/card-220-strategy-descriptions/proposal.md
+++ b/openspec/changes/card-220-strategy-descriptions/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Generated strategies are visible in product surfaces with technical or generic names that make comparison harder for common users. The same surfaces must explain the strategy purpose without exposing parameters, thresholds, formulas, indicator recipes, or implementation details that would let a user recreate the strategy outside Cripto Farol.
+
+## What Changes
+
+- Add a curated public identity catalog for generated strategy templates: safe display names and short product descriptions.
+- Use those public names and descriptions in common-user Favorites and Monitor payloads.
+- Keep technical template names, parameters, entry/exit rules, and raw descriptions available only in admin/internal surfaces already allowed to view strategy secrets.
+- Preserve strategy execution, ranking, backtest, refresh, and parameter behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `strategy-template-descriptions`: Public strategy identity must include safe, distinguishable names and descriptions that do not expose replicable strategy logic.
+- `monitor`: Protected common-user Monitor payloads must use safe public strategy identities while keeping technical details redacted.
+
+## Impact
+
+- Backend public copy helpers for strategy names/descriptions.
+- Backend redaction for Favorites and Monitor payloads.
+- Focused tests for public copy safety and admin/common-user visibility boundaries.
+- No database schema changes, no strategy parameter changes, and no backtest engine changes.

--- a/openspec/changes/card-220-strategy-descriptions/specs/monitor/spec.md
+++ b/openspec/changes/card-220-strategy-descriptions/specs/monitor/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Monitor hides strategy secrets from non-admin users
+The Monitor API and UI MUST hide strategy implementation details from non-admin users while preserving the current trading decision workflow. Protected common-user payloads SHALL expose only a safe public strategy display name and high-level description.
+
+#### Scenario: Non-admin views monitor opportunity
+- **WHEN** a non-admin user opens the Monitor
+- **THEN** each opportunity MUST avoid showing the original strategy/template name
+- **AND** each opportunity MUST avoid showing parameter values and indicator values
+- **AND** the UI MUST show a safe public strategy display name instead of empty, broken, or raw technical content
+- **AND** the public description MUST avoid thresholds, formulas, exact indicator combinations, and complete entry/exit rules.
+
+#### Scenario: Admin views monitor opportunity
+- **WHEN** an admin user opens the Monitor
+- **THEN** each opportunity MUST show the original strategy/template name, parameters, indicator values, and analyzer context as before
+
+#### Scenario: Non-admin exports opportunity summary
+- **WHEN** a non-admin user exports or copies an opportunity summary
+- **THEN** the exported payload MUST NOT include original strategy/template names, parameter values, indicator values, or analyzer details

--- a/openspec/changes/card-220-strategy-descriptions/specs/strategy-template-descriptions/spec.md
+++ b/openspec/changes/card-220-strategy-descriptions/specs/strategy-template-descriptions/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Public Strategy Descriptions
+The system SHALL expose a short, trader-friendly, non-promissory public identity for each visible strategy/template. Public identity SHALL include a distinguishable display name and high-level description, and MUST NOT expose parameter values, thresholds, formulas, exact indicator combinations, full entry/exit rules, or implementation details that allow recreation outside the platform.
+
+#### Scenario: Combo template list includes description
+- **WHEN** an admin opens the Combo template selection flow
+- **THEN** each listed template SHALL include a high-level description beside the template name
+- **AND** the description SHALL avoid parameter dumps and profit promises.
+
+#### Scenario: Favorites shows strategy and description
+- **WHEN** a common user opens Favorites
+- **THEN** each favorite row/card SHALL show the public strategy display name
+- **AND** SHALL show a high-level description when available
+- **AND** SHALL NOT show parameters, thresholds, formulas, exact indicator combinations, or complete entry/exit logic.
+
+#### Scenario: Monitor shows strategy description
+- **WHEN** a common user opens Monitor opportunities
+- **THEN** the visible strategy identity SHALL include a public display name and high-level description when available
+- **AND** the public copy SHALL explain the market-reading purpose without exposing a replicable technical recipe.
+
+#### Scenario: Admin keeps technical audit identity
+- **WHEN** an admin views strategy metadata in an authorized surface
+- **THEN** the system MAY show the original template name, parameters, raw description, and technical implementation details needed for audit.

--- a/openspec/changes/card-220-strategy-descriptions/tasks.md
+++ b/openspec/changes/card-220-strategy-descriptions/tasks.md
@@ -1,0 +1,16 @@
+## 1. Public Strategy Identity
+
+- [x] 1.1 Add curated public display names for generated strategy templates.
+- [x] 1.2 Refine public descriptions so they are useful, distinguishable, and non-replicable.
+- [x] 1.3 Ensure unknown-template fallback avoids exposing technical recipe text to common users.
+
+## 2. Visibility Boundary
+
+- [x] 2.1 Route common-user Favorites and Monitor payloads through the public identity catalog.
+- [x] 2.2 Preserve admin/internal payload behavior for technical audit.
+
+## 3. Validation
+
+- [x] 3.1 Add focused backend tests for safe public names/descriptions and admin redaction boundaries.
+- [x] 3.2 Run OpenSpec validation and focused backend tests.
+- [x] 3.3 Follow project skills and repo workflow evidence requirements before moving the card to Done.

--- a/openspec/changes/card-237-onboarding-favorites-first/.openspec.yaml
+++ b/openspec/changes/card-237-onboarding-favorites-first/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/card-237-onboarding-favorites-first/design.md
+++ b/openspec/changes/card-237-onboarding-favorites-first/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The #222 onboarding release added a Help route, first-use prompt, and contextual screen guidance. After review, the published sequence still starts with wallet setup, but the product direction is Favorites first: users evaluate strategies, select what matters, then monitor those strategies. Binance wallet setup is optional and later.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep the #222 onboarding structure and styling.
+- Correct visible copy and CTA order to Favorites -> selected strategies -> Monitor -> Binance optional.
+- Update tests and OpenSpec contracts to match the corrected journey.
+
+**Non-Goals:**
+- No new route, modal, backend API, persistence, or onboarding state model.
+- No changes to chart, strategy, wallet, or Monitor business logic.
+- No edits to archived `card-222-onboarding` artifacts.
+
+## Decisions
+
+- Reuse `OnboardingGuide` rather than creating another onboarding component.
+  - Rationale: the issue is copy/order, not a new interaction pattern.
+  - Alternative rejected: a separate first-access flow would increase UI surface and test cost.
+- Modify main specs through a new delta spec instead of reopening the archived #222 change.
+  - Rationale: #222 is already in `Pronto`; this is a new follow-up correction.
+- Keep the existing focused Playwright spec and adjust assertions to the corrected text.
+  - Rationale: it already covers first-use prompt, Help route, navigation, Monitor, and Favorites guidance.
+
+## Risks / Trade-offs
+
+- Existing screenshots from #222 may show the older journey -> leave them archived as historical evidence and produce new validation output through tests/build.
+- Copy-only changes can regress product intent without breaking TypeScript -> keep test assertions tied to the journey order.

--- a/openspec/changes/card-237-onboarding-favorites-first/proposal.md
+++ b/openspec/changes/card-237-onboarding-favorites-first/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The published onboarding from #222 still presents wallet setup as the first step, which conflicts with the approved beta journey. New users should start in Favorites, choose strategies, then use Monitor; Binance wallet setup must be optional and later.
+
+## What Changes
+
+- Update onboarding and Help copy to make Favorites the first step.
+- Change the onboarding secondary action from Monitor to Favorites.
+- Clarify Monitor and Favorites contextual guidance around selected strategies.
+- Keep Binance/wallet setup as an optional follow-up, not a prerequisite.
+- Update focused onboarding Playwright coverage.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `user-onboarding`: Correct the recommended beta journey and wallet positioning.
+- `frontend-ux`: Align contextual guidance copy on Favorites and Monitor with the corrected journey.
+
+## Impact
+
+- Frontend copy/components only:
+  - `frontend/src/components/onboarding/OnboardingGuide.tsx`
+  - `frontend/src/pages/HelpPage.tsx`
+  - `frontend/src/pages/FavoritesDashboard.tsx`
+  - `frontend/src/pages/MonitorPage.tsx`
+  - `frontend/tests/e2e/card-222-onboarding.spec.ts`
+- No backend, database, or API changes.

--- a/openspec/changes/card-237-onboarding-favorites-first/specs/frontend-ux/spec.md
+++ b/openspec/changes/card-237-onboarding-favorites-first/specs/frontend-ux/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Core screens provide contextual guidance
+Monitor and Favorites SHALL provide concise contextual guidance explaining the purpose of each screen.
+
+#### Scenario: User opens Monitor
+- **WHEN** the user opens `/monitor`
+- **THEN** the page SHALL explain that Monitor is used to acompanhar strategies selected in Favorites
+- **AND** the guidance SHALL preserve responsible support-to-decision language
+
+#### Scenario: User opens Favorites
+- **WHEN** the user opens `/favorites`
+- **THEN** the page SHALL explain that Favorites is the starting point to compare strategies, inspect charts/trades, and choose what to monitor
+- **AND** the guidance SHALL avoid technical jargon and excessive reading

--- a/openspec/changes/card-237-onboarding-favorites-first/specs/user-onboarding/spec.md
+++ b/openspec/changes/card-237-onboarding-favorites-first/specs/user-onboarding/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: First-use onboarding prompt
+The authenticated app SHALL show new users a concise onboarding prompt that explains where to start and how to continue the core beta journey.
+
+#### Scenario: New user opens the app
+- **WHEN** an authenticated user opens a protected route without dismissing onboarding in the current browser
+- **THEN** the app SHALL show a concise first-use guide with the recommended starting path
+- **AND** the guide SHALL present Favorites as the first step
+- **AND** the guide SHALL provide direct actions to open Help and Favorites
+
+#### Scenario: User dismisses first-use guide
+- **WHEN** the user dismisses the first-use guide
+- **THEN** the guide SHALL stop appearing in that browser session/storage
+- **AND** Help SHALL remain accessible from navigation
+
+### Requirement: Help center explains the recommended beta journey
+The app SHALL provide a Help route that explains the recommended order of the main screens in simple Portuguese.
+
+#### Scenario: User opens Help
+- **WHEN** an authenticated user opens `/help`
+- **THEN** the app SHALL explain the recommended order: Favoritos, selecao de estrategias, Monitor, and optional Binance wallet setup
+- **AND** the page SHALL provide direct navigation actions for the core screens
+- **AND** wallet setup SHALL NOT be presented as a prerequisite to start
+
+#### Scenario: User reads responsible positioning
+- **WHEN** the user reads onboarding or Help content
+- **THEN** the content SHALL frame Cripto Farol as apoio a decisao
+- **AND** the content SHALL NOT promise profit, present signals as guaranteed calls, encourage leverage, or use guru-style claims

--- a/openspec/changes/card-237-onboarding-favorites-first/tasks.md
+++ b/openspec/changes/card-237-onboarding-favorites-first/tasks.md
@@ -1,0 +1,15 @@
+## 1. Onboarding Copy
+
+- [x] 1.1 Update `OnboardingGuide` journey order and secondary CTA to start in Favorites.
+- [x] 1.2 Update Help page copy/actions so Binance wallet setup is optional and later.
+- [x] 1.3 Update Monitor and Favorites contextual guidance.
+
+## 2. Validation
+
+- [x] 2.1 Update focused onboarding Playwright assertions for the corrected journey.
+- [x] 2.2 Run OpenSpec validation, frontend build, and focused onboarding E2E.
+- [x] 2.3 Integrate into `develop`, restart services, and verify served frontend/backend health.
+
+## 3. Project Skills Note
+
+- [x] 3.1 Use the local OpenSpec skills for new/ff/apply/verify workflow; use frontend validation patterns from the repo.

--- a/openspec/changes/card-238-sinais-mesmo-dia/.openspec.yaml
+++ b/openspec/changes/card-238-sinais-mesmo-dia/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/card-238-sinais-mesmo-dia/design.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/design.md
@@ -1,0 +1,36 @@
+## Context
+
+Favorites and Monitor now share the operational chart surface, but marker construction still lives in multiple callers. Each caller turns a trade into one entry marker and one exit marker. When a daily trade opens and closes on the same candle timestamp, the chart receives independent `COMPRA` and `VENDA` markers at the same time, which reads as contradictory simultaneous advice instead of one same-candle round trip.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make trade-to-marker conversion deterministic and shared across Favorites result charts and Monitor chart modals.
+- Collapse valid same-candle entry/exit pairs into one explicit combined marker.
+- Preserve normal separate entry/exit markers when trades span different candles.
+- Keep existing Portuguese labels and current chart test contracts.
+
+**Non-Goals:**
+
+- Recalibrate strategy parameters or trading logic.
+- Change metric calculation.
+- Add database columns.
+- Solve unrelated signal divergence for other strategies unless it uses the same marker construction path.
+
+## Decisions
+
+- Add a shared frontend chart marker utility instead of patching only one page.
+  - Rationale: the same favorite can be opened through Favorites and Monitor. One utility prevents drift.
+  - Alternative considered: normalize inside `StrategyChartSurface`. Rejected because that component only sees markers, not the source trade context or direction.
+- Treat same-candle entry and exit as a valid round trip by default.
+  - Rationale: daily backtests can produce entry and exit timestamps that normalize to the same candle. The UI should be explicit without changing strategy math.
+  - Alternative considered: delete one marker. Rejected because it hides real trade history.
+- Normalize same-candle comparison by UTC candle timestamp.
+  - Rationale: chart timestamps already render in UTC seconds, so comparison should use the same anchor.
+
+## Risks / Trade-offs
+
+- Same-day but different intraday times on a daily chart may collapse into one marker if both normalize to the same daily candle. This is intended for 1D display and keeps the UI coherent.
+- Existing E2E assertions that count markers may need targeted updates where same-candle samples are introduced.
+- If the root cause is backend trade extraction creating invalid same-candle trades, this change still surfaces them clearly; implementation evidence must record whether the ADA case is valid round trip or upstream data bug.

--- a/openspec/changes/card-238-sinais-mesmo-dia/proposal.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The ADA/USDT daily strategy chart can show `Compra` and `Venda` on the same day without a clear relationship to the trade list or current state. This creates an ambiguous operational signal and weakens trust in Favorites and Monitor charts.
+
+## What Changes
+
+- Normalize chart marker generation so entry/exit markers for the same trade share one coherent candle anchor and cannot appear as unrelated contradictory signals.
+- Preserve valid same-day entry/exit trades by representing them as an explicit same-candle round trip instead of two ambiguous independent recommendations.
+- Keep Favorites and Monitor chart paths aligned when they render the same favorite strategy.
+- Add focused backend/frontend tests for same-day buy/sell marker coherence.
+
+## Capabilities
+
+### New Capabilities
+
+- `same-candle-signal-coherence`: Covers coherent rendering and payload normalization when a trade has entry and exit signals in the same candle/day.
+
+### Modified Capabilities
+
+- `chart-visualization`: Chart surfaces must render same-candle trade signals without making them look like contradictory simultaneous recommendations.
+- `favorites-trade-regeneration`: Favorite trade payloads must expose normalized trade timing metadata usable by chart marker builders.
+
+## Impact
+
+- Affected frontend chart marker utilities and shared chart consumers.
+- Affected favorite trade payload normalization if backend returns entry/exit date shapes inconsistently.
+- No database migration expected.
+- No change to strategy math unless investigation proves the duplicate signal comes from invalid trade generation.

--- a/openspec/changes/card-238-sinais-mesmo-dia/specs/chart-visualization/spec.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/specs/chart-visualization/spec.md
@@ -5,7 +5,7 @@ Strategy chart surfaces SHALL consume trade markers built by a same-candle-aware
 
 #### Scenario: Favorites chart renders same-candle trade
 - **WHEN** a Favorites analysis chart renders a trade whose entry and exit resolve to the same displayed candle
-- **THEN** the chart SHALL show one combined marker for the trade
+- **THEN** the chart SHALL show one resolved marker for the trade based on signal alternation
 - **AND** it SHALL NOT show separate `COMPRA` and `VENDA` markers on the same candle for that same trade
 
 #### Scenario: Monitor chart renders same favorite trade
@@ -14,5 +14,5 @@ Strategy chart surfaces SHALL consume trade markers built by a same-candle-aware
 - **AND** the marker count and labels SHALL match the favorite analysis chart for that trade set
 
 #### Scenario: Monitor fallback signal is already covered
-- **WHEN** the Monitor chart modal has a same-candle combined marker that already includes the current signal action
+- **WHEN** the Monitor chart modal has a favorite trade marker on the current displayed candle
 - **THEN** the current-signal fallback marker SHALL NOT add another independent `Compra` or `Venda` marker on that same displayed candle

--- a/openspec/changes/card-238-sinais-mesmo-dia/specs/chart-visualization/spec.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/specs/chart-visualization/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Shared chart trade markers are same-candle aware
+Strategy chart surfaces SHALL consume trade markers built by a same-candle-aware conversion path when rendering Favorites result charts and Monitor favorite-backed charts.
+
+#### Scenario: Favorites chart renders same-candle trade
+- **WHEN** a Favorites analysis chart renders a trade whose entry and exit resolve to the same displayed candle
+- **THEN** the chart SHALL show one combined marker for the trade
+- **AND** it SHALL NOT show separate `COMPRA` and `VENDA` markers on the same candle for that same trade
+
+#### Scenario: Monitor chart renders same favorite trade
+- **WHEN** the Monitor chart modal renders the same favorite trade payload
+- **THEN** it SHALL use the same marker conversion behavior as Favorites
+- **AND** the marker count and labels SHALL match the favorite analysis chart for that trade set
+

--- a/openspec/changes/card-238-sinais-mesmo-dia/specs/chart-visualization/spec.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/specs/chart-visualization/spec.md
@@ -13,3 +13,6 @@ Strategy chart surfaces SHALL consume trade markers built by a same-candle-aware
 - **THEN** it SHALL use the same marker conversion behavior as Favorites
 - **AND** the marker count and labels SHALL match the favorite analysis chart for that trade set
 
+#### Scenario: Monitor fallback signal is already covered
+- **WHEN** the Monitor chart modal has a same-candle combined marker that already includes the current signal action
+- **THEN** the current-signal fallback marker SHALL NOT add another independent `Compra` or `Venda` marker on that same displayed candle

--- a/openspec/changes/card-238-sinais-mesmo-dia/specs/favorites-trade-regeneration/spec.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/specs/favorites-trade-regeneration/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Favorite trade payloads preserve same-candle trade details
+Favorite trade responses SHALL preserve entry and exit timestamps for trades that open and close on the same candle so chart rendering can represent the round trip without losing trade-list detail.
+
+#### Scenario: Saved favorite has same-candle trade
+- **WHEN** `/api/favorites/{favorite_id}/trades` returns a saved trade with same-candle entry and exit
+- **THEN** the response SHALL keep both `entry_time` and `exit_time`
+- **AND** the frontend SHALL not need to infer or discard either side of the trade
+
+#### Scenario: Regenerated favorite has same-candle trade
+- **WHEN** trade regeneration returns a same-candle trade
+- **THEN** the persisted `metrics.trades` payload SHALL keep both timestamps
+- **AND** later chart opens SHALL render from the saved payload consistently

--- a/openspec/changes/card-238-sinais-mesmo-dia/specs/same-candle-signal-coherence/spec.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/specs/same-candle-signal-coherence/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Same-candle trade signals render as one coherent chart event
+The system SHALL represent a trade whose entry and exit resolve to the same displayed candle as one explicit same-candle trade event, not as two independent contradictory recommendations.
+
+#### Scenario: Long trade enters and exits on the same daily candle
+- **WHEN** a long trade has `entry_time` and `exit_time` on the same displayed 1D candle
+- **THEN** the chart marker source SHALL contain one marker for that trade
+- **AND** the marker label SHALL communicate both `Compra` and `Venda`
+- **AND** the trade list SHALL continue to show the original entry and exit timestamps
+
+#### Scenario: Trade spans different candles
+- **WHEN** a trade has `entry_time` and `exit_time` on different displayed candles
+- **THEN** the chart marker source SHALL contain separate entry and exit markers
+- **AND** their labels SHALL remain direction-aware in Portuguese
+
+### Requirement: Same-candle signal evidence remains inspectable
+The system SHALL keep enough evidence in UI/test output to verify how same-candle signals were represented.
+
+#### Scenario: Test reads marker labels
+- **WHEN** automated UI validation inspects the shared chart surface
+- **THEN** it SHALL be able to distinguish a same-candle combined marker from separate `COMPRA` and `VENDA` markers
+

--- a/openspec/changes/card-238-sinais-mesmo-dia/specs/same-candle-signal-coherence/spec.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/specs/same-candle-signal-coherence/spec.md
@@ -14,10 +14,14 @@ The system SHALL represent a trade whose entry and exit resolve to the same disp
 - **THEN** the chart marker source SHALL contain separate entry and exit markers
 - **AND** their labels SHALL remain direction-aware in Portuguese
 
+#### Scenario: Exit and next entry share one daily candle
+- **WHEN** one trade exits and another trade enters on the same displayed 1D candle
+- **THEN** the chart marker source SHALL represent the candle with one combined marker for the opposite actions
+- **AND** it SHALL NOT render independent `Compra` and `Venda` markers for that same displayed candle
+
 ### Requirement: Same-candle signal evidence remains inspectable
 The system SHALL keep enough evidence in UI/test output to verify how same-candle signals were represented.
 
 #### Scenario: Test reads marker labels
 - **WHEN** automated UI validation inspects the shared chart surface
 - **THEN** it SHALL be able to distinguish a same-candle combined marker from separate `COMPRA` and `VENDA` markers
-

--- a/openspec/changes/card-238-sinais-mesmo-dia/specs/same-candle-signal-coherence/spec.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/specs/same-candle-signal-coherence/spec.md
@@ -1,12 +1,12 @@
 ## ADDED Requirements
 
 ### Requirement: Same-candle trade signals render as one coherent chart event
-The system SHALL represent a trade whose entry and exit resolve to the same displayed candle as one explicit same-candle trade event, not as two independent contradictory recommendations.
+The system SHALL resolve conflicting trade actions on the same displayed candle to the opposite action of the last emitted signal, not as two independent contradictory recommendations.
 
 #### Scenario: Long trade enters and exits on the same daily candle
 - **WHEN** a long trade has `entry_time` and `exit_time` on the same displayed 1D candle
 - **THEN** the chart marker source SHALL contain one marker for that trade
-- **AND** the marker label SHALL communicate both `Compra` and `Venda`
+- **AND** the marker label SHALL resolve to `Venda`
 - **AND** the trade list SHALL continue to show the original entry and exit timestamps
 
 #### Scenario: Trade spans different candles
@@ -16,7 +16,8 @@ The system SHALL represent a trade whose entry and exit resolve to the same disp
 
 #### Scenario: Exit and next entry share one daily candle
 - **WHEN** one trade exits and another trade enters on the same displayed 1D candle
-- **THEN** the chart marker source SHALL represent the candle with one combined marker for the opposite actions
+- **AND** the last emitted signal before that candle was `Compra`
+- **THEN** the chart marker source SHALL represent that candle as `Venda`
 - **AND** it SHALL NOT render independent `Compra` and `Venda` markers for that same displayed candle
 
 ### Requirement: Same-candle signal evidence remains inspectable

--- a/openspec/changes/card-238-sinais-mesmo-dia/tasks.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/tasks.md
@@ -1,0 +1,16 @@
+## 1. Marker Utility
+
+- [x] 1.1 Add shared frontend trade-to-marker utility for direction-aware Portuguese labels.
+- [x] 1.2 Normalize same displayed candle entry/exit pairs into one combined marker.
+
+## 2. Chart Integration
+
+- [x] 2.1 Use the shared marker utility in Favorites/Combo result charts.
+- [x] 2.2 Use the shared marker utility in Monitor chart modal.
+
+## 3. Validation
+
+- [x] 3.1 Add focused tests for same-candle marker behavior.
+- [x] 3.2 Run OpenSpec, frontend test/build, and focused runtime validation.
+
+Note: use project skills when applicable; OpenSpec skills used for new, fast-forward, apply, and verify phases.

--- a/openspec/changes/card-238-sinais-mesmo-dia/tasks.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/tasks.md
@@ -19,4 +19,10 @@
 - [x] 4.2 Prevent the Monitor current-signal fallback from re-adding a Compra/Venda marker already covered by a same-candle combined marker.
 - [x] 4.3 Re-run focused Playwright/build/OpenSpec validation and reintegrate in develop.
 
+## 5. Alternating Signal Rule
+
+- [x] 5.1 Resolve same-candle conflicts to the opposite action of the last emitted signal instead of a combined label.
+- [x] 5.2 Update focused Monitor tests and OpenSpec specs for the alternating signal rule.
+- [x] 5.3 Re-run validation, integrate in develop, restart, and update card evidence.
+
 Note: use project skills when applicable; OpenSpec skills used for new, fast-forward, apply, and verify phases.

--- a/openspec/changes/card-238-sinais-mesmo-dia/tasks.md
+++ b/openspec/changes/card-238-sinais-mesmo-dia/tasks.md
@@ -13,4 +13,10 @@
 - [x] 3.1 Add focused tests for same-candle marker behavior.
 - [x] 3.2 Run OpenSpec, frontend test/build, and focused runtime validation.
 
+## 4. Follow-up Persisting Bug
+
+- [x] 4.1 Collapse opposite markers from different trades that resolve to the same displayed candle.
+- [x] 4.2 Prevent the Monitor current-signal fallback from re-adding a Compra/Venda marker already covered by a same-candle combined marker.
+- [x] 4.3 Re-run focused Playwright/build/OpenSpec validation and reintegrate in develop.
+
 Note: use project skills when applicable; OpenSpec skills used for new, fast-forward, apply, and verify phases.

--- a/rules.md
+++ b/rules.md
@@ -7,39 +7,44 @@ Este arquivo define as regras obrigatorias e curtas do projeto. O `AGENTS.md` de
 - `rules.md`: politica normativa, curta e obrigatoria. Use para decidir o que nunca pode ser pulado.
 - `AGENTS.md`: manual operacional detalhado. Use para comandos, ordem de execucao, mapeamento OpenSpec/OPSX, GitHub Project, Git e responsabilidades dos agentes.
 - Em caso de duvida ou conflito, siga a regra mais restritiva. Se ainda houver ambiguidade, pare e registre o conflito antes de alterar codigo, card ou Git.
+- Regras gerais do modo de trabalho do Alan ficam na skill global `alan-workflow` (`/root/.codex/skills/alan-workflow/SKILL.md`). Este arquivo deve manter somente regras normativas especificas do projeto cripto.
 
 ## Regras obrigatorias
 
-1. Sempre usar OpenSpec para qualquer alteracao de codigo, independente de tamanho ou complexidade.
+1. Siga `alan-workflow` para o ciclo global de card, OpenSpec, evidencias, status, release, higiene Git/worktree/stash e fechamento.
+   - No cripto, OpenSpec e obrigatorio para qualquer alteracao de codigo, independente de tamanho ou complexidade.
    - Toda mudanca de codigo deve ter trilha em `openspec/changes/<change>/` antes da implementacao e evidencia de validacao antes do fechamento.
 
-2. Quando Alan pedir implementacao por card (`#99`, por exemplo), localizar o card no GitHub Project, criar/usar uma branch propria da change a partir de `develop`, mover para `In Progress`, executar o fluxo OpenSpec ate `/opsx:verify`, integrar em `develop`, rodar `./restart` e so entao mover para `Done`.
+2. Quando Alan pedir implementacao por card (`#99`, por exemplo), aplique `alan-workflow` com os overlays do cripto.
+   - Board: GitHub Project `MVP Cripto - Beta Fechado` / Project 1.
+   - Branch base de implementacao: `develop`.
    - Branch padrao: `change-<id>-<slug>` ou `card-<id>-<slug>`.
-   - Commits locais na branch da change sao permitidos.
+   - Integracao tecnica antes de homologacao: merge/squash em `develop`.
+   - Runtime de validacao: `./restart` e URL do sistema servindo o resultado novo.
    - Nessa etapa nao arquivar OpenSpec, nao abrir PR para `main` e nao publicar.
-   - Para qualquer correcao de bug ou ajuste solicitado por Alan, nao dizer `concluido` antes de validar, integrar em `develop`, rodar `./restart` e confirmar que a URL do sistema serve o resultado novo.
 
-3. Fluxo das colunas do GitHub Project:
-   - `In Progress`: card em execucao.
-   - `Done`: codigo implementado e validado tecnicamente em `develop`.
+3. No cripto, o campo `Status` e a fonte principal das colunas. O campo `Fluxo`, quando existir, e substatus/legado; se houver divergencia, `Status` prevalece.
+   - `Todo`: backlog ou pronto para comecar.
+   - `In Progress`: Codex/Clara esta trabalhando ou validando tecnicamente.
+   - `Done`: Done tecnico; codigo implementado, validado tecnicamente e integrado em `develop`, aguardando teste/aprovacao do Alan.
    - `Homologado`: Alan testou/aprovou funcionalmente em `develop`.
-   - `Pronto`: alteracao ja subiu para `main`/producao.
+   - `Pronto`: alteracao ja subiu para `main`/producao com evidencia; este e o fechamento final.
+   - `Cancelado`: nao sera feito ou foi substituido.
+   - Nao descreva `Status=Done` como card fechado/finalizado; use `Done tecnico` ou `aguardando homologacao`.
 
-4. Quando Alan disser que um card esta homologado, mover somente de `Done` para `Homologado`.
-   - Nao abrir PR, nao mergear em `main`, nao arquivar OpenSpec e nao fazer commit por esse evento.
-   - Termos como `homologado`, `homologuei`, `aprovado em develop` ou `cards homologados` nunca autorizam release, commit, PR ou merge.
-
-5. Quando Alan pedir `subir lote`, `fechar lote`, `fechar release` ou equivalente, executar o fechamento de producao dos cards `Homologado`: listar cards e commits incluidos, revisar pendencias locais, rodar validacao final completa, arquivar OpenSpec, subir para GitHub, abrir/reusar PR para `main`, fazer merge manual e so depois mover os cards incluidos para `Pronto`.
-   - Nao usar auto-merge.
+4. Homologacao e release seguem `alan-workflow`.
+   - No cripto, homologacao e aprovacao funcional em `develop`.
    - So comandos explicitos de lote/release autorizam qualquer acao em `main`.
+
+5. Quando Alan pedir `subir lote`, `fechar lote`, `fechar release` ou equivalente, execute `alan-workflow` com fechamento de producao dos cards `Homologado`.
+   - Nao usar auto-merge.
    - Se `develop` contiver mudanca nao homologada, nao fazer merge direto `develop -> main`; usar branch `release-*` com somente conteudo aprovado ou pedir decisao de Alan.
+   - Usar `scripts/release-guard pre` antes de abrir/mesclar PR e `scripts/release-guard post` depois da publicacao.
 
-6. Commits locais em branch de change/card sao permitidos e nao exigem suite completa a cada commit.
-   - Evitar commit direto em `develop` enquanto a implementacao estiver parcial.
+6. Branches e testes seguem `alan-workflow`; no cripto, evitar commit direto em `develop` enquanto a implementacao estiver parcial.
    - Integrar em `develop` somente quando a change estiver pronta para teste integrado/homologacao, preferencialmente com commit claro ou squash referenciando o card.
-   - Durante o card, rodar testes proporcionais/focados; testes completos ficam para fechamento de lote/release.
 
-7. Stash nao e armazenamento principal de entrega.
+7. Siga `alan-workflow` para higiene Git/worktree/stash; no cripto, stash nao e armazenamento principal de entrega.
    - Antes de iniciar segunda change, rode `git status --short` e isole o trabalho em branch/worktree propria.
    - Use stash apenas como protecao temporaria, sempre com nome, hash, arquivos incluidos, motivo e comando de recuperacao.
    - Branches de change devem ser apagadas no fechamento final, depois que o conteudo entrar em `main`/`Pronto`, e somente se nao houver commits exclusivos pendentes.
@@ -50,7 +55,7 @@ Este arquivo define as regras obrigatorias e curtas do projeto. O `AGENTS.md` de
 9. PostgreSQL e obrigatorio em runtime, QA, homologacao e scripts operacionais.
    - Nao usar SQLite como banco de operacao.
 
-10. Apos validacao e evidencia, o agente tem autonomia para executar o fluxo manual de fechamento previsto no `AGENTS.md`, sem solicitar nova autorizacao para cada etapa.
+10. Apos validacao e evidencia, o agente tem autonomia para executar o fluxo manual de fechamento previsto no `AGENTS.md` e em `alan-workflow`, sem solicitar nova autorizacao para cada etapa.
    - Essa autonomia nao autoriza pular teste, OpenSpec, homologacao, isolamento por branch, pedido explicito de lote/release ou merge manual.
 
 11. Usar a skill `caveman` em modo `lite` como padrao de comunicacao com Alan.


### PR DESCRIPTION
## Escopo

Publica em main somente os cards homologados:
- #220 P1: Renomear e descrever estrategias geradas para uso no produto
- #237 Onboarding: comecar por Favoritos e deixar Binance opcional
- #238 Dois sinais mesmo dia na estrategia ADA/USDT Compra Medias Moveis

Tambem inclui ajustes de regras operacionais em AGENTS.md/rules.md/.gitignore para alinhar Status como workflow principal e preservar arquivos locais do OpenClaw fora da release.

## Fora do escopo

- #239 esta salvo em develop e branch propria, mas continua In Progress e nao entra nesta release.

## Validacao local

- openspec validate --all: 131 passed, 0 failed
- /root/.openclaw/workspace/crypto/backend/.venv/bin/python -m pytest -q: 450 passed, 4 skipped
- npm --prefix frontend ci --prefer-offline --no-audit
- npm --prefix frontend run build: passed

## Release guard

- scripts/release-guard pre aponta worktrees/branches preservados (#239 e preserve-strategy-description-copy) como bloqueio estrito local; ambos foram classificados e salvos em branches remotas, e #239 foi excluido desta branch de release por ainda nao estar homologado.