### PR TITLE
release: publicar card 248

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,7 +3,6 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/stores/authStore'
 import axios from 'axios'
 import { Eye, EyeOff } from 'lucide-react'
-import { MonitorDisclaimer } from '@/components/monitor/MonitorDisclaimer'
 
 interface FormErrors {
   email?: string
@@ -73,8 +72,6 @@ export default function LoginPage() {
 
   return (
     <div className="w-full max-w-md">
-      <MonitorDisclaimer className="mb-4" />
-
       {/* Card */}
       <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-elevated)] p-8 shadow-[var(--shadow-xl)] backdrop-blur-xl">
         {/* Logo */}

--- a/frontend/tests/e2e/login-closed-beta.spec.ts
+++ b/frontend/tests/e2e/login-closed-beta.spec.ts
@@ -12,4 +12,6 @@ test('login page does not expose public account creation during closed beta', as
   await expect(page.getByText('Criar conta')).toHaveCount(0)
   await expect(page.getByText('Nome')).toHaveCount(0)
   await expect(page.getByText('Confirmar Senha')).toHaveCount(0)
+  await expect(page.getByText('Produto educacional com finalidade informativa')).toHaveCount(0)
+  await expect(page.getByText('não configuram recomendação financeira')).toHaveCount(0)
 })


### PR DESCRIPTION
## Resumo\n- Publica o card #248 em main.\n- Remove o disclaimer educacional/informativo da tela de login.\n- Mantém o fluxo de autenticação intacto.\n\n## Cards incluídos\n- #248 Login: remover mensagem sobre produto educacional informativo\n\n## Validações locais\n- npm run build\n- npx playwright test tests/e2e/login-closed-beta.spec.ts\n- openspec validate --all: 135 passed, 0 failed\n- git diff --check\n\n## Observação\nBranch de release criada a partir de origin/main para publicar apenas o card homologado, sem incluir commit documental extra presente em develop.