### PR TITLE
docs: concluir tarefas do card 284

### DIFF
--- a/openspec/changes/card-284-automated-qa-gate/tasks.md
+++ b/openspec/changes/card-284-automated-qa-gate/tasks.md
@@ -18,7 +18,7 @@
 - [x] 3.1 Executar testes focados de CI/Playwright, build frontend e validações OpenSpec da change.
 - [x] 3.2 Mover o card para Code Review, revisar o diff exato e corrigir/classificar achados.
 - [x] 3.3 Commitar/publicar a branch, verificar o `qa-gate` e registrar evidências no card.
-- [ ] 3.4 Integrar em develop, executar `./restart`, validar runtime e mover para Done técnico.
+- [x] 3.4 Integrar em develop, executar `./restart`, validar runtime e mover para Done técnico.
 
 ## Nota de execução
 


### PR DESCRIPTION
Fecha o registro OpenSpec apos a integracao da implementacao pelo PR #285.

- Marca task 3.4 apos merge em develop, restart DEV e runtime saudavel.
- Sem alteracao de comportamento do produto.
- Evidencias: #285, qa-gate verde, health 8004 e frontend 5175.