### PR TITLE
Hotfix: repassar UTMs no serviço de leads

### DIFF
--- a/frontend/public/posthog-config.js
+++ b/frontend/public/posthog-config.js
@@ -1,0 +1,6 @@
+// Runtime-only PostHog config for the published landing root.
+// Keep the key empty in Git. Fill it in the deployed environment when the PostHog project exists.
+window.CRIPTOFAROL_POSTHOG = {
+  key: '',
+  host: 'https://us.i.posthog.com',
+};

--- a/ops/landing-leads/server.js
+++ b/ops/landing-leads/server.js
@@ -21,6 +21,16 @@ const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS ||
 
 const HEADERS = ["Data", "Nome", "Email", "WhatsApp", "Perfil", "Dificuldade", "Origem"];
 const LEGACY_HEADERS = ["Data", "Nome", "Email", "Perfil", "Dificuldade", "Origem"];
+const ATTRIBUTION_FIELDS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "referrer",
+  "landing_path",
+  "first_seen_at",
+];
 let queue = Promise.resolve();
 
 function corsHeaders(origin) {
@@ -58,6 +68,14 @@ function readBody(req) {
 
 function clean(value) {
   return String(value || "").trim().replace(/\s+/g, " ");
+}
+
+function attributionPayload(lead) {
+  return Object.fromEntries(
+    ATTRIBUTION_FIELDS
+      .map((field) => [field, lead[field]])
+      .filter(([, value]) => value),
+  );
 }
 
 async function ensureWorkbook() {
@@ -126,6 +144,7 @@ async function createBetaAccess(lead) {
       profile: lead.profile,
       pain: lead.pain,
       origin: lead.origin,
+      ...attributionPayload(lead),
     }),
   });
 
@@ -222,6 +241,14 @@ async function handleLead(req, res, origin) {
     profile: clean(payload.profile),
     pain: clean(payload.pain),
     origin: clean(payload.origin) || "landing",
+    utm_source: clean(payload.utm_source),
+    utm_medium: clean(payload.utm_medium),
+    utm_campaign: clean(payload.utm_campaign),
+    utm_content: clean(payload.utm_content),
+    utm_term: clean(payload.utm_term),
+    referrer: clean(payload.referrer),
+    landing_path: clean(payload.landing_path),
+    first_seen_at: clean(payload.first_seen_at),
   };
 
   if (!lead.name || lead.name.length < 2) {


### PR DESCRIPTION
## Correção
Durante a validação da release em produção, o PostHog carregou corretamente, mas o POST público de lead gravou audit log sem UTMs.

Causa: `ops/landing-leads/server.js` filtrava o payload antes de encaminhar para o backend `/api/leads`.

## Mudanças
- Repassa `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `referrer`, `landing_path` e `first_seen_at` do serviço de leads para o backend.
- Adiciona `frontend/public/posthog-config.js` vazio para que o build gere `/posthog-config.js` na raiz publicada da landing.

## Validações locais
- node --check ops/landing-leads/server.js: PASS
- npm run build em frontend: PASS
- backend/.venv/bin/python -m pytest backend/tests/unit/test_database_and_auth.py -k 'attribution or leads_route_returns_safe_response_without_temporary_password': 2 passed
